### PR TITLE
Progress: Extend functionality with new props

### DIFF
--- a/src/Display/Progress/Progress.tsx
+++ b/src/Display/Progress/Progress.tsx
@@ -86,7 +86,7 @@ const Progress: React.FunctionComponent<Props> = (props) => {
 interface Props extends Omit<React.ComponentPropsWithoutRef<typeof ProgressContainer>, 'progress'> {
   percentage: number;
   percentageRange?: [] | [number] | [number, number];
-  size?: 1|2|3|4|5|6|7|8|9|10;
+  size?: number;
   content?: React.ReactNode;
 }
 

--- a/src/Display/Progress/Progress.tsx
+++ b/src/Display/Progress/Progress.tsx
@@ -14,36 +14,43 @@ import { PrimaryColor, SecondaryColor } from '../../Style/Colors';
 const Progress: React.FunctionComponent<Props> = (props) => {
   const {
     className,
-    percentage,
+    percentage = 100,
     percentageRange = [50],
     size = 8,
     content,
     ...defaultProps
   } = props;
-  
+
+  let normalizedPercentage;
+  let normalizedSize;
+
   if (percentage < 0 || percentage > 100) {
-    throw new Error(`Error: percentage prop on Progress component expected a value between 0-100. Received ${percentage} instead.`)
-  }  
-
+    normalizedPercentage = percentage < 0 ? 0 : percentage > 100 ? 100 : percentage;
+    console.warn(`Invalid prop value on Progress component: percentage prop expected a value between 0-100. Received ${percentage} instead.`)
+  } else {
+    normalizedPercentage = percentage;
+  }
   if (percentageRange.length > 2) {
-    throw new Error(`Error: percentageRange prop on Progress component expected a maximum of 2 numbers. Received [${percentageRange}] instead.`)
+    console.warn(`Invalid prop value on Progress component: percentageRange prop expected an array with a maximum of 2 numbers. Received [${percentageRange}] instead.`)
+  }
+  if (size < 1|| size > 10) {
+    normalizedSize = size < 1 ? 1 : size > 10 ? 10 : size;
+    console.warn(`Invalid prop value on Progress component: size prop expected a value between 1-10. Received ${size} instead.`)
+  } else {
+    normalizedSize = size;
   }
 
-  if (size > 10 || size < 1) {
-    throw new Error(`Error: size prop on Progress component expected a number between 1 - 10. Received ${size} instead.`)
-  }
-
-  const progressValue = percentage > 100 ? 282.6 * (1 - (100 / 100)) : 282.6 * (1 - (percentage / 100));
-  const sizeInEm = (size + 2) / 10;
-  
+  const progressValue = normalizedPercentage > 100 ? 282.6 * (1 - (100 / 100)) : 282.6 * (1 - (normalizedPercentage / 100));
+  const sizeInEm = (normalizedSize + 2) / 10;
   let color;
-  if (percentageRange.length === 2) {
+  
+  if (percentageRange.length >= 2) {
     const [firstRange, secondRange] = percentageRange;
-    color = percentage > secondRange ? SecondaryColor.green : 
-      (percentage > firstRange ? SecondaryColor.orange : PrimaryColor.glintsred);
+    color = normalizedPercentage > secondRange ? SecondaryColor.green : 
+      (normalizedPercentage > firstRange ? SecondaryColor.orange : PrimaryColor.glintsred);
   } else if (percentageRange.length === 1) {
     const [firstRange] = percentageRange;
-    color = percentage > firstRange ? SecondaryColor.green : SecondaryColor.orange
+    color = normalizedPercentage > firstRange ? SecondaryColor.green : SecondaryColor.orange
   } else {
     color = SecondaryColor.green
   }
@@ -55,7 +62,7 @@ const Progress: React.FunctionComponent<Props> = (props) => {
         progress={progressValue}
         size={sizeInEm}
         role="progressbar"
-        aria-valuenow={percentage}
+        aria-valuenow={normalizedPercentage}
         aria-valuemin={0}
         aria-valuemax={100}
         tabIndex={0}
@@ -67,7 +74,7 @@ const Progress: React.FunctionComponent<Props> = (props) => {
             <circle className="progress-circle__value" cx="50" cy="50" r="45" fill="none" stroke={color} strokeWidth="8" />
           </svg>
           <ProgressLabelWrapper aria-hidden="true">
-            {content || <PercentageCompletion>{`${percentage > 100 ? 100 : percentage}%`}</PercentageCompletion>}
+            {content || <PercentageCompletion>{`${normalizedPercentage > 100 ? 100 : normalizedPercentage}%`}</PercentageCompletion>}
             {content ? null : <LabelText>COMPLETE</LabelText>}
           </ProgressLabelWrapper>
         </ProgressContent>
@@ -78,8 +85,8 @@ const Progress: React.FunctionComponent<Props> = (props) => {
 
 interface Props extends Omit<React.ComponentPropsWithoutRef<typeof ProgressContainer>, 'progress'> {
   percentage: number;
-  percentageRange?: Array<number>;
-  size?: number;
+  percentageRange?: [] | [number] | [number, number];
+  size?: 1|2|3|4|5|6|7|8|9|10;
   content?: React.ReactNode;
 }
 

--- a/src/Display/Progress/Progress.tsx
+++ b/src/Display/Progress/Progress.tsx
@@ -2,50 +2,85 @@ import * as React from 'react';
 
 import classNames from 'classnames';
 
-import { ProgressContainer, ProgressContent, ProgressLabelWrapper } from '../../Style/Display/ProgressStyle';
-import { SecondaryColor } from '../../Style/Colors';
+import { 
+  ProgressContainer, 
+  ProgressContent, 
+  ProgressLabelWrapper, 
+  PercentageCompletion, 
+  LabelText 
+} from '../../Style/Display/ProgressStyle';
+import { PrimaryColor, SecondaryColor } from '../../Style/Colors';
 
 const Progress: React.FunctionComponent<Props> = (props) => {
   const {
     className,
     percentage,
+    percentageRange = [50],
+    size = 8,
+    content,
     ...defaultProps
   } = props;
+  
+  if (percentage < 0 || percentage > 100) {
+    throw new Error(`Error: percentage prop on Progress component expected a value between 0-100. Received ${percentage} instead.`)
+  }  
+
+  if (percentageRange.length > 2) {
+    throw new Error(`Error: percentageRange prop on Progress component expected a maximum of 2 numbers. Received [${percentageRange}] instead.`)
+  }
+
+  if (size > 10 || size < 1) {
+    throw new Error(`Error: size prop on Progress component expected a number between 1 - 10. Received ${size} instead.`)
+  }
 
   const progressValue = percentage > 100 ? 282.6 * (1 - (100 / 100)) : 282.6 * (1 - (percentage / 100));
-  const color = percentage > 50 ? SecondaryColor.green : SecondaryColor.orange;
-
+  const sizeInEm = (size + 2) / 10;
+  
+  let color;
+  if (percentageRange.length === 2) {
+    const [firstRange, secondRange] = percentageRange;
+    color = percentage > secondRange ? SecondaryColor.green : 
+      (percentage > firstRange ? SecondaryColor.orange : PrimaryColor.glintsred);
+  } else if (percentageRange.length === 1) {
+    const [firstRange] = percentageRange;
+    color = percentage > firstRange ? SecondaryColor.green : SecondaryColor.orange
+  } else {
+    color = SecondaryColor.green
+  }
+  
   return (
     <React.Fragment>
-      {percentage >= 0 && (
-        <ProgressContainer
-          className={classNames('aries-progress', className)}
-          progress={progressValue}
-          role="progressbar"
-          aria-valuenow={percentage}
-          aria-valuemin={0}
-          aria-valuemax={100}
-          tabIndex={0}
-          {...defaultProps}
-        >
-          <ProgressContent tabIndex={-1}>
-            <svg width="8em" height="8em" viewBox="0 0 100 100">
-              <circle cx="50" cy="50" r="45" fill="none" stroke={SecondaryColor.lighterblack} strokeWidth="8" />
-              <circle className="progress-circle__value" cx="50" cy="50" r="45" fill="none" stroke={color} strokeWidth="8" />
-            </svg>
-            <ProgressLabelWrapper aria-hidden="true">
-              {`${percentage > 100 ? 100 : percentage}%`}
-              <p>COMPLETE</p>
-            </ProgressLabelWrapper>
-          </ProgressContent>
-        </ProgressContainer>
-      )}
+      <ProgressContainer
+        className={classNames('aries-progress', className)}
+        progress={progressValue}
+        size={sizeInEm}
+        role="progressbar"
+        aria-valuenow={percentage}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        tabIndex={0}
+        {...defaultProps}
+      >
+        <ProgressContent tabIndex={-1} size={sizeInEm}>
+          <svg width="8em" height="8em" viewBox="0 0 100 100">
+            <circle cx="50" cy="50" r="45" fill="none" stroke={SecondaryColor.lighterblack} strokeWidth="8" />
+            <circle className="progress-circle__value" cx="50" cy="50" r="45" fill="none" stroke={color} strokeWidth="8" />
+          </svg>
+          <ProgressLabelWrapper aria-hidden="true">
+            {content || <PercentageCompletion>{`${percentage > 100 ? 100 : percentage}%`}</PercentageCompletion>}
+            {content ? null : <LabelText>COMPLETE</LabelText>}
+          </ProgressLabelWrapper>
+        </ProgressContent>
+      </ProgressContainer>
     </React.Fragment>
   );
 };
 
 interface Props extends Omit<React.ComponentPropsWithoutRef<typeof ProgressContainer>, 'progress'> {
   percentage: number;
+  percentageRange?: Array<number>;
+  size?: number;
+  content?: React.ReactNode;
 }
 
 export default Progress;

--- a/src/Style/Display/ProgressStyle.ts
+++ b/src/Style/Display/ProgressStyle.ts
@@ -12,16 +12,12 @@ const spinning = keyframes`
 `;
 
 export const ProgressContent = styled.div<ProgressContentProps>`
-  size: ${((props: ProgressContentProps) => props.size) as any};  
-
   position: relative;
   outline: none;
   font-size: ${props => `${props.size}em`};
 `;
 
 export const ProgressContainer = styled.div<ProgressContainerProps>`
-  size: ${((props: ProgressContentProps) => props.size) as any}; 
-
   position: relative;
   display: flex;
   background: transparent;

--- a/src/Style/Display/ProgressStyle.ts
+++ b/src/Style/Display/ProgressStyle.ts
@@ -11,12 +11,17 @@ const spinning = keyframes`
   }
 `;
 
-export const ProgressContent = styled.div`
+export const ProgressContent = styled.div<ProgressContentProps>`
+  size: ${((props: ProgressContentProps) => props.size) as any};  
+
   position: relative;
   outline: none;
+  font-size: ${props => `${props.size}em`};
 `;
 
 export const ProgressContainer = styled.div<ProgressContainerProps>`
+  size: ${((props: ProgressContentProps) => props.size) as any}; 
+
   position: relative;
   display: flex;
   background: transparent;
@@ -39,11 +44,12 @@ export const ProgressContainer = styled.div<ProgressContainerProps>`
     width: 7.2em;
     height: 7.2em;
     border-radius: 50%;
+    font-size: ${props => `${props.size}em`};
     background: ${SecondaryColor.whitesmoke};
     z-index: -1;
   }
 
-  svg {
+  > div > svg {
     transform: rotate(-90deg);
 
     .progress-circle__value {
@@ -56,25 +62,33 @@ export const ProgressContainer = styled.div<ProgressContainerProps>`
 
 interface ProgressContainerProps {
   progress: number;
+  size?: number;
+}
+
+interface ProgressContentProps {
+  size?: number;
 }
 
 export const ProgressLabelWrapper = styled.label`
-  display: block;
   position: absolute;
+  top: 50%;
+  left: 0;
+  display: block;
   width: 100%;
   text-align: center;
   line-height: 1;
-  top: 50%;
+  font-size: inherit;
   transform: translateY(-50%);
-  left: 0;
+`;
+
+export const PercentageCompletion = styled.h1`
   margin: 0;
   font-size: 1.5em;
   font-weight: 900;
+`;
 
-  p {
-    margin: 0;
-    margin-top: .6em;
-    font-size: .5em;
-    font-weight: 500;
-  }
+export const LabelText = styled.p`
+  margin: .6em 0 0;
+  font-size: .75em;
+  font-weight: 500;
 `;

--- a/stories/Display/ProgressStory.tsx
+++ b/stories/Display/ProgressStory.tsx
@@ -14,6 +14,30 @@ const props = {
       require: 'Yes',
       description: 'Sets progress value.',
     },
+    {
+      name: 'percentageRange',
+      type: 'array',
+      defaultValue: '[50]',
+      possibleValue: '[], [50] or [15,60]. The numbers in the array can be any integer between 0-100. The maximum number of items in the array is 2.',
+      require: 'No',
+      description: 'Sets the percentage range to display a different color on the progress component.\n[] sets values from 0-100 to green.\n[50] sets values from 0-50 to orange, 51-100 to green.\n[15,60] sets values from 0-15 to red, 16-60 to orange, 61-100 to green.',
+    },
+    {
+      name: 'size',
+      type: 'number',
+      defaultValue: '8',
+      possibleValue: '1 - 10',
+      require: 'No',
+      description: 'Sets the size of the progress component.',
+    },
+    {
+      name: 'content',
+      type: 'any',
+      defaultValue: '',
+      possibleValue: '',
+      require: 'No',
+      description: 'Sets the content inside the progress component.',
+    },
   ],
 };
 
@@ -22,9 +46,9 @@ const ProgressStory = () => (
     title="Progress"
     code="import { Progress } from 'glints-aries'"
     propsObject={props}
-    usage={'<Progress percentage={54} />'}
+    usage={'<Progress percentage={51} />'}
   >
-    <Progress percentage={54} />
+    <Progress percentage={51} />
   </StorybookComponent>
 );
 


### PR DESCRIPTION
- `content`: sets the content inside the component
- `percentageRange`: sets the percentage range to display a different color on the progress component when the percentage changes
- `size`: sets the size of the component