### PR TITLE
Hotfix/update job card storybook

### DIFF
--- a/src/Application/JobCard/JobCard.js
+++ b/src/Application/JobCard/JobCard.js
@@ -6,7 +6,7 @@ import { JobcardContainer, CustomLink } from '../../Style/Application/JobCardSty
 
 class JobCard extends Component <Props> {
   renderLinkChild = () => {
-    const { children, defaultProps, targetUrl } = this.props;
+    const { children, targetUrl, ...defaultProps } = this.props;
     const linkChild = Children.map(children, (child) => {
       if (targetUrl && child.props.isLinkAble) {
         return React.cloneElement(child, { ...defaultProps });
@@ -31,7 +31,6 @@ class JobCard extends Component <Props> {
     const {
       children,
       targetUrl,
-      onClick,
       ...defaultProps
     } = this.props;
     return (
@@ -55,11 +54,6 @@ class JobCard extends Component <Props> {
 type Props = {
   children: React$Node,
   targetUrl: String,
-  onClick: Function,
 }
-
-JobCard.defaultProps = {
-  onClick: () => {},
-};
 
 export default JobCard;

--- a/src/Application/JobCard/JobCard.js
+++ b/src/Application/JobCard/JobCard.js
@@ -6,9 +6,9 @@ import { JobcardContainer, CustomLink } from '../../Style/Application/JobCardSty
 
 class JobCard extends Component <Props> {
   renderLinkChild = () => {
-    const { children, defaultProps, url } = this.props;
+    const { children, defaultProps, targetUrl } = this.props;
     const linkChild = Children.map(children, (child) => {
-      if (url && child.props.isLinkAble) {
+      if (targetUrl && child.props.isLinkAble) {
         return React.cloneElement(child, { ...defaultProps });
       }
       return null;
@@ -29,21 +29,21 @@ class JobCard extends Component <Props> {
 
   render() {
     const {
-      children, url, target, onClick, ...defaultProps
+      children,
+      targetUrl,
+      onClick,
+      ...defaultProps
     } = this.props;
     return (
       <JobcardContainer {...defaultProps}>
         <Choose>
-          <When condition={url}>
-            <CustomLink to={url} target={target}>
+          <When condition={targetUrl}>
+            <CustomLink to={targetUrl} target="_blank">
               { this.renderLinkChild() }
             </CustomLink>
             { this.renderNonLinkChild() }
           </When>
           <Otherwise>
-            <div onClick={onClick}>
-              { this.renderLinkChild() }
-            </div>
             { this.renderNonLinkChild() }
           </Otherwise>
         </Choose>
@@ -54,10 +54,11 @@ class JobCard extends Component <Props> {
 
 type Props = {
   children: React$Node,
+  targetUrl: String,
+  onClick: Function,
 }
 
 JobCard.defaultProps = {
-  target: '_blank',
   onClick: () => {},
 };
 

--- a/src/Application/JobCard/JobCardHeader.js
+++ b/src/Application/JobCard/JobCardHeader.js
@@ -11,7 +11,6 @@ const JobCardHeader = (props: Props) => {
     tag,
     url,
     imgUrl,
-    isExternal,
     subtitle,
     subtitleOnClick,
     className,
@@ -59,7 +58,6 @@ type Props = {
   tag: string,
   subtitle: string,
   imgUrl: string,
-  isExternal: boolean,
   jobTitleClass: string,
   url: string,
 };

--- a/src/Application/JobCard/JobCardHeader.js
+++ b/src/Application/JobCard/JobCardHeader.js
@@ -2,7 +2,13 @@
 
 import React from 'react';
 import {
-  JobcardHeaderWrapper, JobcardHeaderImage, JobcardHeaderContent, Image, SubtitleTitle, LabelTag,
+  JobcardHeaderWrapper,
+  JobcardHeaderImage,
+  JobcardHeaderContent,
+  Image,
+  SubtitleTitle,
+  Title,
+  LabelTag,
 } from '../../Style/Application/JobCardStyle';
 
 const JobCardHeader = (props: Props) => {
@@ -37,9 +43,9 @@ const JobCardHeader = (props: Props) => {
             {tag}
           </LabelTag>
         </If>
-        <h3 className={jobTitleClass}>
+        <Title className={jobTitleClass}>
           {`${title.slice(0, 50)}`}
-        </h3>
+        </Title>
         <SubtitleTitle
           onClick={subtitleOnClick}
           className={companyNameClass}

--- a/src/Style/Application/JobCardStyle.js
+++ b/src/Style/Application/JobCardStyle.js
@@ -173,6 +173,10 @@ export const JobcardDescriptionWrapper = styled.div`
   }
 `;
 
+export const Title = styled.h3`
+  word-break: break-word;
+`;
+
 export const SubtitleTitle = styled.p`
   color: ${SecondaryColor.blue};
   word-break: break-word;

--- a/src/Style/Application/JobCardStyle.js
+++ b/src/Style/Application/JobCardStyle.js
@@ -175,6 +175,7 @@ export const JobcardDescriptionWrapper = styled.div`
 
 export const SubtitleTitle = styled.p`
   color: ${SecondaryColor.blue};
+  word-break: break-word;
 `;
 
 export const JobcardFooterWrapper = styled.footer`

--- a/stories/Application/JobCardStory.js
+++ b/stories/Application/JobCardStory.js
@@ -27,7 +27,7 @@ const JobCardStory = () => (
               targetUrl="https://glints.com/"
             >
               <JobCard.Header
-                title="Item title"
+                title="https://brillianceadvisory.wixsite.com/mysite"
                 tag="Special"
                 subtitle="https://brillianceadvisory.wixsite.com/mysite"
                 imgUrl="https://upload.wikimedia.org/wikipedia/commons/d/df/GLINTS_LOGO293.png"

--- a/stories/Application/JobCardStory.js
+++ b/stories/Application/JobCardStory.js
@@ -55,6 +55,7 @@ const JobCardStory = () => (
     tag="Special"
     subtitle="Item subtitle"
     imgUrl="imageUrl | imageComponent"
+    subtitleOnClick={() => ...}
     isLinkAble={true}
   />
   <JobCard.Body isLinkAble={true}>
@@ -144,6 +145,13 @@ const JobCardStory = () => (
           <td><pre>true | false</pre></td>
           <td>no</td>
           <td>Should the component be included in link.</td>
+        </tr>
+        <tr>
+          <td>subtitleOnClick</td>
+          <td>function</td>
+          <td>any</td>
+          <td>no</td>
+          <td>Callback function for subtitle OnClick</td>
         </tr>
       </tbody>
     </table>

--- a/stories/Application/JobCardStory.js
+++ b/stories/Application/JobCardStory.js
@@ -6,70 +6,58 @@ import Button from '../../src/General/Button';
 const JobCardStory = () => (
   <div className="doc-mainbar">
     <div style={{ marginBottom: '2em' }}>
-      <h1>
-        Job Card
-      </h1>
+      <h1>Job Card</h1>
       <div>
         <code>
           {'import { JobCard } from \'glints-aries\''}
         </code>
       </div>
     </div>
-
     <table className="doc-table">
       <thead>
         <tr>
-          <th>
-              Preview
-          </th>
-          <th>
-              Usage
-          </th>
+          <th>Preview</th>
+          <th>Usage</th>
         </tr>
       </thead>
       <tbody>
         <tr>
           <td style={{ padding: 20 }}>
             <JobCard
-              url="https://www.glints.com"
+              targetUrl="https://glints.com/"
             >
               <JobCard.Header
                 title="Item title"
                 tag="Special"
-                subtitle="Item subtitle"
+                subtitle="https://brillianceadvisory.wixsite.com/mysite"
                 imgUrl="https://upload.wikimedia.org/wikipedia/commons/d/df/GLINTS_LOGO293.png"
-                isExternal
                 isLinkAble
               />
               <JobCard.Body isLinkAble>
                 <JobCard.Detail details={['Design', 'SGD 1000 - 2000', 'Singapore', 'Full-Time']} />
-                <JobCard.Description description={'Relentless. College Dropouts. Venture-backed. Straits Times called us the "Stuff of Many Singaporeans Parents\' Nightmares", due to our "fundamental naughtiness and healthy disrespect for rules”. We were nearly flung into military prison for rebelling against irrational rules. Grow fast, dare to do what we love, and break conventions. That’s how we started, that\'s how we roll here at this crazy company ;)'} time="5 days ago" />
+                <JobCard.Description
+                  description={'Relentless. College Dropouts. Venture-backed. Straits Times called us the "Stuff of Many Singaporeans Parents\' Nightmares", due to our "fundamental naughtiness and healthy disrespect for rules”. We were nearly flung into military prison for rebelling against irrational rules. Grow fast, dare to do what we love, and break conventions. That’s how we started, that\'s how we roll here at this crazy company ;)'}
+                  time="5 days ago"
+                />
               </JobCard.Body>
               <JobCard.Footer>
-                <Button>
-                  Save
-                </Button>
-                <Button>
-                  Apply
-                </Button>
-                <Button variant="secondary">
-                  Detail
-                </Button>
+                <Button>Save</Button>
+                <Button>Apply</Button>
+                <Button variant="secondary">Detail</Button>
               </JobCard.Footer>
             </JobCard>
           </td>
           <td style={{ verticalAlign: 'top', paddingTop: 20, width: '100%' }}>
             <pre>
-              {`<JobCard>
+              {`<JobCard targetUrl="...">
   <JobCard.Header
     title="Item title"
     tag="Special"
     subtitle="Item subtitle"
-    url="..."
     imgUrl="imageUrl | imageComponent"
-    isExternal
+    isLinkAble={true}
   />
-  <JobCard.Body>
+  <JobCard.Body isLinkAble={true}>
     <JobCard.Detail details={['...', '...', '...', '...']} />
     <JobCard.Description 
       description={'...'} 
@@ -84,6 +72,151 @@ const JobCardStory = () => (
 </JobCard>`}
             </pre>
           </td>
+        </tr>
+      </tbody>
+    </table>
+    <h1>Props</h1>
+    <h2>JobCard</h2>
+    <table className="doc-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Value</th>
+          <th>Required</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>targetUrl</td>
+          <td>string</td>
+          <td>any</td>
+          <td>no</td>
+          <td>redirect URL when clicked</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>JobCard.Header</h2>
+    <table className="doc-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Value</th>
+          <th>Required</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>title</td>
+          <td>string</td>
+          <td>any</td>
+          <td>yes</td>
+          <td>Sets title for job card.</td>
+        </tr>
+        <tr>
+          <td>tag</td>
+          <td>string</td>
+          <td>any</td>
+          <td>yes</td>
+          <td>Highlighted tag fro job card.</td>
+        </tr>
+        <tr>
+          <td>subtitle</td>
+          <td>string</td>
+          <td>any</td>
+          <td>yes</td>
+          <td>Subtitle for job card.</td>
+        </tr>
+        <tr>
+          <td>imgUrl</td>
+          <td>string</td>
+          <td>any</td>
+          <td>yes</td>
+          <td>Image URL for job card.</td>
+        </tr>
+        <tr>
+          <td>isLinkAble</td>
+          <td>boolean</td>
+          <td><pre>true | false</pre></td>
+          <td>no</td>
+          <td>Should the component be included in link.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>JobCard.Body</h2>
+    <table className="doc-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Value</th>
+          <th>Required</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>isLinkAble</td>
+          <td>boolean</td>
+          <td><pre>true | false</pre></td>
+          <td>no</td>
+          <td>Should the component be included in link.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>JobCard.Detail</h2>
+    <table className="doc-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Value</th>
+          <th>Required</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>details</td>
+          <td>Array</td>
+          <td>any</td>
+          <td>yes</td>
+          <td>Sets title for job card detail.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>JobCard.Description</h2>
+    <table className="doc-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Value</th>
+          <th>Required</th>
+          <th>Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>description</td>
+          <td>string</td>
+          <td>any</td>
+          <td>yes</td>
+          <td>Sets description for job card description.</td>
+        </tr>
+        <tr>
+          <td>time</td>
+          <td>string</td>
+          <td>any</td>
+          <td>yes</td>
+          <td>Sets time to show in job card description.</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## What Changed & Why
- change props `URL` into `targetURL`
- added word-break for job title and subtitle to handle long string
- remove unnecessary props
- update JobCard storybook to documented props 


