### PR TITLE
StorybookComponent: Change import statement to require to workaround typescript error

### DIFF
--- a/stories/StorybookComponent.tsx
+++ b/stories/StorybookComponent.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import jsxToString from 'jsx-to-string';
 
 import Collapsible from '../src/Display/Collapsible';
+
+const jsxToString = require('jsx-to-string');
 
 const propsColumnName = [
   'name',


### PR DESCRIPTION
This import statement was causing  a type error:
```
import jsxToString from 'jsx-to-string';
```

```
ERROR in /home/francis/aries/glints-aries/stories/StorybookComponent.tsx(2,25):
TS7016: Could not find a declaration file for module 'jsx-to-string'. '/home/francis/aries/glints-aries/node_modules/jsx-to-string/lib/index.js' implicitly has an 'any' type.
  Try `npm install @types/jsx-to-string` if it exists or add a new declaration (.d.ts) file containing `declare module 'jsx-to-string';`
Version: typescript 3.5.1
```

Changed the import statement to a require statement instead to workaround the issue.

https://stackoverflow.com/questions/41292559/could-not-find-a-declaration-file-for-module-module-name-path-to-module-nam