### PR TITLE
Test/text field

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@testing-library/dom": "^6.1.0",
     "@testing-library/jest-dom": "^4.0.0",
     "@testing-library/react": "^9.1.3",
+    "@testing-library/user-event": "^7.1.2",
     "@types/classnames": "^2.2.8",
     "@types/jest": "^24.0.17",
     "@types/lodash": "^4.14.132",

--- a/src/Display/Modal/Modal.test.tsx
+++ b/src/Display/Modal/Modal.test.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import Modal from '.';
 
 import * as renderer from 'react-test-renderer';
 import '@testing-library/jest-dom/extend-expect';
 import { fireEvent, render } from '@testing-library/react';
 
+import Modal, { sizeType } from './Modal';
 import { SIZES } from '../../Style/Display/ModalStyle';
 
 const props = {
@@ -114,12 +114,13 @@ describe('onClose should be called once when:', () => {
 });
 
 describe('displays the correct size', () => {
-  Object.keys(SIZES).forEach(size => {
+  const sizes = Object.keys(SIZES) as sizeType[];
+  sizes.forEach(size => {
     const width = SIZES[size];
 
     it(`${size}: ${width}`, () => {
       const { getByRole } = render(
-        <Modal size={size} isVisible={true}>
+        <Modal size={size} isVisible={true} onClose={props.onClose}>
           <p>{props.content}</p>
         </Modal>
       );
@@ -131,7 +132,12 @@ describe('displays the correct size', () => {
 
 it('should not show the header when hideHeader is true', () => {
   const { getByTestId } = render(
-    <Modal hideHeader title={props.title} isVisible={true}>
+    <Modal
+      hideHeader
+      title={props.title}
+      isVisible={true}
+      onClose={props.onClose}
+    >
       <p>{props.content}</p>
     </Modal>
   );
@@ -141,7 +147,7 @@ it('should not show the header when hideHeader is true', () => {
 
 it('should center the Modal vertically when centering is true', () => {
   const { getByTestId } = render(
-    <Modal centering isVisible={true}>
+    <Modal centering isVisible={true} onClose={props.onClose}>
       <p>{props.content}</p>
     </Modal>
   );

--- a/src/Display/Modal/Modal.tsx
+++ b/src/Display/Modal/Modal.tsx
@@ -127,6 +127,8 @@ class Modal extends React.Component<Props, State> {
   }
 }
 
+export type sizeType = 's' | 'm' | 'l' | 'xl';
+
 interface Props
   extends React.ComponentPropsWithoutRef<typeof ModalContentArea> {
   children: React.ReactNode;
@@ -137,7 +139,7 @@ interface Props
   centering?: boolean;
   removeAnimation?: boolean;
   footer?: React.ReactElement[];
-  size?: 's' | 'm' | 'l' | 'xl';
+  size?: sizeType;
   hideHeader?: boolean;
 }
 

--- a/src/General/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/General/Button/__snapshots__/Button.test.tsx.snap
@@ -2,10 +2,10 @@
 
 exports[`<Button> should render with text "click me" and an onClick handler 1`] = `
 <div
-  className="aries-defaultbtn sc-bwzfXH kqZtLE"
+  className="aries-defaultbtn sc-htpNat cqvpiG"
 >
   <button
-    className="sc-bdVaJa defaultbtn-content sc-htpNat cyXKnd"
+    className="sc-bdVaJa defaultbtn-content sc-bwzfXH bmngHj"
     onClick={[MockFunction]}
   >
     click me

--- a/src/General/Typography/__snapshots__/Typography.test.tsx.snap
+++ b/src/General/Typography/__snapshots__/Typography.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`<Typography> should contain the Title and Paragraph components: <Typogr
 
 exports[`<Typography> should contain the Title and Paragraph components: <Typography.Title> should render a h1 tag with the text Glints Aries 1`] = `
 <h1
-  className="aries-typography-title sc-bdVaJa jsMYET"
+  className="aries-typography-title sc-bdVaJa eiimym"
   color="#000000"
 >
   Glints Aries

--- a/src/Input/TextField/TextField.test.tsx
+++ b/src/Input/TextField/TextField.test.tsx
@@ -1,0 +1,148 @@
+import * as React from 'react';
+
+import * as renderer from 'react-test-renderer';
+import '@testing-library/jest-dom/extend-expect';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import TextField, { textFieldType } from './TextField';
+import { SecondaryColor, PrimaryColor } from '../../Style/Colors';
+
+const props = {
+  type: 'text' as textFieldType,
+  label: 'Username',
+  onChange: jest.fn().mockImplementation(event => event.target.value),
+};
+
+const inputValue = 'glintsaries';
+
+function setupTextField(otherProps?: any) {
+  const { getByLabelText, ...utils } = render(
+    <TextField
+      type={props.type}
+      label={props.label}
+      onChange={props.onChange}
+      {...otherProps}
+    />
+  );
+  const textFieldInput = getByLabelText(props.label) as HTMLInputElement;
+  return { textFieldInput, utils };
+}
+
+function setupTextFieldWithChangeEvent(otherProps?: any) {
+  const { textFieldInput } = setupTextField(otherProps);
+  userEvent.type(textFieldInput, inputValue);
+  return { textFieldInput };
+}
+
+it('<TextField> should render with a label of Username and type of text', () => {
+  const TextFieldSnapshot = renderer
+    .create(<TextField type={props.type} label={props.label} />)
+    .toJSON();
+  expect(TextFieldSnapshot).toMatchSnapshot();
+});
+
+describe('when it is rendered', () => {
+  it('should display the correct input label', () => {
+    const { textFieldInput } = setupTextField();
+    expect(textFieldInput).toBeTruthy();
+  });
+
+  it('should have the correct type', () => {
+    const { textFieldInput } = setupTextField();
+    expect(textFieldInput.type).toEqual(props.type);
+  });
+
+  it('should have an empty string as its value', () => {
+    const { textFieldInput } = setupTextField();
+    expect(textFieldInput.value).toEqual('');
+  });
+});
+
+describe('when a value is entered', () => {
+  it('should call onChange once', () => {
+    setupTextFieldWithChangeEvent();
+    expect(props.onChange).toHaveBeenCalledTimes(inputValue.length);
+  });
+
+  it('should return the input value when onChange is passed a function: event => event.target.value', () => {
+    setupTextFieldWithChangeEvent();
+    expect(props.onChange.mock.results.slice(-1)[0].value).toEqual(inputValue);
+  });
+
+  it('should display the correct value', () => {
+    const { textFieldInput } = setupTextFieldWithChangeEvent();
+    expect(textFieldInput.value).toEqual(inputValue);
+  });
+});
+
+describe('when status is:', () => {
+  it("'success', it should display a lightblack border", () => {
+    const { textFieldInput } = setupTextField();
+    expect(textFieldInput).toHaveStyle(`
+      border-color: ${SecondaryColor.lightblack};
+    `);
+  });
+
+  it("'error', it should display a red border", () => {
+    const { textFieldInput } = setupTextField({ status: 'error' });
+    expect(textFieldInput).toHaveStyle(`
+      border-color: ${PrimaryColor.glintsred};
+    `);
+  });
+});
+
+describe('when disabled is true', () => {
+  it('should display cursor: not-allowed', () => {
+    const { textFieldInput } = setupTextField({ disabled: true });
+    expect(textFieldInput).toHaveStyle('cursor: not-allowed;');
+  });
+
+  it('should be disabled', () => {
+    const { textFieldInput } = setupTextField({ disabled: true });
+    expect(textFieldInput).toBeDisabled();
+  });
+});
+
+describe('when small is:', () => {
+  it('true, it should display the correct size', () => {
+    const { textFieldInput } = setupTextField({ small: true });
+    expect(textFieldInput).toHaveStyle('padding: 13px 15px;');
+  });
+
+  it('false, it should display the correct size', () => {
+    const { textFieldInput } = setupTextField({ disabled: true });
+    expect(textFieldInput).toHaveStyle('padding: 15px 20px;');
+  });
+});
+
+describe('when disableTyping is true', () => {
+  it('should display cursor: pointer', () => {
+    const { textFieldInput } = setupTextField({ disableTyping: true });
+    expect(textFieldInput).toHaveStyle('cursor: pointer;');
+  });
+
+  it('should not be able to input a value', () => {
+    const { textFieldInput } = setupTextField({
+      disableTyping: true,
+    });
+    userEvent.type(textFieldInput, inputValue);
+    expect(textFieldInput.value).toBe('');
+  });
+});
+
+describe('when removeFloatingLabel is true', () => {
+  it('should remove the floating label', () => {
+    const { textFieldInput } = setupTextField({ removeFloatingLabel: true });
+    const textFieldLabel = textFieldInput.parentElement.querySelector(
+      '[data-testid="textfield-label"]'
+    ) as HTMLLabelElement;
+    expect(textFieldInput.parentElement).not.toContainElement(textFieldLabel);
+  });
+
+  it('should display a placeholder', () => {
+    const { utils } = setupTextField({ removeFloatingLabel: true });
+    const textFieldInput = utils.getByPlaceholderText(props.label);
+    expect(textFieldInput).toBeTruthy();
+  });
+});

--- a/src/Input/TextField/TextField.test.tsx
+++ b/src/Input/TextField/TextField.test.tsx
@@ -111,7 +111,7 @@ describe('when small is:', () => {
   });
 
   it('false, it should display the correct size', () => {
-    const { textFieldInput } = setupTextField({ disabled: true });
+    const { textFieldInput } = setupTextField();
     expect(textFieldInput).toHaveStyle('padding: 15px 20px;');
   });
 });

--- a/src/Input/TextField/TextField.tsx
+++ b/src/Input/TextField/TextField.tsx
@@ -112,6 +112,7 @@ class TextField extends React.Component<Props, State> {
         />
         {!removeFloatingLabel && (
           <TextFieldLabel
+            data-testid="textfield-label"
             className="textfield-label"
             floating={floating}
             status={status}
@@ -133,8 +134,10 @@ class TextField extends React.Component<Props, State> {
   }
 }
 
+export type textFieldType = 'text' | 'password';
+
 interface Props extends React.ComponentPropsWithoutRef<typeof TextFieldInput> {
-  type: 'text' | 'password';
+  type: textFieldType;
   label: string;
   disabled?: boolean;
   className?: string;

--- a/src/Input/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/src/Input/TextField/__snapshots__/TextField.test.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<TextField> should render with a label of Username and type of text 1`] = `
+<div
+  className="aries-textfield sc-bdVaJa ktXGUd"
+>
+  <input
+    aria-label="Username"
+    className="sc-htpNat evWPXU"
+    onBlur={[Function]}
+    onKeyDown={[Function]}
+    type="text"
+  />
+  <label
+    className="textfield-label sc-bwzfXH gtXjtR"
+    data-testid="textfield-label"
+  >
+    Username
+  </label>
+</div>
+`;

--- a/src/Style/Display/ModalStyle.ts
+++ b/src/Style/Display/ModalStyle.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { Device } from '../../Utils/StyleConfig';
 import { SecondaryColor } from '../Colors';
+import { sizeType } from '../../Display/Modal/Modal';
 
 export const SIZES: { [s: string]: number } = {
   s: 300,
@@ -108,7 +109,7 @@ export const ModalContentArea = styled.div<ModalContentAreaProps>`
 
 interface ModalContentAreaProps {
   hideContentArea?: boolean;
-  size?: string;
+  size?: sizeType;
   centering?: boolean;
   removeAnimation?: boolean;
   isOpen?: boolean;

--- a/src/Style/Input/TextFieldStyle.ts
+++ b/src/Style/Input/TextFieldStyle.ts
@@ -55,10 +55,12 @@ export const TextFieldLabel = styled.label<TextFieldLabelProps>`
   }}
 `;
 
+type statusType = 'success' | 'error';
+
 interface TextFieldLabelProps {
   small: boolean;
   floating: boolean;
-  status: string;
+  status: statusType;
 }
 
 export const TextFieldInput = styled.input<TextFieldInputProps>`
@@ -168,9 +170,9 @@ export const TextFieldInput = styled.input<TextFieldInputProps>`
   }
 `;
 
-interface TextFieldInputProps {
+export interface TextFieldInputProps {
   small?: boolean;
-  status?: string;
+  status?: statusType;
   disableTyping?: boolean;
   floating?: boolean;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1879,6 +1879,11 @@
     "@testing-library/dom" "^6.0.0"
     "@types/testing-library__react" "^9.1.0"
 
+"@testing-library/user-event@^7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-7.1.2.tgz#3a71bb8a45a1e08b71a54c9efcee9927f3895e80"
+  integrity sha512-lDyCVxxgX5lrgCa75ELCfWcdEDyfisjqoDIM3YsghQ+lyViIac/qT67qabQ/HmoVxyikFKovjKwWdn3b/oKhZA==
+
 "@types/babel__core@^7.1.0":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.2.tgz#608c74f55928033fce18b99b213c16be4b3d114f"


### PR DESCRIPTION
- Add @testing-library/user-event to simulate user events https://github.com/testing-library/user-event
- TextField: Add unit and snapshot tests
- Modal: Fix some typescript errors
- Update failing snapshots