### PR TITLE
Remove unexpected gap after Go! button

### DIFF
--- a/src/Style/Input/OmniSearchStyle.ts
+++ b/src/Style/Input/OmniSearchStyle.ts
@@ -44,7 +44,7 @@ export const OmniSearchBar = styled.div`
 
 export const OmniSearchButton = styled(Button)`
   position: absolute;
-  right: 3px;
+  right: 2px;
   font-size: 1.5em;
   font-weight: normal;
   height: 100%;


### PR DESCRIPTION
Fixes: #94 

Removed the white gap after Go! button.

Before:
![image](https://user-images.githubusercontent.com/22127980/63418604-0518ff80-c421-11e9-8ba5-caa75441cd14.png)

After Changes:
![image](https://user-images.githubusercontent.com/22127980/63418660-1c57ed00-c421-11e9-8cc2-4831eaa536b9.png)
