### PR TITLE
Feature/allow collapsible to render dynamic content

### DIFF
--- a/src/Display/Collapsible/Collapsible.tsx
+++ b/src/Display/Collapsible/Collapsible.tsx
@@ -67,7 +67,7 @@ class Collapsible extends React.Component<Props, State> {
 
 interface Props
   extends React.ComponentPropsWithoutRef<typeof CollapsibleContainer> {
-  label: string;
+  label: React.ReactNode;
   isOpen?: boolean;
 }
 

--- a/src/Display/Collapsible/Collapsible.tsx
+++ b/src/Display/Collapsible/Collapsible.tsx
@@ -19,17 +19,6 @@ class Collapsible extends React.Component<Props, State> {
     this.setState({ isOpen: !isOpen });
   };
 
-  shouldComponentUpdate(nextProps: Props, nextState: State) {
-    const { isOpen } = this.state;
-    if (isOpen !== nextState.isOpen) {
-      // re-render
-      return true;
-    }
-
-    // nothing changed. avoid unnecessary re-render
-    return false;
-  }
-
   componentDidMount() {
     const { isOpen } = this.props;
 


### PR DESCRIPTION
1. `Collapsible` had `shouldComponentUpdate` which only re-render the component when `isOpen` changes, so it cannot render dynamic content inside it. So removed `shouldComponentUpdate`, `shouldComponentUpdate` should be implemented by its children component or parent component.

2. change label's type to `React.ReactNode`, so label can be not only `string` but all react nodes.
