### PR TITLE
Badge: Fix bug where a label of 0 causes the badge not to show

### DIFF
--- a/src/General/Badge/Badge.tsx
+++ b/src/General/Badge/Badge.tsx
@@ -1,36 +1,22 @@
 import * as React from 'react';
 import classNames from 'classnames';
+import { isNil } from 'lodash';
 import { BadgeContainer } from '../../Style/General/BadgeStyle';
 
-const Badge: React.FunctionComponent<Props> = (props) => {
-  const {
-    label,
-    sup,
-    className,
-    ...defaultProps
-  } = props;
-
-  return (
-    <React.Fragment>
-      {label
-        && (
-          <BadgeContainer
-            className={classNames('aries-badge', className)}
-            sup={sup}
-            {...defaultProps}
-          >
-            <span className="badge-content">
-              {label}
-            </span>
-          </BadgeContainer>
-        )
-      }
-    </React.Fragment>
-  );
-};
+const Badge: React.FunctionComponent<Props> = ({
+  label, sup, className, ...defaultProps
+}) => (
+  <React.Fragment>
+    {!isNil(label) && (
+      <BadgeContainer className={classNames('aries-badge', className)} sup={sup} {...defaultProps}>
+        <span className="badge-content">{label}</span>
+      </BadgeContainer>
+    )}
+  </React.Fragment>
+);
 
 interface Props extends React.ComponentPropsWithoutRef<typeof BadgeContainer> {
-  label: string;
+  label: string | number;
   sup?: boolean;
 }
 

--- a/stories/General/BadgeStory.tsx
+++ b/stories/General/BadgeStory.tsx
@@ -8,7 +8,7 @@ const props = {
   Badge: [
     {
       name: 'label',
-      type: 'string',
+      type: 'string | number',
       defaultValue: '',
       possibleValue: 'any',
       require: 'yes',


### PR DESCRIPTION
https://github.com/glints-dev/glints-aries/issues/119
- Change the type of label to string or number
- Only hide the badge when label is null or undefined