### PR TITLE
refactor(package): move react-dom into dev & peer dependencies, upgrade to react v16.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "flow-copy-source": "1.3.0",
     "jest": "23.1.0",
     "jest-styled-components": "5.0.1",
-    "react": "^16.4.1",
+    "react": "^16.5.2",
+    "react-dom": "^16.5.2",
     "react-router-dom": "4.3.1",
     "react-test-renderer": "16.4.1",
     "styled-components": "^3.3.3",
@@ -77,12 +78,12 @@
     "nuka-carousel": "4.1.0",
     "r": "0.0.5",
     "react-datetime": "2.14.0",
-    "react-dom": "16.4.1",
     "react-responsive": "^5.0.0",
     "throttle-debounce": "1.0.1"
   },
   "peerDependencies": {
-    "react": "^16.4.1",
+    "react": "^16.5.2",
+    "react-dom": "^16.5.2",
     "styled-components": "^3.3.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7546,14 +7546,14 @@ react-docgen@^3.0.0-beta11:
     node-dir "^0.1.10"
     recast "^0.15.0"
 
-react-dom@16.4.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.1.tgz#7f8b0223b3a5fbe205116c56deb85de32685dad6"
+react-dom@^16.5.2:
+  version "16.5.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.5.2.tgz#b69ee47aa20bab5327b2b9d7c1fe2a30f2cfa9d7"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    schedule "^0.5.0"
 
 react-error-overlay@^4.0.1:
   version "4.0.1"
@@ -7700,14 +7700,14 @@ react-treebeard@^2.1.0:
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
 
-react@^16.4.1:
-  version "16.4.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.4.2.tgz#2cd90154e3a9d9dd8da2991149fdca3c260e129f"
+react@^16.5.2:
+  version "16.5.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.5.2.tgz#19f6b444ed139baa45609eee6dc3d318b3895d42"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    schedule "^0.5.0"
 
 reactcss@^1.2.0:
   version "1.2.3"
@@ -8217,6 +8217,12 @@ sane@^2.0.0:
 sax@^1.2.4, sax@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+
+schedule@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/schedule/-/schedule-0.5.0.tgz#c128fffa0b402488b08b55ae74bb9df55cc29cc8"
+  dependencies:
+    object-assign "^4.1.1"
 
 schema-utils@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Issue: `https://github.com/glints-dev/glints-aries/issues/18`