### PR TITLE
JobCard: Remove default prop `target` to leave it undefined when not provided

### DIFF
--- a/src/Application/JobCard/JobCard.js
+++ b/src/Application/JobCard/JobCard.js
@@ -5,9 +5,6 @@ import React, { Component, Children } from 'react';
 import { JobcardContainer, JobCardWrapper, CustomLink } from '../../Style/Application/JobCardStyle';
 
 class JobCard extends Component <Props> {
-  static defaultProps = {
-    target: '_self',
-  }
 
   renderLinkChild = () => {
     const { children, targetUrl, ...defaultProps } = this.props;


### PR DESCRIPTION
Trello card: https://trello.com/c/kPDosHcu/2917-redirection-of-job-card-to-job-details-shouldnt-be-render-the-whole-page-reported-by-chong-an

Removed default property for `target` as it causes the page redirect on click
