### PR TITLE
Hotfix/search-filter-closes-on-scroll

### DIFF
--- a/src/Input/SearchFilter/SearchFilter.tsx
+++ b/src/Input/SearchFilter/SearchFilter.tsx
@@ -18,14 +18,39 @@ class SearchFilter extends React.Component<Props, State> {
   static List = SearchFilterList;
   static Item = SearchFilterItem;
 
-  state = {
-    isOpen: false,
-  };
+  state = { isOpen: false };
+  searchFilterRef = React.createRef() as React.RefObject<HTMLDivElement>;
+  inputRef = React.createRef() as React.RefObject<HTMLInputElement>;
+
+  componentDidMount() {
+    document.addEventListener('mousedown', this.handleMouseDown, false);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('mousedown', this.handleMouseDown, false);
+  }
 
   handleOpen = () => {
-    const { isOpen } = this.state;
-    this.setState({ isOpen: !isOpen });
+    this.setState({ isOpen: true });
   };
+
+  handleClose = () => {
+    this.setState({ isOpen: false });
+  }
+
+  handleMouseDown = (event: MouseEvent) => {
+    const element = event.target as HTMLElement;
+    const hasClickedOnInput = element === this.inputRef.current;
+    const hasClickedInsideSearchFilter = this.searchFilterRef.current.contains(element);
+    const hasClickedOnScrollBar = hasClickedInsideSearchFilter &&
+      (event.offsetX > element.clientWidth || event.offsetY > element.clientHeight);
+
+    if (hasClickedOnInput || hasClickedOnScrollBar) {
+      return;
+    } else {
+      this.handleClose();
+    }
+  }
 
   render() {
     const {
@@ -45,14 +70,15 @@ class SearchFilter extends React.Component<Props, State> {
         role="search"
         aria-expanded={isOpen}
         aria-label={label}
+        ref={this.searchFilterRef}
       >
         <SearchFilterBar className="searchfilter-inputwrapper">
           <input
             type="text"
             placeholder={label}
             onFocus={this.handleOpen}
-            onBlur={this.handleOpen}
             value={value}
+            ref={this.inputRef}
             {...defaultProps}
           />
           {content}


### PR DESCRIPTION
Fixed problem of SearchFilter dropdown automatically closing when scrollbar is clicked

- Before:
  - We passed a handleOpen function to the input's onBlur prop which toggles the isOpen state everytime the input loses focus.
  - This caused the dropdown to close everytime the dropdown's scrollbar is clicked because the input loses focus.
- After:
  - We added a handleMouseDown eventListener which ignores the mousedown event if it is on the scrollbar.
  - Moving forward, the dropdown will only close when a mousedown event takes place outside the component or when a dropdown list item is clicked.