### PR TITLE
Fixed text area bug

### DIFF
--- a/src/General/ProfilePicture/ProfilePicture.js
+++ b/src/General/ProfilePicture/ProfilePicture.js
@@ -45,12 +45,12 @@ class ProfilePicture extends Component <Props, State> {
         aria-label="Profile Picture"
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
-        tabIndex={editable && '0'}
+        tabIndex={editable ? '0' : undefined}
         {...defaultProps}
       >
         <ProfilePictureContent
           editable={editable}
-          tabIndex={editable && '-1'}
+          tabIndex={editable ? '-1' : undefined}
         >
           {isHover && <Icon name="edit" color="white" />}
           {children}

--- a/src/Input/Textarea/Textarea.js
+++ b/src/Input/Textarea/Textarea.js
@@ -1,13 +1,13 @@
 /* @flow */
 
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import {
   TextareaContainer,
   TextareaInput,
   TextareaLabel,
 } from '../../Style/Input/TextareaStyle';
 
-class Textarea extends Component <Props, State> {
+class Textarea extends PureComponent <Props, State> {
   state = {
     floating: false,
     rows: 4,
@@ -30,35 +30,31 @@ class Textarea extends Component <Props, State> {
     return listener;
   }
 
-  handleChange = (onChange) => {
-    const listener = (e) => {
-      const { minRows, maxRows } = this.state;
+  handleChange = e => {
+    const { minRows, maxRows } = this.state;
 
-      const previousRows = e.target.rows;
-      e.target.rows = minRows;
+    const previousRows = e.target.rows;
+    e.target.rows = minRows;
 
-      const currentRows = ~~(e.target.scrollHeight / 30);
+    const currentRows = ~~(e.target.scrollHeight / 30);
 
-      if (currentRows === previousRows) {
-        e.target.rows = currentRows;
-      }
+    if (currentRows === previousRows) {
+      e.target.rows = currentRows;
+    }
 
-      if (currentRows >= maxRows) {
-        e.target.rows = maxRows;
-        e.target.scrollTop = e.target.scrollHeight;
-      }
+    if (currentRows >= maxRows) {
+      e.target.rows = maxRows;
+      e.target.scrollTop = e.target.scrollHeight;
+    }
 
-      this.setState({
-        rows: currentRows < maxRows ? currentRows : maxRows,
-      });
+    this.setState({
+      rows: currentRows < maxRows ? currentRows : maxRows,
+    });
 
-      if (onChange !== undefined) {
-        return onChange(e);
-      }
-    };
-
-    return listener;
-  }
+    if (this.props.onChange !== undefined) {
+      return this.props.onChange(e);
+    }
+  };
 
   componentDidMount() {
     const textarea = document.getElementById('textarea-input');
@@ -111,7 +107,7 @@ class Textarea extends Component <Props, State> {
           status={status}
           disabled={disabled}
           onBlur={this.handleFocusChange(onBlur)}
-          onChange={this.handleChange(onChange)}
+          onChange={this.handleChange}
           floating={floating}
           value={value}
           aria-label={label}

--- a/src/Input/Textarea/Textarea.js
+++ b/src/Input/Textarea/Textarea.js
@@ -1,6 +1,8 @@
 /* @flow */
 
 import React, { PureComponent } from 'react';
+
+import { isFunction } from 'lodash';
 import {
   TextareaContainer,
   TextareaInput,
@@ -51,7 +53,7 @@ class Textarea extends PureComponent <Props, State> {
       rows: currentRows < maxRows ? currentRows : maxRows,
     });
 
-    if (this.props.onChange !== undefined) {
+    if (isFunction(this.props.onChange)) {
       return this.props.onChange(e);
     }
   };


### PR DESCRIPTION
Actual Results: Cursor in textarea bounced to the end of input text after 2 character inputs, if we start typing in the middle of the text.

Expected Results: Typing to continue in the middle of the text.

Cause: Suspected that the textarea component was unloaded and reloaded multiple times.

Fix: Modified the handleChange handler to return onChange directly instead of a function; Changed textArea to a pure component, so as to minimize re-rendering. 