### PR TITLE
hotfix/alert-continuous-rerendering

### DIFF
--- a/src/General/Alert/Alert.js
+++ b/src/General/Alert/Alert.js
@@ -33,7 +33,7 @@ class Alert extends Component <State, Props> {
 
     if (prevProps.isOpen && !isOpen) {
       setTimeout(() => this.setState({ isVisible: false }), 300);
-    } else if (prevProps.autoClose) {
+    } else if (isOpen && prevProps.autoClose) {
       this.autoCloseTimeout = setTimeout(() => {
         prevProps.onClose();
       }, prevProps.autoClose);


### PR DESCRIPTION
Fix Alert component continuous re-rendering
- before: the component re-renders every x ms if `autoClose={x}` is given as props because `setTimeout` is called on every `componentDidUpdate`
- after: `setTimeout` is only called when the `isOpen` state is `true`