### PR TITLE
Popover: Add a property to show the number of options selected as a badge

### DIFF
--- a/src/Display/Popover/Popover.tsx
+++ b/src/Display/Popover/Popover.tsx
@@ -12,6 +12,7 @@ import {
   PopOverContent,
   PopoverItemWrapper,
 } from '../../Style/Display/PopoverStyle';
+import Badge from '../../General/Badge';
 
 class Popover extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -45,9 +46,18 @@ class Popover extends React.Component<Props, State> {
     );
   };
 
+  renderBadge = (number: number) => {
+    if (number > 0) {
+      return <Badge label={number} />;
+    }
+  };
+
   render() {
     const { children, className } = this.props;
-
+    let { showBadgeNumber } = this.props;
+    if (!showBadgeNumber) {
+      showBadgeNumber = 0;
+    }
     return (
       <PopoverContainer
         className={classNames('aries-popover', className)}
@@ -57,7 +67,7 @@ class Popover extends React.Component<Props, State> {
         tabIndex={0}
       >
         <PopoverChildren onClick={this.handleOnClick}>
-          {children}
+          {children} {this.renderBadge(showBadgeNumber)}
         </PopoverChildren>
         <PopoverContentWrapper onClick={this.handleOnClick}>
           {this.renderChildren()}
@@ -69,6 +79,7 @@ class Popover extends React.Component<Props, State> {
 
 interface Props {
   className?: string;
+  showBadgeNumber?: number;
   children: React.ReactNode;
   content: React.ReactNode;
 }

--- a/stories/Display/PopoverStory.tsx
+++ b/stories/Display/PopoverStory.tsx
@@ -19,6 +19,14 @@ const props = {
       require: 'yes',
       description: 'Display content when button is clicked.',
     },
+    {
+      name: 'showBadgeNumber',
+      type: 'number',
+      defaultValue: '0',
+      possibleValue: 'integer value',
+      require: 'no',
+      description: 'To display a badge with the number of options selected from popover',
+    },
   ],
 };
 


### PR DESCRIPTION
Fixes: #166 
Add a property to the pop over called showBadgeNumber which if greater than 0 shows a badge with the number specified.