### PR TITLE
Feature/typography

### DIFF
--- a/src/General/Typography/Paragraph.test.tsx
+++ b/src/General/Typography/Paragraph.test.tsx
@@ -15,7 +15,7 @@ const paragraphText =
   'As the first sign in the zodiac, the presence of Aries always marks the beginning of something energetic and turbulent. They are continuously looking for dynamic, speed and competition, always being the first in everything - from work to social gatherings.';
 
 describe('displays the correct text and font-size for each variant:', () => {
-  const variants: paragraphType[] = Object.values(PARAGRAPH_VARIANTS);
+  const variants = Object.values(PARAGRAPH_VARIANTS) as paragraphType[];
   variants.forEach(variant => {
     const fontSize = PARAGRAPH_FONT_SIZES[variant];
     it(`${variant}: ${fontSize}px`, () => {

--- a/src/General/Typography/Paragraph.test.tsx
+++ b/src/General/Typography/Paragraph.test.tsx
@@ -5,18 +5,26 @@ import { PrimaryColor } from '../../Style/Colors';
 import '@testing-library/jest-dom/extend-expect';
 import { render } from '@testing-library/react';
 
+import {
+  PARAGRAPH_FONT_SIZES,
+  PARAGRAPH_VARIANTS,
+  paragraphType,
+} from './ParagraphStyles';
+
 const paragraphText =
   'As the first sign in the zodiac, the presence of Aries always marks the beginning of something energetic and turbulent. They are continuously looking for dynamic, speed and competition, always being the first in everything - from work to social gatherings.';
 
-describe('displays the correct text for each variant:', () => {
-  const variants: any[] = ['subtitle', 'regular', 'caption', 'smallest'];
+describe('displays the correct text and font-size for each variant:', () => {
+  const variants: paragraphType[] = Object.values(PARAGRAPH_VARIANTS);
   variants.forEach(variant => {
-    it(`${variant}`, () => {
+    const fontSize = PARAGRAPH_FONT_SIZES[variant];
+    it(`${variant}: ${fontSize}px`, () => {
       const { getByText } = render(
         <Paragraph variant={variant}>{paragraphText}</Paragraph>
       );
       const paragraphTag = getByText(paragraphText);
-      expect(paragraphTag).toHaveTextContent(paragraphText);
+      expect(paragraphTag).toBeTruthy();
+      expect(paragraphTag).toHaveStyle(`font-size: ${fontSize}px`);
     });
   });
 });

--- a/src/General/Typography/Paragraph.test.tsx
+++ b/src/General/Typography/Paragraph.test.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import Paragraph from './Paragraph';
+import { PrimaryColor } from '../../Style/Colors';
+
+import '@testing-library/jest-dom/extend-expect';
+import { render } from '@testing-library/react';
+
+const paragraphText =
+  'As the first sign in the zodiac, the presence of Aries always marks the beginning of something energetic and turbulent. They are continuously looking for dynamic, speed and competition, always being the first in everything - from work to social gatherings.';
+
+describe('displays the correct text for each variant:', () => {
+  const variants: any[] = ['subtitle', 'regular', 'caption', 'smallest'];
+  variants.forEach(variant => {
+    it(`${variant}`, () => {
+      const { getByText } = render(
+        <Paragraph variant={variant}>{paragraphText}</Paragraph>
+      );
+      const paragraphTag = getByText(paragraphText);
+      expect(paragraphTag).toHaveTextContent(paragraphText);
+    });
+  });
+});
+
+it('displays the text in bold', () => {
+  const { getByText } = render(<Paragraph bold>{paragraphText}</Paragraph>);
+  const paragraphTag = getByText(paragraphText);
+  expect(paragraphTag).toHaveStyle('font-weight: bold');
+});
+
+it('displays the correct color', () => {
+  const { getByText } = render(
+    <Paragraph color={PrimaryColor.glintsred}>{paragraphText}</Paragraph>
+  );
+  const paragraphTag = getByText(paragraphText);
+  expect(paragraphTag).toHaveStyle(`color: ${PrimaryColor.glintsred}`);
+});
+
+it('display the ellipsis', () => {
+  const { getByText } = render(<Paragraph ellipsis>{paragraphText}</Paragraph>);
+  const paragraphTag = getByText(paragraphText);
+  expect(paragraphTag).toHaveStyle(`
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+  `);
+});

--- a/src/General/Typography/Paragraph.tsx
+++ b/src/General/Typography/Paragraph.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import classNames from 'classnames';
+
+import {
+  Paragraph as StyledParagraph,
+  ParagraphProps,
+} from './ParagraphStyles';
+
+const Paragraph: React.FunctionComponent<Props> = props => {
+  const {
+    className,
+    children,
+    variant = 'regular',
+    bold,
+    color,
+    ellipsis,
+    ...defaultProps
+  } = props;
+
+  return (
+    <StyledParagraph
+      className={classNames('aries-typography-paragraph', className)}
+      variant={variant}
+      bold={bold}
+      color={color}
+      ellipsis={ellipsis}
+      {...defaultProps}
+    >
+      {children}
+    </StyledParagraph>
+  );
+};
+
+interface Props extends ParagraphProps {
+  className?: string;
+  children: React.ReactNode;
+}
+
+export default Paragraph;

--- a/src/General/Typography/Paragraph.tsx
+++ b/src/General/Typography/Paragraph.tsx
@@ -5,6 +5,7 @@ import {
   Paragraph as StyledParagraph,
   ParagraphProps,
 } from './ParagraphStyles';
+import { SecondaryColor } from '../../Style/Colors';
 
 const Paragraph: React.FunctionComponent<Props> = props => {
   const {
@@ -12,9 +13,9 @@ const Paragraph: React.FunctionComponent<Props> = props => {
     children,
     variant = 'regular',
     bold,
-    color,
+    color = SecondaryColor.black,
     ellipsis,
-    ...defaultProps
+    ...restProps
   } = props;
 
   return (
@@ -24,7 +25,7 @@ const Paragraph: React.FunctionComponent<Props> = props => {
       bold={bold}
       color={color}
       ellipsis={ellipsis}
-      {...defaultProps}
+      {...restProps}
     >
       {children}
     </StyledParagraph>

--- a/src/General/Typography/ParagraphStyles.ts
+++ b/src/General/Typography/ParagraphStyles.ts
@@ -25,37 +25,13 @@ export interface ParagraphProps {
 
 export const Paragraph = styled.p<ParagraphProps>`
   margin: 0;
+  font-size: ${props => PARAGRAPH_FONT_SIZES[props.variant]}px;
   font-weight: ${props => (props.bold ? 'bold' : 'normal')};
   font-stretch: normal;
   font-style: normal;
   line-height: normal;
   letter-spacing: normal;
   color: ${props => props.color};
-
-  ${props => {
-    switch (props.variant) {
-      case PARAGRAPH_VARIANTS.subtitle:
-        return `
-          font-size: ${PARAGRAPH_FONT_SIZES.subtitle}px;
-        `;
-      case PARAGRAPH_VARIANTS.regular:
-        return `
-          font-size: ${PARAGRAPH_FONT_SIZES.regular}px;
-        `;
-      case PARAGRAPH_VARIANTS.caption:
-        return `
-          font-size: ${PARAGRAPH_FONT_SIZES.caption}px;
-        `;
-      case PARAGRAPH_VARIANTS.smallest:
-        return `
-          font-size: ${PARAGRAPH_FONT_SIZES.smallest}px;
-        `;
-      default:
-        return `
-          font-size: ${PARAGRAPH_FONT_SIZES.regular}px;
-        `;
-    }
-  }};
 
   ${props => {
     if (props.ellipsis) {

--- a/src/General/Typography/ParagraphStyles.ts
+++ b/src/General/Typography/ParagraphStyles.ts
@@ -1,12 +1,26 @@
 import styled from 'styled-components';
 
-import { SecondaryColor } from '../../Style/Colors';
+export const PARAGRAPH_VARIANTS = {
+  subtitle: 'subtitle',
+  regular: 'regular',
+  caption: 'caption',
+  smallest: 'smallest',
+};
+
+export const PARAGRAPH_FONT_SIZES = {
+  [PARAGRAPH_VARIANTS.subtitle]: 18,
+  [PARAGRAPH_VARIANTS.regular]: 16,
+  [PARAGRAPH_VARIANTS.caption]: 14,
+  [PARAGRAPH_VARIANTS.smallest]: 12,
+};
+
+export type paragraphType = 'subtitle' | 'regular' | 'caption' | 'smallest';
 
 export interface ParagraphProps {
   bold?: boolean;
   color?: string;
   ellipsis?: boolean;
-  variant?: 'subtitle' | 'regular' | 'caption' | 'smallest';
+  variant?: paragraphType;
 }
 
 export const Paragraph = styled.p<ParagraphProps>`
@@ -16,29 +30,29 @@ export const Paragraph = styled.p<ParagraphProps>`
   font-style: normal;
   line-height: normal;
   letter-spacing: normal;
-  color: ${props => props.color || SecondaryColor.black};
+  color: ${props => props.color};
 
   ${props => {
     switch (props.variant) {
-      case 'subtitle':
+      case PARAGRAPH_VARIANTS.subtitle:
         return `
-          font-size: 18px;
+          font-size: ${PARAGRAPH_FONT_SIZES.subtitle}px;
         `;
-      case 'regular':
+      case PARAGRAPH_VARIANTS.regular:
         return `
-          font-size: 16px;
+          font-size: ${PARAGRAPH_FONT_SIZES.regular}px;
         `;
-      case 'caption':
+      case PARAGRAPH_VARIANTS.caption:
         return `
-          font-size: 14px;
+          font-size: ${PARAGRAPH_FONT_SIZES.caption}px;
         `;
-      case 'smallest':
+      case PARAGRAPH_VARIANTS.smallest:
         return `
-          font-size: 12px;
+          font-size: ${PARAGRAPH_FONT_SIZES.smallest}px;
         `;
       default:
         return `
-          font-size: 16px;
+          font-size: ${PARAGRAPH_FONT_SIZES.regular}px;
         `;
     }
   }};

--- a/src/General/Typography/ParagraphStyles.ts
+++ b/src/General/Typography/ParagraphStyles.ts
@@ -1,0 +1,55 @@
+import styled from 'styled-components';
+
+import { SecondaryColor } from '../../Style/Colors';
+
+export interface ParagraphProps {
+  bold?: boolean;
+  color?: string;
+  ellipsis?: boolean;
+  variant?: 'subtitle' | 'regular' | 'caption' | 'smallest';
+}
+
+export const Paragraph = styled.p<ParagraphProps>`
+  margin: 0;
+  font-weight: ${props => (props.bold ? 'bold' : 'normal')};
+  font-stretch: normal;
+  font-style: normal;
+  line-height: normal;
+  letter-spacing: normal;
+  color: ${props => props.color || SecondaryColor.black};
+
+  ${props => {
+    switch (props.variant) {
+      case 'subtitle':
+        return `
+          font-size: 18px;
+        `;
+      case 'regular':
+        return `
+          font-size: 16px;
+        `;
+      case 'caption':
+        return `
+          font-size: 14px;
+        `;
+      case 'smallest':
+        return `
+          font-size: 12px;
+        `;
+      default:
+        return `
+          font-size: 16px;
+        `;
+    }
+  }};
+
+  ${props => {
+    if (props.ellipsis) {
+      return `
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      `;
+    }
+  }}
+`;

--- a/src/General/Typography/Title.test.tsx
+++ b/src/General/Typography/Title.test.tsx
@@ -1,22 +1,26 @@
 import * as React from 'react';
-import Title from './Title';
-import { PrimaryColor } from '../../Style/Colors';
-
 import '@testing-library/jest-dom/extend-expect';
 import { render } from '@testing-library/react';
 
+import Title, { tagType } from './Title';
+import { TITLE_VARIANTS, TITLE_FONT_SIZES } from './TitleStyles';
+import { PrimaryColor } from '../../Style/Colors';
+
 const titleText = 'Glints Aries';
 
-describe('displays the correct text and uses the correct html tag for each tag:', () => {
-  const tags: any[] = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
+describe('displays the correct text, uses the correct html tag and font-size for each tag:', () => {
+  const tags: tagType[] = Object.values(TITLE_VARIANTS);
+
   tags.forEach(tag => {
+    const fontSize = TITLE_FONT_SIZES[tag];
     it(`${tag}`, () => {
       const { container, getByText } = render(
         <Title tag={tag}>{titleText}</Title>
       );
       const heading = getByText(titleText);
-      expect(heading).toHaveTextContent(titleText);
+      expect(heading).toBeTruthy();
       expect(container).toContainHTML(tag);
+      expect(heading).toHaveStyle(`font-size: ${fontSize}px`);
     });
   });
 });

--- a/src/General/Typography/Title.test.tsx
+++ b/src/General/Typography/Title.test.tsx
@@ -9,7 +9,7 @@ import { PrimaryColor } from '../../Style/Colors';
 const titleText = 'Glints Aries';
 
 describe('displays the correct text, uses the correct html tag and font-size for each tag:', () => {
-  const tags: tagType[] = Object.values(TITLE_VARIANTS);
+  const tags = Object.values(TITLE_VARIANTS) as tagType[];
 
   tags.forEach(tag => {
     const fontSize = TITLE_FONT_SIZES[tag];

--- a/src/General/Typography/Title.test.tsx
+++ b/src/General/Typography/Title.test.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import Title from './Title';
+import { PrimaryColor } from '../../Style/Colors';
+
+import '@testing-library/jest-dom/extend-expect';
+import { render } from '@testing-library/react';
+
+const titleText = 'Glints Aries';
+
+describe('displays the correct text and uses the correct html tag for each tag:', () => {
+  const tags: any[] = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
+  tags.forEach(tag => {
+    it(`${tag}`, () => {
+      const { container, getByText } = render(
+        <Title tag={tag}>{titleText}</Title>
+      );
+      const heading = getByText(titleText);
+      expect(heading).toHaveTextContent(titleText);
+      expect(container).toContainHTML(tag);
+    });
+  });
+});
+
+it('displays the correct color', () => {
+  const { getByText } = render(
+    <Title color={PrimaryColor.glintsred}>Glints Aries</Title>
+  );
+  const heading = getByText(titleText);
+  expect(heading).toHaveStyle(`color: ${PrimaryColor.glintsred}`);
+});
+
+it('display the ellipsis', () => {
+  const { getByText } = render(<Title ellipsis>{titleText}</Title>);
+  const heading = getByText(titleText);
+  expect(heading).toHaveStyle(`
+      overflow: hidden; 
+      white-space: nowrap; 
+      text-overflow: ellipsis;
+    `);
+});

--- a/src/General/Typography/Title.tsx
+++ b/src/General/Typography/Title.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import classNames from 'classnames';
+
+import { Title as StyledTitle } from './TitleStyles';
+
+const Title: React.FunctionComponent<Props> = props => {
+  const {
+    className,
+    children,
+    color,
+    ellipsis,
+    tag = 'h1',
+    ...defaultProps
+  } = props;
+
+  return (
+    <StyledTitle
+      className={classNames('aries-typography-title', className)}
+      as={tag}
+      color={color}
+      ellipsis={ellipsis}
+      {...defaultProps}
+    >
+      {children}
+    </StyledTitle>
+  );
+};
+
+interface Props {
+  className?: string;
+  children: React.ReactNode;
+  color?: string;
+  ellipsis?: boolean;
+  tag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+}
+
+export default Title;

--- a/src/General/Typography/Title.tsx
+++ b/src/General/Typography/Title.tsx
@@ -2,15 +2,16 @@ import * as React from 'react';
 import classNames from 'classnames';
 
 import { Title as StyledTitle } from './TitleStyles';
+import { SecondaryColor } from '../../Style/Colors';
 
 const Title: React.FunctionComponent<Props> = props => {
   const {
     className,
     children,
-    color,
+    color = SecondaryColor.black,
     ellipsis,
     tag = 'h1',
-    ...defaultProps
+    ...restProps
   } = props;
 
   return (
@@ -19,19 +20,21 @@ const Title: React.FunctionComponent<Props> = props => {
       as={tag}
       color={color}
       ellipsis={ellipsis}
-      {...defaultProps}
+      {...restProps}
     >
       {children}
     </StyledTitle>
   );
 };
 
+export type tagType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
 interface Props {
   className?: string;
   children: React.ReactNode;
   color?: string;
   ellipsis?: boolean;
-  tag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  tag?: tagType;
 }
 
 export default Title;

--- a/src/General/Typography/TitleStyles.ts
+++ b/src/General/Typography/TitleStyles.ts
@@ -1,0 +1,70 @@
+import styled from 'styled-components';
+
+import { SecondaryColor } from '../../Style/Colors';
+
+interface TitleProps {
+  as: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  color?: string;
+  ellipsis?: boolean;
+}
+
+export const Title = styled.h1<TitleProps>`
+  margin: 0;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: normal;
+  letter-spacing: normal;
+  color: ${props => props.color || SecondaryColor.black};
+
+  ${props => {
+    switch (props.as) {
+      case 'h1':
+        return `
+        font-size: 50px;
+        font-weight: 900;
+        line-height: 1.2;
+      `;
+      case 'h2':
+        return `
+        font-size: 36px;
+        line-height: 1.2;
+      `;
+      case 'h3':
+        return `
+        font-size: 30px;
+        line-height: 1.4;
+      `;
+      case 'h4':
+        return `
+        font-size: 26px;
+        line-height: 1.4;
+      `;
+      case 'h5':
+        return `
+        font-size: 22px;
+        line-height: 1.4;
+      `;
+      case 'h6':
+        return `
+        font-size: 18px;
+        line-height: 1.4;
+      `;
+      default:
+        return `
+        font-size: 50px;
+        font-weight: 900;
+        line-height: 1.2;
+    `;
+    }
+  }};
+
+  ${props => {
+    if (props.ellipsis) {
+      return `
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      `;
+    }
+  }}
+`;

--- a/src/General/Typography/TitleStyles.ts
+++ b/src/General/Typography/TitleStyles.ts
@@ -1,9 +1,27 @@
 import styled from 'styled-components';
 
-import { SecondaryColor } from '../../Style/Colors';
+import { tagType } from './Title';
+
+export const TITLE_VARIANTS = {
+  h1: 'h1',
+  h2: 'h2',
+  h3: 'h3',
+  h4: 'h4',
+  h5: 'h5',
+  h6: 'h6',
+};
+
+export const TITLE_FONT_SIZES = {
+  [TITLE_VARIANTS.h1]: 50,
+  [TITLE_VARIANTS.h2]: 36,
+  [TITLE_VARIANTS.h3]: 30,
+  [TITLE_VARIANTS.h4]: 26,
+  [TITLE_VARIANTS.h5]: 22,
+  [TITLE_VARIANTS.h6]: 18,
+};
 
 interface TitleProps {
-  as: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  as: tagType;
   color?: string;
   ellipsis?: boolean;
 }
@@ -14,44 +32,44 @@ export const Title = styled.h1<TitleProps>`
   font-stretch: normal;
   font-style: normal;
   letter-spacing: normal;
-  color: ${props => props.color || SecondaryColor.black};
+  color: ${props => props.color};
 
   ${props => {
     switch (props.as) {
-      case 'h1':
+      case TITLE_VARIANTS.h1:
         return `
-        font-size: 50px;
+        font-size: ${TITLE_FONT_SIZES.h1}px;
         font-weight: 900;
         line-height: 1.2;
       `;
-      case 'h2':
+      case TITLE_VARIANTS.h2:
         return `
-        font-size: 36px;
+        font-size: ${TITLE_FONT_SIZES.h2}px;
         line-height: 1.2;
       `;
-      case 'h3':
+      case TITLE_VARIANTS.h3:
         return `
-        font-size: 30px;
+        font-size: ${TITLE_FONT_SIZES.h3}px;
         line-height: 1.4;
       `;
-      case 'h4':
+      case TITLE_VARIANTS.h4:
         return `
-        font-size: 26px;
+        font-size: ${TITLE_FONT_SIZES.h4}px;
         line-height: 1.4;
       `;
-      case 'h5':
+      case TITLE_VARIANTS.h5:
         return `
-        font-size: 22px;
+        font-size: ${TITLE_FONT_SIZES.h5}px;
         line-height: 1.4;
       `;
-      case 'h6':
+      case TITLE_VARIANTS.h6:
         return `
-        font-size: 18px;
+        font-size: ${TITLE_FONT_SIZES.h6}px;
         line-height: 1.4;
       `;
       default:
         return `
-        font-size: 50px;
+        font-size: ${TITLE_FONT_SIZES.h1}px;
         font-weight: 900;
         line-height: 1.2;
     `;

--- a/src/General/Typography/Typography.test.tsx
+++ b/src/General/Typography/Typography.test.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import Typography from './Typography';
+
+import * as renderer from 'react-test-renderer';
+import '@testing-library/jest-dom/extend-expect';
+
+const { Title, Paragraph } = Typography;
+const shortText = 'Glints Aries';
+
+describe('<Typography> should contain the Title and Paragraph components:', () => {
+  it(`<Typography.Title> should render a h1 tag with the text Glints Aries`, () => {
+    const TitleSnapshot = renderer
+      .create(<Title tag="h1">{shortText}</Title>)
+      .toJSON();
+    expect(TitleSnapshot).toMatchSnapshot();
+  });
+
+  it(`<Typography.Paragraph> should render a p tag with the text Glints Aries`, () => {
+    const ParagraphSnapshot = renderer
+      .create(<Paragraph>{shortText}</Paragraph>)
+      .toJSON();
+    expect(ParagraphSnapshot).toMatchSnapshot();
+  });
+});

--- a/src/General/Typography/Typography.tsx
+++ b/src/General/Typography/Typography.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+import Title from './Title';
+import Paragraph from './Paragraph';
+
+const Typography: Typography = props => {
+  const { children } = props;
+
+  return <article>{children}</article>;
+};
+
+type Typography = React.FunctionComponent<Props> & {
+  Title: typeof Title;
+  Paragraph: typeof Paragraph;
+};
+
+Typography.Title = Title;
+Typography.Paragraph = Paragraph;
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export default Typography;

--- a/src/General/Typography/TypographyStory.tsx
+++ b/src/General/Typography/TypographyStory.tsx
@@ -1,0 +1,232 @@
+import * as React from 'react';
+
+import StorybookComponent from '../../../stories/StorybookComponent';
+
+import Heading from '../Heading';
+import Typography from '../Typography';
+import { PrimaryColor } from '../../Style/Colors';
+
+const { Title, Paragraph } = Typography;
+
+const titleProps = {
+  'Typography.Title': [
+    {
+      name: 'color',
+      type: 'string',
+      defaultValue: <code>black</code>,
+      possibleValue: <code>hex-value | rba-value | string-value</code>,
+      require: 'no',
+      description: "Sets the Title's color.",
+    },
+    {
+      name: 'ellipsis',
+      type: 'boolean',
+      defaultValue: <code>false</code>,
+      possibleValue: <code>true | false</code>,
+      require: 'no',
+      description: 'Display ellipsis when the title overflows.',
+    },
+    {
+      name: 'tag',
+      type: 'string',
+      defaultValue: <code>h1</code>,
+      possibleValue: <code>h1 | h2 | h3 | h4 | h5 | h6</code>,
+      require: 'no',
+      description: 'Sets the title tag to one of the <h1> - <h6> tags.',
+    },
+  ],
+};
+
+const paragraphProps = {
+  'Typography.Paragraph': [
+    {
+      name: 'bold',
+      type: 'boolean',
+      defaultValue: <code>false</code>,
+      possibleValue: <code>true | false</code>,
+      require: 'no',
+      description: "Sets the Paragraph's font-weight to bold.",
+    },
+    {
+      name: 'color',
+      type: 'string',
+      defaultValue: <code>black</code>,
+      possibleValue: <code>hex-value | rba-value | string-value</code>,
+      require: 'no',
+      description: "Sets the Paragraph's color.",
+    },
+    {
+      name: 'ellipsis',
+      type: 'boolean',
+      defaultValue: <code>false</code>,
+      possibleValue: <code>true | false</code>,
+      require: 'no',
+      description: 'Display ellipsis when the title overflows.',
+    },
+    {
+      name: 'variant',
+      type: 'string',
+      defaultValue: <code>regular</code>,
+      possibleValue: <code>subtitle | regular | caption | smallest</code>,
+      require: 'no',
+      description: "Sets the Paragraph's variant.",
+    },
+  ],
+};
+
+const TitleStory = () => (
+  <StorybookComponent
+    title="Typography"
+    code="import { Typography } from 'glints-aries'"
+    propsObject={titleProps}
+    usage={`import { Typography, PrimaryColor } from 'glints-aries';
+
+const { Title } = Typography;
+
+ReactDOM.render(
+  <div style={{ display: 'grid', gridRowGap: '15px' }}>
+    <Title tag="h1">Heading 1</Title>
+    <Title tag="h2">Heading 2</Title>
+    <Title tag="h3">Heading 3</Title>
+    <Title tag="h4">Heading 4</Title>
+    <Title tag="h5">Heading 5</Title>
+    <Title tag="h6">Heading 6</Title>
+    <Title tag="h5" color={PrimaryColor.glintsred}>
+      Colored Title
+    </Title>
+    <Title tag="h5" ellipsis>
+      Title with Ellipses - As the first sign in the zodiac, the presence of
+      Aries always marks the beginning of something energetic and turbulent.
+      They are continuously looking for dynamic, speed and competition, always
+      being the first in everything - from work to social gatherings.
+    </Title>
+  </div>,
+  mountNode
+);`}
+  >
+    <Heading style={{ fontSize: '24px', marginBottom: '1em' }}>
+      Typography.Title
+    </Heading>
+    <div style={{ display: 'grid', gridRowGap: '15px' }}>
+      <Title tag="h1">Heading 1</Title>
+      <Title tag="h2">Heading 2</Title>
+      <Title tag="h3">Heading 3</Title>
+      <Title tag="h4">Heading 4</Title>
+      <Title tag="h5">Heading 5</Title>
+      <Title tag="h6">Heading 6</Title>
+      <Title tag="h5" color={PrimaryColor.glintsred}>
+        Colored Title
+      </Title>
+      <Title tag="h5" ellipsis>
+        Title with Ellipses - As the first sign in the zodiac, the presence of
+        Aries always marks the beginning of something energetic and turbulent.
+        They are continuously looking for dynamic, speed and competition, always
+        being the first in everything - from work to social gatherings.
+      </Title>
+    </div>
+  </StorybookComponent>
+);
+
+const ParagraphStory = () => (
+  <StorybookComponent
+    propsObject={paragraphProps}
+    usage={`import { Typography, PrimaryColor } from 'glints-aries';
+
+const { Paragraph } = Typography;
+
+ReactDOM.render(
+  <div style={{ display: 'grid', gridRowGap: '15px' }}>
+    <Paragraph variant="subtitle">
+      Subtitle <br />
+      As the first sign in the zodiac, the presence of Aries always marks the
+      beginning of something energetic and turbulent.
+    </Paragraph>
+    <Paragraph variant="regular">
+      Regular <br />
+      As the first sign in the zodiac, the presence of Aries always marks the
+      beginning of something energetic and turbulent.
+    </Paragraph>
+    <Paragraph variant="caption">
+      Caption <br />
+      As the first sign in the zodiac, the presence of Aries always marks the
+      beginning of something energetic and turbulent.
+    </Paragraph>
+    <Paragraph variant="smallest">
+      Smallest <br />
+      As the first sign in the zodiac, the presence of Aries always marks the
+      beginning of something energetic and turbulent.
+    </Paragraph>
+    <Paragraph bold>
+      Bold Paragraph <br />
+      As the first sign in the zodiac, the presence of Aries always marks the
+      beginning of something energetic and turbulent.
+    </Paragraph>
+    <Paragraph color={PrimaryColor.glintsred}>
+      Colored Paragraph <br />
+      As the first sign in the zodiac, the presence of Aries always marks the
+      beginning of something energetic and turbulent.
+    </Paragraph>
+    <Paragraph ellipsis>
+      Paragraph with Ellipses - As the first sign in the zodiac, the presence
+      of Aries always marks the beginning of something energetic and
+      turbulent. They are continuously looking for dynamic, speed and
+      competition, always being the first in everything - from work to social
+      gatherings.
+    </Paragraph>
+  </div>,
+  mountNode
+);`}
+  >
+    <Heading style={{ fontSize: '24px', marginBottom: '1em' }}>
+      Typography.Paragraph
+    </Heading>
+    <div style={{ display: 'grid', gridRowGap: '15px' }}>
+      <Paragraph variant="subtitle">
+        Subtitle <br />
+        As the first sign in the zodiac, the presence of Aries always marks the
+        beginning of something energetic and turbulent.
+      </Paragraph>
+      <Paragraph variant="regular">
+        Regular <br />
+        As the first sign in the zodiac, the presence of Aries always marks the
+        beginning of something energetic and turbulent.
+      </Paragraph>
+      <Paragraph variant="caption">
+        Caption <br />
+        As the first sign in the zodiac, the presence of Aries always marks the
+        beginning of something energetic and turbulent.
+      </Paragraph>
+      <Paragraph variant="smallest">
+        Smallest <br />
+        As the first sign in the zodiac, the presence of Aries always marks the
+        beginning of something energetic and turbulent.
+      </Paragraph>
+      <Paragraph bold>
+        Bold Paragraph <br />
+        As the first sign in the zodiac, the presence of Aries always marks the
+        beginning of something energetic and turbulent.
+      </Paragraph>
+      <Paragraph color={PrimaryColor.glintsred}>
+        Colored Paragraph <br />
+        As the first sign in the zodiac, the presence of Aries always marks the
+        beginning of something energetic and turbulent.
+      </Paragraph>
+      <Paragraph ellipsis>
+        Paragraph with Ellipses - As the first sign in the zodiac, the presence
+        of Aries always marks the beginning of something energetic and
+        turbulent. They are continuously looking for dynamic, speed and
+        competition, always being the first in everything - from work to social
+        gatherings.
+      </Paragraph>
+    </div>
+  </StorybookComponent>
+);
+
+const TypographyStory = () => (
+  <React.Fragment>
+    <TitleStory />
+    <ParagraphStory />
+  </React.Fragment>
+);
+
+export default TypographyStory;

--- a/src/General/Typography/TypographyStory.tsx
+++ b/src/General/Typography/TypographyStory.tsx
@@ -2,8 +2,10 @@ import * as React from 'react';
 
 import StorybookComponent from '../../../stories/StorybookComponent';
 
+import Typography from '.';
+import { TITLE_VARIANTS } from './TitleStyles';
+import { PARAGRAPH_VARIANTS } from './ParagraphStyles';
 import Heading from '../Heading';
-import Typography from '../Typography';
 import { PrimaryColor } from '../../Style/Colors';
 
 const { Title, Paragraph } = Typography;
@@ -30,7 +32,12 @@ const titleProps = {
       name: 'tag',
       type: 'string',
       defaultValue: <code>h1</code>,
-      possibleValue: <code>h1 | h2 | h3 | h4 | h5 | h6</code>,
+      possibleValue: (
+        <code>
+          {TITLE_VARIANTS.h1} | {TITLE_VARIANTS.h2} | {TITLE_VARIANTS.h3} |{' '}
+          {TITLE_VARIANTS.h4} | {TITLE_VARIANTS.h5} | {TITLE_VARIANTS.h6}
+        </code>
+      ),
       require: 'no',
       description: 'Sets the title tag to one of the <h1> - <h6> tags.',
     },
@@ -67,7 +74,12 @@ const paragraphProps = {
       name: 'variant',
       type: 'string',
       defaultValue: <code>regular</code>,
-      possibleValue: <code>subtitle | regular | caption | smallest</code>,
+      possibleValue: (
+        <code>
+          {PARAGRAPH_VARIANTS.subtitle} | {PARAGRAPH_VARIANTS.regular} |{' '}
+          {PARAGRAPH_VARIANTS.caption} | {PARAGRAPH_VARIANTS.smallest}
+        </code>
+      ),
       require: 'no',
       description: "Sets the Paragraph's variant.",
     },

--- a/src/General/Typography/__snapshots__/Typography.test.tsx.snap
+++ b/src/General/Typography/__snapshots__/Typography.test.tsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Typography> should contain the Title and Paragraph components: <Typography.Paragraph> should render a p tag with the text Glints Aries 1`] = `
+<p
+  className="aries-typography-paragraph sc-bwzfXH iZfUBB"
+>
+  Glints Aries
+</p>
+`;
+
+exports[`<Typography> should contain the Title and Paragraph components: <Typography.Title> should render a h1 tag with the text Glints Aries 1`] = `
+<h1
+  className="aries-typography-title sc-bdVaJa jsMYET"
+>
+  Glints Aries
+</h1>
+`;

--- a/src/General/Typography/__snapshots__/Typography.test.tsx.snap
+++ b/src/General/Typography/__snapshots__/Typography.test.tsx.snap
@@ -2,7 +2,8 @@
 
 exports[`<Typography> should contain the Title and Paragraph components: <Typography.Paragraph> should render a p tag with the text Glints Aries 1`] = `
 <p
-  className="aries-typography-paragraph sc-bwzfXH iZfUBB"
+  className="aries-typography-paragraph sc-bwzfXH ePzYCu"
+  color="#000000"
 >
   Glints Aries
 </p>
@@ -11,6 +12,7 @@ exports[`<Typography> should contain the Title and Paragraph components: <Typogr
 exports[`<Typography> should contain the Title and Paragraph components: <Typography.Title> should render a h1 tag with the text Glints Aries 1`] = `
 <h1
   className="aries-typography-title sc-bdVaJa jsMYET"
+  color="#000000"
 >
   Glints Aries
 </h1>

--- a/src/General/Typography/index.ts
+++ b/src/General/Typography/index.ts
@@ -1,0 +1,5 @@
+import Typography from './Typography';
+
+export { Typography };
+
+export default Typography;

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -61,6 +61,7 @@ import TextareaStory from './Input/TextareaStory';
 import TextFieldStory from './Input/TextFieldStory';
 import ToastStory from './Display/ToastStory';
 import TooltipStory from './Display/TooltipStory';
+import TypographyStory from '../src/General/Typography/TypographyStory';
 
 // Employers
 import EmployersBlockquoteStory from './Display/EmployersBlockquoteStory';
@@ -89,7 +90,8 @@ storiesOf('General', module)
   .add('Loading', () => <LoadingStory />)
   .add('Profile Picture', () => <ProfilePictureStory />)
   .add('Psychedelic Text', () => <PsychedelicTextStory />)
-  .add('Tag', () => <TagStory />);
+  .add('Tag', () => <TagStory />)
+  .add('Typography', () => <TypographyStory />);
 
 storiesOf('Layout', module)
   .addDecorator(story => (


### PR DESCRIPTION
- Created Typography component as per issue https://github.com/glints-dev/glints-aries/issues/89
- `Typography.Title` renders h1-h6 tags 
- `Typography.Paragraph` renders a paragraph tag with variants `'subtitle' | 'regular' | 'caption' | 'smallest'`

Glints UI: https://app.zeplin.io/project/5ba343bf0c399c33db483653/screen/5bc6d879fbe15b18ca619fb0