### PR TITLE
Gallery: The number of images displayed at once to be dynamic

### DIFF
--- a/src/Application/Gallery/Gallery.tsx
+++ b/src/Application/Gallery/Gallery.tsx
@@ -13,6 +13,8 @@ import {
   GalleryThumbnailWrapper,
 } from '../../Style/Application/GalleryStyle';
 
+const defaultImagesDisplayed = 8;
+
 class Gallery extends React.Component<Props, State> {
   sliderRef: React.RefObject<Slider>;
 
@@ -53,10 +55,9 @@ class Gallery extends React.Component<Props, State> {
   };
 
   componentDidMount() {
-    const { children } = this.props;
-
-    if (React.Children.count(children) > 8) {
-      this.setState({ imageLeft: React.Children.count(children) - 8 });
+    const { children, imagesDisplayed = defaultImagesDisplayed } = this.props;
+    if (React.Children.count(children) > imagesDisplayed) {
+      this.setState({ imageLeft: React.Children.count(children) - imagesDisplayed });
     }
   }
 
@@ -71,14 +72,13 @@ class Gallery extends React.Component<Props, State> {
   }
 
   render() {
-    const { children } = this.props;
+    const { children, imagesDisplayed = defaultImagesDisplayed } = this.props;
     const { visible, currentIndex, imageLeft } = this.state;
-
     return (
       <GalleryContainer className="aries-gallery">
         <GalleryItemWrapper className="gallery-wrapper">
           {React.Children.toArray(children)
-            .slice(0, 8)
+            .slice(0, imagesDisplayed)
             .map((data: React.ReactElement<React.HTMLProps<'img'>>, index) => (
               <GalleryItem
                 className="gallery-item"
@@ -143,6 +143,7 @@ class Gallery extends React.Component<Props, State> {
 
 interface Props {
   children?: React.ReactNode;
+  imagesDisplayed?: number;
 }
 
 interface State {

--- a/stories/Application/GalleryStory.tsx
+++ b/stories/Application/GalleryStory.tsx
@@ -4,10 +4,25 @@ import StorybookComponent from '../StorybookComponent';
 
 import Gallery from '../../src/Application/Gallery';
 
+const props = {
+  Gallery: [
+    {
+      name: 'imagesDisplayed',
+      type: 'number',
+      defaultValue: '8',
+      possibleValue: 'number',
+      require: 'no',
+      description:
+        'Set the number of images displayed by the gallery component at once',
+    },
+  ],
+};
+
 const GalleryStory = () => (
   <StorybookComponent
     title="Gallery"
     code="import { Gallery } from 'glints-aries'"
+    propsObject={props}
     usage={`<Gallery>
   <img src="..." />
   <img src="..." />


### PR DESCRIPTION
For the number of images shown at once while using the Gallery component, the user should be able to pass that as a value. And the default one is set to 8 (as per the current implementation).

When the number is set to 3:
![image](https://user-images.githubusercontent.com/22127980/70425169-b4441a00-1a96-11ea-8a38-f3a2c56b2bc9.png)
