### PR TITLE
Alert: Fix the closing of the alert on clicking below the close icon

### DIFF
--- a/src/Style/General/AlertStyle.ts
+++ b/src/Style/General/AlertStyle.ts
@@ -43,7 +43,7 @@ export const AlertContainer = styled.div<AlertContainerProps>`
   font-size: 1em;
 
   @media ${Device.mobileM} {
-    min-width: 100%;
+    min-width: calc(100% - 30px);
   }
 
   ${({ type }) => {
@@ -98,6 +98,7 @@ export const AlertContent = styled.div`
 export const AlertMessage = styled.p`
   position: relative;
   margin: 0;
+  padding-right: 10px;
 `;
 
 export const AlertIcon = styled.div`

--- a/src/Style/General/AlertStyle.ts
+++ b/src/Style/General/AlertStyle.ts
@@ -101,9 +101,8 @@ export const AlertMessage = styled.p`
 `;
 
 export const AlertIcon = styled.div`
-  position: relative;
-
-  svg {
-    cursor: pointer;
-  }
+  height: 1em;
+  width: 1em;
+  align-self: center;
+  cursor: pointer;
 `;


### PR DESCRIPTION
Currently for the Alert component clicking on the area below the close icon results in closing of the alert box. This is caused by the `div` wrapping the icon taking up the height of its parent.

![image](https://user-images.githubusercontent.com/35050056/68737398-48e56480-061e-11ea-93b9-311d1aa96435.png)

Fixes (only for the desktop) : #158 
