### PR TITLE
Tabs: Refactor to function component with hooks and adjust tab index to allow for changing tabs with tab key

### DIFF
--- a/src/Display/Tabs/TabPane.tsx
+++ b/src/Display/Tabs/TabPane.tsx
@@ -21,6 +21,7 @@ const TabPane: React.FunctionComponent<Props> = (props) => {
 export interface Props extends React.ComponentPropsWithoutRef<typeof TabsContent> {
   children: React.ReactNode;
   tab?: string;
+  label?: string | number;
 }
 
 export default TabPane;

--- a/src/Display/Tabs/Tabs.tsx
+++ b/src/Display/Tabs/Tabs.tsx
@@ -10,84 +10,70 @@ import {
   TabsBody,
 } from '../../Style/Display/TabsStyle';
 
-class Tabs extends React.Component<Props, State> {
-  static Pane = TabPane;
+const Tabs: Tabs = ({activeTab, onTabClick, children, className}) => {
+  const [currentIndex, setCurrentIndex] = React.useState(0);
+  const activeTabOrIndex: any = activeTab || currentIndex;
+  const onClick = onTabClick || setCurrentIndex;
 
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      currentIndex: 0,
-    };
-  }
+  const childrenArray = React.Children.toArray(children);
+  const currentChild = childrenArray[activeTabOrIndex];
 
-  handleClickTab = (index: number) => {
-    const listener = () => {
-      this.setState({
-        currentIndex: index,
-      });
-    };
+  const handleTabClick = (tab: any) => {
+    const listener = () => onClick(tab);
     return listener;
-  }
+  };
 
-  render() {
-    const {
-      children,
-      className,
-    } = this.props;
-
-    const { currentIndex } = this.state;
-
-    const childrenArray = React.Children.toArray(children);
-    const currentChild = childrenArray[currentIndex];
-
-    return (
-      <TabsContainer className={classNames('aries-tabs', className)}>
-        <TabsHeader className="tabs-header">
-          <ul className="tabs-list" role="tablist">
-            {React.Children.map(children, (data: React.ReactElement<TabPaneProps>, index) => (
-              <li
-                className={classNames(`tab-${index}`, { active: currentIndex === index })}
-                key={data.props.tab}
-                role="tab"
-                aria-selected={currentIndex === index && true}
-                aria-controls={`tab-item-${index}`}
-                tabIndex={currentIndex === index ? 0 : -1}
+  return (
+    <TabsContainer className={classNames('aries-tabs', className)}>
+      <TabsHeader className="tabs-header">
+        <ul className="tabs-list" role="tablist">
+          {React.Children.map(children, (data: React.ReactElement<TabPaneProps>, index) => {
+            const tabLabel = data.props.label || index;
+            return(
+            <li
+              className={classNames(`tab-${tabLabel}`, { active: activeTabOrIndex === tabLabel })}
+              key={data.props.tab}
+              role="tab"
+              aria-selected={activeTabOrIndex === tabLabel && true}
+              aria-controls={`tab-item-${tabLabel}`}
+              tabIndex={-1}
+            >
+              <button
+                type="button"
+                onClick={handleTabClick(tabLabel)}
               >
-                <button
-                  type="button"
-                  onClick={this.handleClickTab(index)}
-                  tabIndex={-1}
-                >
-                  {data.props.tab}
-                </button>
-              </li>
-            ))}
-          </ul>
-        </TabsHeader>
-        <TabsBody className="tabs-body" tabIndex={0}>
-          <TabPane
-            className={classNames('tabs-item', `tab-item-${currentIndex}`)}
-            role="tabpanel"
-            aria-labelledby={`tab-${currentIndex}`}
-            tabIndex={-1}
-          >
-            {React.isValidElement<TabPaneProps>(currentChild) &&
-              currentChild.props.children}
-          </TabPane>
-        </TabsBody>
-      </TabsContainer>
-    );
-  }
+                {data.props.tab}
+              </button>
+            </li>
+          )})}
+        </ul>
+      </TabsHeader>
+      <TabsBody className="tabs-body" tabIndex={0}>
+        <TabPane
+          className={classNames('tabs-item', `tab-item-${activeTabOrIndex}`)}
+          role="tabpanel"
+          aria-labelledby={`tab-${activeTabOrIndex}`}
+          tabIndex={-1}
+        >
+          {React.isValidElement<TabPaneProps>(currentChild) &&
+            currentChild.props.children}
+        </TabPane>
+      </TabsBody>
+    </TabsContainer>
+  );
 }
+
+type Tabs = React.FunctionComponent<Props> & {
+  Pane: typeof TabPane;
+}
+
+Tabs.Pane = TabPane;
 
 interface Props {
   children: React.ReactNode;
-  label?: string;
+  activeTab?: string;
+  onTabClick?(e: React.MouseEvent<HTMLButtonElement, MouseEvent>): void;
   className?: string;
-}
-
-interface State {
-  currentIndex: number;
 }
 
 export default Tabs;

--- a/src/Display/Tabs/Tabs.tsx
+++ b/src/Display/Tabs/Tabs.tsx
@@ -12,14 +12,17 @@ import {
 
 const Tabs: Tabs = ({activeTab, onTabClick, children, className}) => {
   const [currentIndex, setCurrentIndex] = React.useState(0);
-  const activeTabOrIndex: any = activeTab || currentIndex;
-  const onClick = onTabClick || setCurrentIndex;
-
+  const activeTabOrIndex: string | number = activeTab || currentIndex;
   const childrenArray = React.Children.toArray(children);
-  const currentChild = childrenArray[activeTabOrIndex];
+  const currentChild = childrenArray[currentIndex];
 
-  const handleTabClick = (tab: any) => {
-    const listener = () => onClick(tab);
+  const handleTabClick = (index: number, tab: React.ReactText) => {
+    const listener = () => {
+      setCurrentIndex(index);
+      if (onTabClick) {
+        onTabClick(tab);
+      }
+    };
     return listener;
   };
 
@@ -40,7 +43,7 @@ const Tabs: Tabs = ({activeTab, onTabClick, children, className}) => {
             >
               <button
                 type="button"
-                onClick={handleTabClick(tabLabel)}
+                onClick={handleTabClick(index, tabLabel)}
               >
                 {data.props.tab}
               </button>
@@ -72,7 +75,7 @@ Tabs.Pane = TabPane;
 interface Props {
   children: React.ReactNode;
   activeTab?: string;
-  onTabClick?(e: React.MouseEvent<HTMLButtonElement, MouseEvent>): void;
+  onTabClick?(tab: React.ReactText): void;
   className?: string;
 }
 

--- a/src/Style/Display/TabsStyle.ts
+++ b/src/Style/Display/TabsStyle.ts
@@ -19,14 +19,13 @@ export const TabsHeader = styled.div`
     font-size: 1em;
     padding: 0;
     margin: 0;
-    
+
     &::-webkit-scrollbar {
       display: none;
     }
 
     li {
-      display: inline-flex;
-      padding: 1.2em 0;
+      display: inline-flex;    
       margin: 0 10px;
       text-transform: uppercase;
       list-style-type: none;
@@ -52,12 +51,8 @@ export const TabsHeader = styled.div`
         outline: none;
       }
 
-      &:focus > button {
-        outline: 5px auto -webkit-focus-ring-color;
-      }
-
       button {
-        padding: 0;
+        padding: 20px 0;
         background: transparent;
         border: none;
         cursor: pointer;


### PR DESCRIPTION
- add props on Tabs to allow devs to set the activeTab and the onTabClick behaviour
- add label prop on children to set the label when it is passed to TabPane
- adjust tab index to allow users to press tab key to switch focus of tabs
- adjust tab index to allow users to press enter to switch to a tab in focus