### PR TITLE
Add more specificity to headers and text in toast to avoid overriding by client styles

### DIFF
--- a/src/Style/Display/ToastStyle.js
+++ b/src/Style/Display/ToastStyle.js
@@ -17,6 +17,10 @@ export const ToastContainer = styled.div`
   padding: 1em;
   box-shadow: 0 10px 15px 0 rgba(0,0,0,0.05);
 
+  h1, h2, h3, h4, h5, h6, p {
+    color: ${({ theme }) => theme === 'black' ? `${SecondaryColor.white}` : `${SecondaryColor.black}`};
+  }
+
   @media ${Device.mobileM} {
     min-width: 100%;
     bottom: 0;


### PR DESCRIPTION
## What Changed & Why
Added more specificity to the css of Toast component that sets the font colour of all text within it. This is because on certain projects such as Employers, the theme overrides this css by specificity simply by setting `h2` for example. This change sets the attribute by selecting the tag.