### PR TITLE
Fix the unexpected behavior of BreadCrumb

### DIFF
--- a/src/Style/Navigation/BreadcrumbStyle.ts
+++ b/src/Style/Navigation/BreadcrumbStyle.ts
@@ -2,12 +2,12 @@ import styled from 'styled-components';
 import { SecondaryColor } from '../Colors';
 
 export const BreadcrumbItemWrapper = styled.label<BreadcrumbItemWrapper>`
-  cursor: pointer;
+  cursor: ${({ active }) => active ? 'default' : 'pointer'};
   font-size: 1em;
   line-height: 1.5;
   
   * {
-    color: ${({ active }) => active ? `${SecondaryColor.blue}` : `${SecondaryColor.lightblack}`};
+    color: ${({ active }) => active ? `${SecondaryColor.grey}` : `${SecondaryColor.black}`};
   }
 
   span {
@@ -30,3 +30,4 @@ export const BreadcrumbContainer = styled.div`
     display: none;
   }
 `;
+


### PR DESCRIPTION
1. In the active BreadCrumb item : Colour changed to grey and the cursor changed to default.
2. For the non active ones: Colour changed to Black.

To view the changes after installing the project :
In the file ` BreadcrumbStory.tsx ` , change the active Breadcrumb Item to div. (For now the active element is written in anchor tags which makes the cursor to be pointer by default.)

![image](https://user-images.githubusercontent.com/22127980/63810775-39218280-c943-11e9-9b8f-16688d7a77a5.png)


Fixes: #95 