### PR TITLE
General: Wrap keyframes interpolation with `css` template processor.

### DIFF
--- a/src/Style/General/ButtonStyle.js
+++ b/src/Style/General/ButtonStyle.js
@@ -1,4 +1,4 @@
-import styled, { keyframes } from 'styled-components';
+import styled, { css, keyframes } from 'styled-components';
 import { PrimaryColor, SecondaryColor } from '../Colors';
 import { Theme } from '../../Utils/StyleConfig';
 
@@ -313,7 +313,7 @@ export const SecondaryContainer = styled.div`
 
   ${({ disabled }) => {
     if (!disabled) {
-      return `
+      return css`
         &:hover:after {
           opacity: 1;
           transition: opacity .8s linear;


### PR DESCRIPTION
When using styled-components v4, this error appears:

    Error: It seems you are interpolating a keyframe declaration (ihrlXY) into an untagged string. This was supported in styled-components v3, but is not longer supported in v4 as keyframes are now injected on-demand. Please wrap your string in the css\`\` helper (see https://www.styled-components.com/docs/api#css), which ensures the styles are injected correctly.

Since the `css` helper is already available with v3, use it first without needing to upgrade styled-components in this project to v4.