### PR TITLE
Checkbox: Refactor to use hooks and add unit and snapshot tests

### DIFF
--- a/src/Input/Checkbox/Checkbox.test.tsx
+++ b/src/Input/Checkbox/Checkbox.test.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+
+import * as renderer from 'react-test-renderer';
+import '@testing-library/jest-dom/extend-expect';
+import { fireEvent, render } from '@testing-library/react';
+
+import Checkbox from './Checkbox';
+
+const props = {
+  id: 'software-engineer',
+  value: 'Software Engineer',
+  onClick: jest.fn().mockImplementation(event => event.target.value),
+};
+
+function setupCheckbox() {
+  const { getByText, getByLabelText } = render(
+    <Checkbox id={props.id} value={props.value} onClick={props.onClick} />
+  );
+  const checkboxInput = getByLabelText(props.value) as HTMLInputElement;
+  const checkboxLabel = getByText(props.value) as HTMLLabelElement;
+  return { checkboxInput, checkboxLabel };
+}
+
+afterEach(() => {
+  props.onClick.mockClear();
+});
+
+it(`<Checkbox> should render an input with id, value and onClick props and a label with the text ${props.value}`, () => {
+  const CheckboxSnapshot = renderer
+    .create(
+      <Checkbox id={props.id} value={props.value} onClick={props.onClick} />
+    )
+    .toJSON();
+  expect(CheckboxSnapshot).toMatchSnapshot();
+});
+
+it('when toggling checkbox, it should fire onClick once and become checked, then fire onClick once and become unchecked', () => {
+  const { checkboxInput, checkboxLabel } = setupCheckbox();
+
+  fireEvent.click(checkboxLabel);
+  expect(props.onClick).toHaveBeenCalledTimes(1);
+  expect(checkboxInput.checked).toEqual(true);
+
+  props.onClick.mockClear();
+
+  fireEvent.click(checkboxLabel);
+  expect(props.onClick).toHaveBeenCalledTimes(1);
+  expect(checkboxInput.checked).toEqual(false);
+});
+
+describe('when it is rendered', () => {
+  it('should display the correct label', () => {
+    const { checkboxInput } = setupCheckbox();
+    expect(checkboxInput).toBeTruthy();
+  });
+
+  it('should display an unchecked checkbox', () => {
+    const { checkboxInput } = setupCheckbox();
+    expect(checkboxInput.checked).toEqual(false);
+  });
+
+  it('should have the correct input id and value', async () => {
+    const { checkboxInput } = setupCheckbox();
+    expect(checkboxInput.id).toEqual(props.id);
+    expect(checkboxInput.value).toEqual(props.value);
+  });
+
+  it('should return the input value when onClick is passed a function: event => event.target.value', () => {
+    const { checkboxLabel } = setupCheckbox();
+    fireEvent.click(checkboxLabel);
+    expect(props.onClick.mock.results[0].value).toEqual(props.value);
+  });
+});

--- a/src/Input/Checkbox/Checkbox.tsx
+++ b/src/Input/Checkbox/Checkbox.tsx
@@ -1,57 +1,46 @@
 import * as React from 'react';
 import classNames from 'classnames';
+
 import { CheckboxContainer } from '../../Style/Input/CheckboxStyle';
 
-class Checkbox extends React.PureComponent<Props, State> {
-  state = {
-    checked: false,
-  };
+const Checkbox: React.FunctionComponent<Props> = ({
+  id,
+  value,
+  onClick,
+  className,
+  ...restProps
+}) => {
+  const [checked, setChecked] = React.useState(false);
 
-  handleClick = (e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
-    const { onClick } = this.props;
-    const { checked } = this.state;
-    this.setState({
-      checked: !checked,
-    });
-
+  const handleClick = (e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+    setChecked(checked => !checked);
     if (onClick !== undefined) {
       return onClick(e);
     }
   };
 
-  render() {
-    const { id, value, onClick, className, ...defaultProps } = this.props;
+  return (
+    <CheckboxContainer
+      className={classNames('aries-checkbox', className)}
+      role="checkbox"
+      aria-labelledby={id}
+      aria-checked={checked}
+      tabIndex={0}
+    >
+      <input
+        type="checkbox"
+        id={id}
+        value={value}
+        onClick={handleClick}
+        {...restProps}
+      />
+      <label htmlFor={id} tabIndex={-1}>
+        {value}
+      </label>
+    </CheckboxContainer>
+  );
+};
 
-    const { checked } = this.state;
-
-    return (
-      <CheckboxContainer
-        className={classNames('aries-checkbox', className)}
-        role="checkbox"
-        aria-labelledby={id}
-        aria-checked={checked}
-        tabIndex={0}
-      >
-        <input
-          type="checkbox"
-          id={id}
-          onClick={this.handleClick}
-          {...defaultProps}
-        />
-        <label htmlFor={id} tabIndex={-1}>
-          {value}
-        </label>
-      </CheckboxContainer>
-    );
-  }
-}
-
-interface Props extends React.HTMLProps<HTMLInputElement> {
-  onClick?(e: React.MouseEvent<HTMLInputElement, MouseEvent>): void;
-}
-
-interface State {
-  checked: boolean;
-}
+interface Props extends React.HTMLProps<HTMLInputElement> {}
 
 export default Checkbox;

--- a/src/Input/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/Input/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Checkbox> should render an input with id, value and onClick props and a label with the text Software Engineer 1`] = `
+<div
+  aria-checked={false}
+  aria-labelledby="software-engineer"
+  className="aries-checkbox sc-bdVaJa bptVgQ"
+  role="checkbox"
+  tabIndex={0}
+>
+  <input
+    id="software-engineer"
+    onClick={[Function]}
+    type="checkbox"
+    value="Software Engineer"
+  />
+  <label
+    htmlFor="software-engineer"
+    tabIndex={-1}
+  >
+    Software Engineer
+  </label>
+</div>
+`;


### PR DESCRIPTION
- Refactor to use hooks 
- Add unit and snapshot tests

Note: I wanted to test the `:before` and `:after` pseudo-elements to make sure that the checkbox exists. However I couldn't find a good way to do it because the `renderer` does not tell us anything about pseudo-elements. 

https://stackoverflow.com/questions/54950000/test-for-pseudo-class-using-jest-and-react-test-renderer

I tried using `getComputedStyle` but that didn't seem to work for the same reason https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle