### PR TITLE
Hotfix/switch input and modal

### DIFF
--- a/src/Display/Modal/Modal.tsx
+++ b/src/Display/Modal/Modal.tsx
@@ -115,7 +115,7 @@ class Modal extends React.Component<Props, State> {
             </ModalBody>
             {footer !== undefined &&
               <ModalFooter className="modal-footer">
-                { footer.map(data => React.cloneElement(data, { key: data.props.children })) }
+                { footer }
               </ModalFooter>
             }
           </ModalContentArea>

--- a/src/Input/Switch/Switch.tsx
+++ b/src/Input/Switch/Switch.tsx
@@ -9,7 +9,7 @@ class Switch extends React.Component<Props, State> {
     initialValue: '',
   };
 
-  handleChange = (e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+  handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const radioButton = e.target as HTMLInputElement;
     const { value } = radioButton;
 

--- a/src/Input/Switch/Switch.tsx
+++ b/src/Input/Switch/Switch.tsx
@@ -9,11 +9,13 @@ class Switch extends React.Component<Props, State> {
     initialValue: '',
   };
 
-  handleClick = (e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+  handleChange = (e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
     const radioButton = e.target as HTMLInputElement;
+    const { value } = radioButton;
+
     this.setState({
-      clickID: radioButton.id,
-      initialValue: radioButton.value,
+      clickID: value,
+      initialValue: value,
     });
   }
 
@@ -55,7 +57,7 @@ class Switch extends React.Component<Props, State> {
             value={value[0]}
             theme="white"
             checked={initialValue === `${value[0]}` && true}
-            onClick={this.handleClick}
+            onChange={this.handleChange}
           />
         </SwitchItemWrapper>
         <SwitchItemWrapper className="switch-right">
@@ -67,7 +69,7 @@ class Switch extends React.Component<Props, State> {
             value={value[1]}
             theme="white"
             checked={initialValue === `${value[1]}` && true}
-            onClick={this.handleClick}
+            onChange={this.handleChange}
           />
         </SwitchItemWrapper>
       </SwitchContainer>

--- a/stories/Display/ModalStory.tsx
+++ b/stories/Display/ModalStory.tsx
@@ -53,7 +53,7 @@ class ModalStory extends React.Component {
           defaultValue: <code>m</code>,
           possibleValue: <code>s | m | l | xl</code>,
           require: 'no',
-          description: ['Sets size of Modal. Default size is medium.', <p style={{ marginBottom: '0', marginTop: '1em', fontWeight: 'bold' }}>Size chart:</p>, <p style={{ margin: '0' }}>Small: 300px</p>, <p style={{ margin: '0' }}>Medium: 500px</p>, <p style={{ margin: '0' }}>Large: 800px</p>, <p style={{ margin: '0' }}>Extra Large: 920px</p>],
+          description: ['Sets size of Modal. Default size is medium.', <p key ="sizeChart" style={{ marginBottom: '0', marginTop: '1em', fontWeight: 'bold' }}>Size chart:</p>, <p key ="small" style={{ margin: '0' }}>Small: 300px</p>, <p key ="medium" style={{ margin: '0' }}>Medium: 500px</p>, <p key ="large" style={{ margin: '0' }}>Large: 800px</p>, <p key ="extraLarge" style={{ margin: '0' }}>Extra Large: 920px</p>],
         },
         {
           name: 'centering',
@@ -87,37 +87,39 @@ class ModalStory extends React.Component {
         title="Modal"
         code="import { Modal } from 'glints-aries'"
         propsObject={props}
-        usage={`state = {
-  visible: false,
-}
+        usage={
+          `state = {
+            visible: false,
+          }
 
-handleOpen = () => {
-  this.setState({ visible: true });
-}
+          handleOpen = () => {
+            this.setState({ visible: true });
+          }
 
-handleClose = () => {
-  this.setState({ visible: false });
-}
+          handleClose = () => {
+            this.setState({ visible: false });
+          }
 
-<Button theme="blue" onClick={this.handleOpen}>
-  Open Modal
-</Button>
+          <Button theme="blue" onClick={this.handleOpen}>
+            Open Modal
+          </Button>
 
-<Modal
-  title="What is Lorem Ipsum?"
-  isVisible={visible}
-  onClose={this.handleClose}
-  footer={[
-    <Button variant="ghost" theme="blue" small onClick={this.handleClose}>
-      Cancel
-    </Button>,
-    <Button variant="default" theme="blue" small onClick={this.handleClose}>
-      Save
-    </Button>,
-  ]}
->
-  <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
-</Modal>`}
+          <Modal
+            title="What is Lorem Ipsum?"
+            isVisible={visible}
+            onClose={this.handleClose}
+            footer={[
+              <Button key="cancel" variant="ghost" theme="blue" small onClick={this.handleClose}>
+                Cancel
+              </Button>,
+              <Button key="save" variant="default" theme="blue" small onClick={this.handleClose}>
+                Save
+              </Button>,
+            ]}
+          >
+            <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
+          </Modal>`
+        }
       >
         <Button theme="blue" onClick={this.handleOpen}>
           Open Modal
@@ -127,15 +129,15 @@ handleClose = () => {
           isVisible={visible}
           onClose={this.handleClose}
           footer={[
-            <Button variant="ghost" theme="blue" small onClick={this.handleClose}>
+            <Button key="cancel" variant="ghost" theme="blue" small onClick={this.handleClose}>
               Cancel
             </Button>,
-            <Button variant="default" theme="blue" small onClick={this.handleClose}>
+            <Button key="save" variant="default" theme="blue" small onClick={this.handleClose}>
               Save
             </Button>,
           ]}
         >
-          <p>{'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.'}</p>
+          <p>Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</p>
         </Modal>
       </StorybookComponent>
     );


### PR DESCRIPTION
- Modal: Stop cloning and setting keys for each item in the `footer` array 
- Switch:  Fix issue of component not switching and fix react warnings
- Refer to commit messages for more detailed explanation