### PR TITLE
Fix rendering of Alert Box when autoClose changes dynamically

### DIFF
--- a/src/General/Alert/Alert.tsx
+++ b/src/General/Alert/Alert.tsx
@@ -39,10 +39,10 @@ class Alert extends React.Component<Props, State> {
 
     if (prevProps.isOpen && !isOpen) {
       setTimeout(() => this.setState({ isVisible: false }), 300);
-    } else if (isOpen && prevProps.autoClose) {
+    } else if (isOpen && this.props.autoClose) {
       this.autoCloseTimeout = setTimeout(() => {
         prevProps.onClose();
-      }, prevProps.autoClose);
+      }, this.props.autoClose);
     }
 
     if (isOpen) {


### PR DESCRIPTION
Fixes: #97 

The Alert Box works according to the current value of the autoClose instead of taking the previous one.