### PR TITLE
Select: Change data-classname to data-id

### DIFF
--- a/src/Input/Select/SelectList.tsx
+++ b/src/Input/Select/SelectList.tsx
@@ -28,7 +28,7 @@ const SelectList: React.FunctionComponent<Props> = ({
             className={cursor === index ? 'active' : null}
             key={data.props.value}
             role="option"
-            data-classname={index}
+            data-id={index}
             data-value={data.props.value}
             onClick={handleClick(data.props.onOptionClick)}
             onMouseEnter={handleMouseEnter}


### PR DESCRIPTION
- Use of data-classname led to displaying the wrong active state of SelectItem
- data-id is used because each SelectItem should be unique to determine the active state