### PR TITLE
Modal: Do not close modal if mousedown occurs inside modal but the subsequent mouseup occurs outside it

### DIFF
--- a/src/Display/Modal/Modal.test.tsx
+++ b/src/Display/Modal/Modal.test.tsx
@@ -40,9 +40,9 @@ function setupModal(isVisible: boolean) {
   const { getByTestId, getByRole } = render(ModalComponent);
 
   return {
-    modalContainer: getByTestId('modal-container'),
-    modalDialog: getByRole('dialog'),
-    closeButton: getByTestId('close-button'),
+    modalContainer: getByTestId('modal-container') as Element,
+    modalDialog: getByRole('dialog') as Element,
+    closeButton: getByTestId('close-button') as Element,
     onClose,
   };
 }
@@ -60,7 +60,7 @@ describe('when modal is opened', () => {
 
   it('should not be closed if the modal is clicked', () => {
     const { modalDialog, onClose } = setupModal(true);
-    fireEvent.click(modalDialog as Element);
+    fireEvent.click(modalDialog);
     expect(onClose).toHaveBeenCalledTimes(0);
   });
 
@@ -93,19 +93,23 @@ describe('when modal is closed', () => {
 describe('onClose should be called once when:', () => {
   it('close icon is clicked', () => {
     const { closeButton, onClose } = setupModal(true);
-    fireEvent.click(closeButton as Element);
+    fireEvent.click(closeButton);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it('area outside modal is clicked', () => {
     const { modalContainer, onClose } = setupModal(true);
-    fireEvent.click(modalContainer as Element);
+    // mousedown needs to be fired because
+    // handleClick checks if the mousedown target element
+    // is the modal container before calling onClose
+    fireEvent.mouseDown(modalContainer);
+    fireEvent.click(modalContainer);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it('escape key is pressed', () => {
     const { modalContainer, onClose } = setupModal(true);
-    fireEvent.keyDown(modalContainer as Element, {
+    fireEvent.keyDown(modalContainer, {
       key: 'Escape',
       keyCode: 27,
     });

--- a/src/Display/Modal/Modal.tsx
+++ b/src/Display/Modal/Modal.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
-
 import classNames from 'classnames';
 
 import Icon from '../../General/Icon';
-
 import { escEvent } from '../../Utils/DomUtils';
 
 import {
@@ -17,6 +15,7 @@ import {
 
 class Modal extends React.Component<Props, State> {
   modalContentAreaRef: React.RefObject<HTMLDivElement>;
+  mouseDownTarget: HTMLElement;
 
   state = {
     isOpen: false,
@@ -58,6 +57,21 @@ class Modal extends React.Component<Props, State> {
     document.body.removeAttribute('style');
   }
 
+  // To prevent the modal from closing
+  // when a mousedown event occurs inside the ModalContentArea
+  // but the subsequent mouseup event occurs outside
+  handleMouseDown = (e: React.MouseEvent) => {
+    const element = e.target as HTMLElement;
+    this.mouseDownTarget = element;
+  };
+
+  handleClick = (e: React.MouseEvent) => {
+    const element = e.target as HTMLElement;
+    if (this.mouseDownTarget === element) {
+      this.props.onClose();
+    }
+  };
+
   render() {
     const {
       title,
@@ -70,7 +84,7 @@ class Modal extends React.Component<Props, State> {
       footer,
       size,
       hideHeader,
-      ...defaultProps
+      ...restProps
     } = this.props;
 
     const { isOpen } = this.state;
@@ -80,9 +94,10 @@ class Modal extends React.Component<Props, State> {
         data-testid="modal-container"
         className={classNames('aries-modal', className)}
         centering={centering}
-        onClick={() => onClose()}
         isOpen={isOpen}
         removeAnimation={removeAnimation}
+        onMouseDown={this.handleMouseDown}
+        onClick={this.handleClick}
       >
         <ModalDialog className="modal-dialog">
           <ModalContentArea
@@ -97,7 +112,7 @@ class Modal extends React.Component<Props, State> {
             removeAnimation={removeAnimation}
             size={size}
             ref={this.modalContentAreaRef}
-            {...defaultProps}
+            {...restProps}
           >
             {!hideHeader && (
               <ModalHeader className="modal-header">
@@ -105,7 +120,7 @@ class Modal extends React.Component<Props, State> {
                 <button
                   data-testid="close-button"
                   type="button"
-                  onClick={() => onClose()}
+                  onClick={onClose}
                 >
                   <Icon
                     name="close"

--- a/src/Display/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/Display/Modal/__snapshots__/Modal.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`<Modal> should render with a title, content, footer and an onClick hand
   className="aries-modal sc-bdVaJa aauuo"
   data-testid="modal-container"
   onClick={[Function]}
+  onMouseDown={[Function]}
 >
   <div
     className="modal-dialog sc-bwzfXH ghuPdm"
@@ -24,7 +25,7 @@ exports[`<Modal> should render with a title, content, footer and an onClick hand
         </h3>
         <button
           data-testid="close-button"
-          onClick={[Function]}
+          onClick={[MockFunction]}
           type="button"
         >
           <svg


### PR DESCRIPTION
Fix for https://github.com/glints-dev/glints-aries/issues/91

Previously, the modal would close if a `mousedown` event occurred inside the modal, but the `mouseup` event occurred outside. This causd the modal to close when a user clicks inside the modal to copy some text, but releases the click outside the modal.

We fixed this by checking if the`mousedown` event occurred inside the modal, and ignoring the subsequent `click` event. 