### PR TITLE
AutoComplete: Fix ActiveItemElement selection logic.

### DIFF
--- a/src/Input/AutoComplete/AutoComplete.tsx
+++ b/src/Input/AutoComplete/AutoComplete.tsx
@@ -96,7 +96,8 @@ class AutoComplete extends React.Component<Props, State> {
       });
 
       if (onChange !== undefined) {
-        const activeItemElement = this.autoCompleteContainerRef.current;
+        const containerElement = this.autoCompleteContainerRef.current;
+        const activeItemElement = containerElement.querySelector('.active') as HTMLLIElement;
         const itemValue = activeItemElement.dataset.value;
         onChange(itemValue);
       }


### PR DESCRIPTION
Due to this bug, selecting a country in job preferences for a recruiter
by clicking on the country was not possible, however pressing enter on
the country was working.

See https://github.com/glints-dev/glints-aries/blob/6080eddc42b9af7aaa6e4cef4b216b448c38e152/src/Input/AutoComplete/AutoComplete.tsx#L128 (L128-L129) for the correct logic which was existing for the enter keypress.

Trello link: https://trello.com/c/9p4cP9UA/3322-recruiter-unable-to-save-work-location-preferences-reported-by-duc