### PR TITLE
Changed job card footer display from grid to flex

### DIFF
--- a/src/Style/Application/JobCardStyle.js
+++ b/src/Style/Application/JobCardStyle.js
@@ -184,8 +184,8 @@ export const SubtitleTitle = styled.p`
 export const JobcardFooterWrapper = styled.footer`
   position: absolute;
   bottom: 0;
-  display: grid;
-  grid-template-columns: 1fr 1fr 2fr;
+  display: flex;
+  width: 100%;
 `;
 
 export const Image = styled.img`


### PR DESCRIPTION
Because there is only 1 dimension in the footer, flex is more suitable.

Display flex also allows for more flexibility in deciding individual button width. Grid specifies the number of columns up front, but flex allows the consumer to decide the number and ratio.