### PR TITLE
Feature/refactor accordion

### DIFF
--- a/src/Display/Accordion/Accordion.tsx
+++ b/src/Display/Accordion/Accordion.tsx
@@ -1,92 +1,74 @@
 import * as React from 'react';
-
 import classNames from 'classnames';
 
+import {
+  AddIcon,
+  MinusIcon,
+  ArrowDownSolidIcon,
+} from '../../General/Icon/components';
 import AccordionPanel, { Props as AccordionPanelProps } from './AccordionPanel';
 
-import { AccordionContainer } from '../../Style/Display/AccordionStyle';
+import { Container } from '../../Style/Display/AccordionStyle';
 
-class Accordion extends React.Component<Props, State> {
-  static Panel = AccordionPanel;
-
-  state = {
-    currIndex: -1,
-    isOpenSingleItem: false,
+const Accordion: Accordion = ({ children, className, iconPosition }) => {
+  const [currIndex, setCurrIndex] = React.useState(-1);
+  const iconOptions: IconOptions = {
+    activeIcon:
+      iconPosition === 'left' ? <MinusIcon /> : <ArrowDownSolidIcon />,
+    inactiveIcon:
+      iconPosition === 'left' ? <AddIcon /> : <ArrowDownSolidIcon />,
+    position: iconPosition,
   };
 
-  handleOpen = (index: number) => {
-    const { currIndex } = this.state;
-
-    this.setState({
-      currIndex: currIndex === index ? -1 : index,
-    });
+  const handleOpen = (index: number) => {
+    setCurrIndex(currIndex === index ? -1 : index);
   };
 
-  handleOpenSingleItem = () => {
-    const { isOpenSingleItem } = this.state;
+  return (
+    <Container className={classNames('aries-accordion', className)}>
+      {React.Children.map(
+        children,
+        (data: React.ReactElement<AccordionPanelProps>, index) => {
+          const { label, content, ...restChildProps } = data.props;
+          return (
+            <AccordionPanel
+              key={index}
+              label={label}
+              content={content}
+              active={currIndex === index}
+              iconOptions={iconOptions}
+              onOpen={() => handleOpen(index)}
+              {...restChildProps}
+            />
+          );
+        }
+      )}
+    </Container>
+  );
+};
 
-    this.setState({
-      isOpenSingleItem: !isOpenSingleItem,
-    });
-  };
+type Accordion = React.FunctionComponent<Props> & {
+  Panel: typeof AccordionPanel;
+};
 
-  renderMultipleItem() {
-    const { children } = this.props;
-    const { currIndex } = this.state;
+export type IconPosition = 'left' | 'right';
 
-    return React.Children.map(
-      children,
-      (data: React.ReactElement<AccordionPanelProps>, index) => (
-        <AccordionPanel
-          className="accordion-contentwrapper"
-          key={index}
-          label={data.props.label}
-          content={data.props.content}
-          active={currIndex === index}
-          onClick={() => this.handleOpen(index)}
-        />
-      )
-    );
-  }
-
-  renderSingleItem() {
-    const { children } = this.props;
-    const { isOpenSingleItem } = this.state;
-
-    const childProps = (children as React.ReactElement<AccordionPanelProps>)
-      .props;
-    return (
-      <AccordionPanel
-        className="accordion-contentwrapper"
-        label={childProps.label}
-        content={childProps.content}
-        active={isOpenSingleItem}
-        onClick={this.handleOpenSingleItem}
-      />
-    );
-  }
-
-  render() {
-    const { children, className } = this.props;
-
-    return (
-      <AccordionContainer className={classNames('aries-accordion', className)}>
-        {React.Children.count(children) > 1
-          ? this.renderMultipleItem()
-          : this.renderSingleItem()}
-      </AccordionContainer>
-    );
-  }
+export interface IconOptions {
+  activeIcon: React.ReactElement;
+  inactiveIcon: React.ReactElement;
+  position: IconPosition;
 }
 
 interface Props {
   children: React.ReactNode;
   className?: string;
+  iconPosition?: IconPosition;
 }
 
-interface State {
-  currIndex: number;
-  isOpenSingleItem: boolean;
-}
+Accordion.defaultProps = {
+  iconPosition: 'left' as IconPosition,
+};
+
+Accordion.Panel = AccordionPanel;
 
 export default Accordion;

--- a/src/Display/Accordion/AccordionPanel.tsx
+++ b/src/Display/Accordion/AccordionPanel.tsx
@@ -1,47 +1,73 @@
 import * as React from 'react';
+import classNames from 'classnames';
 
-import { AddIcon } from '../../General/Icon/components';
+import { IconOptions } from './Accordion';
 
 import {
-  AccordionPanelWrapper,
-  AccordionIconWrapper,
-  AccordionContentWrapper,
-  AccordionContent,
+  PanelWrapper,
+  IconWrapper,
+  IconLabelWrapper,
+  ContentWrapper,
+  Content,
+  Label,
 } from '../../Style/Display/AccordionStyle';
 
-import { SecondaryColor } from '../../Style/Colors';
-
 const AccordionPanel: React.FunctionComponent<Props> = props => {
-  const { className, label, content, active, ...defaultProps } = props;
+  const {
+    className,
+    content,
+    label,
+    active,
+    iconOptions: { activeIcon, inactiveIcon, position },
+    onOpen,
+    onClick,
+    ...restProps
+  } = props;
+  const handleClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    onOpen();
+    if (onClick) {
+      onClick(e);
+    }
+  };
+  const renderIcon = () => (
+    <IconWrapper position={position} active={active}>
+      {active ? activeIcon : inactiveIcon}
+    </IconWrapper>
+  );
 
   return (
-    <AccordionPanelWrapper
-      className={className}
+    <PanelWrapper
+      className={classNames('accordion-panelwrapper', className)}
       role="tab"
       aria-expanded={active}
       tabIndex={0}
-      {...defaultProps}
+      {...restProps}
     >
-      <AccordionContentWrapper className="accordion-content" tabIndex={-1}>
-        <AccordionIconWrapper>
-          <AddIcon color={SecondaryColor.lightblack} />
-        </AccordionIconWrapper>
-        <p>{label}</p>
-        {active && (
-          <AccordionContent onClick={e => e.stopPropagation()}>
-            {content}
-          </AccordionContent>
-        )}
-      </AccordionContentWrapper>
-    </AccordionPanelWrapper>
+      <IconLabelWrapper
+        onClick={handleClick}
+        tabIndex={-1}
+        position={position}
+        active={active}
+      >
+        {position === 'left' && renderIcon()}
+        <Label>{label}</Label>
+        {position === 'right' && renderIcon()}
+      </IconLabelWrapper>
+      <ContentWrapper active={active}>
+        <Content position={position}>{content}</Content>
+      </ContentWrapper>
+    </PanelWrapper>
   );
 };
 
 export interface Props
-  extends React.ComponentPropsWithoutRef<typeof AccordionPanelWrapper> {
-  label: string;
-  content: string;
+  extends React.ComponentPropsWithoutRef<typeof PanelWrapper> {
+  content: React.ReactNode;
+  label: React.ReactNode;
   active?: boolean;
+  iconOptions?: IconOptions;
+  onOpen?(): void;
+  onClick?(e: React.MouseEvent<HTMLDivElement, MouseEvent>): void;
 }
 
 export default AccordionPanel;

--- a/src/Style/Display/AccordionStyle.ts
+++ b/src/Style/Display/AccordionStyle.ts
@@ -1,59 +1,103 @@
-import styled from 'styled-components';
-import { SecondaryColor } from '../Colors';
+import styled, { css } from 'styled-components';
 
-export const AccordionContainer = styled.div`
-  position: relative;
+import { SecondaryColor, Greyscale } from '../Colors';
+import { IconPosition } from '../../Display/Accordion/Accordion';
+
+const iconSize = 15;
+const iconMargin = 30;
+const offsetIcon = iconSize + iconMargin;
+const transitionTiming = '0.24s';
+
+export const PanelWrapper = styled.div`
+  border-top: solid 1px ${Greyscale.grey};
+  outline: none;
 `;
 
-export const AccordionContentWrapper = styled.div`
+export const Container = styled.div`
+  ${PanelWrapper}:first-child {
+    border-top: none;
+  }
+`;
+
+export const IconLabelWrapper = styled.div<IconLabelWrapper>`
   position: relative;
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  grid-gap: 0.6em;
-  font-size: 1em;
-  line-height: 1.5;
-  padding: 1.5em 0;
+  display: flex;
+  justify-content: ${({ position }) =>
+    position === 'left' ? 'flex-start' : 'space-between'};
+  margin-top: 30px;
+  padding-bottom: ${({ active }) => (active ? '16px' : '30px')};
   cursor: pointer;
   outline: none;
+  transition: ${({ active }) =>
+    active ? 'none' : `padding-bottom ${transitionTiming} ease-in-out`};
 
-  p {
-    margin: 0;
-    font-weight: bold;
-
-    &:hover {
-      color: ${SecondaryColor.actionblue};
+  &:hover {
+    color: ${SecondaryColor.actionblue};
+    svg {
+      fill: ${SecondaryColor.actionblue};
     }
   }
-
-  &:not(:last-child):after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    width: 100%;
-    height: 1px;
-    background: ${SecondaryColor.lightgrey};
-  }
 `;
 
-export const AccordionPanelWrapper = styled.div`
-  position: relative;
+interface IconLabelWrapper {
+  active: boolean;
+  position: IconPosition;
+}
 
-  &:focus {
-    outline: none;
-  }
-
-  &:focus > ${AccordionContentWrapper} {
-    outline: 5px auto -webkit-focus-ring-color;
-  }
+export const ContentWrapper = styled.div<ContentWrapper>`
+  visibility: ${({ active }) => (active ? 'visible' : 'hidden')};
+  opacity: ${({ active }) => (active ? '1' : '0')};
+  max-height: ${({ active }) => (active ? '100rem' : '0')};
+  transition: all ${transitionTiming} ease-in-out;
 `;
 
-export const AccordionIconWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  margin-right: 1em;
-`;
+interface ContentWrapper {
+  active: boolean;
+}
 
-export const AccordionContent = styled.div`
-  grid-column-start: 2;
+export const Content = styled.div<Content>`
+  margin-left: ${({ position }) =>
+    position === 'left' ? `${offsetIcon}px` : '0'};
+  margin-right: ${({ position }) =>
+    position === 'right' ? `${offsetIcon}px` : '0'};
+  padding-bottom: 30px;
   cursor: default;
 `;
+
+interface Content {
+  position: IconPosition;
+}
+
+export const Label = styled.div`
+  margin: 0;
+  font-size: 18px;
+  font-weight: bold;
+  line-height: 1.4em;
+`;
+
+export const IconWrapper = styled.div<IconWrapper>`
+  display: flex;
+  align-items: center;
+
+  svg {
+    width: ${`${iconSize}px`};
+    height: ${`${iconSize}px`};
+  }
+
+  ${({ position, active }) => {
+    if (position === 'right') {
+      return css`
+        transform: ${active ? 'rotate(180deg)' : 'none'};
+        transition: transform ${transitionTiming};
+      `;
+    }
+    return css`
+      margin-right: ${`${iconMargin}px`};
+    `;
+  }}
+`;
+
+interface IconWrapper {
+  active: boolean;
+  position: IconPosition;
+}

--- a/stories/Display/AccordionStory.tsx
+++ b/stories/Display/AccordionStory.tsx
@@ -7,20 +7,30 @@ import Accordion from '../../src/Display/Accordion';
 const props = {
   Accordion: [
     {
-      name: 'label',
+      name: 'iconPosition',
       type: 'string',
+      defaultValue: <code>'left'</code>,
+      possibleValue: <code>'left' | 'right'</code>,
+      require: 'no',
+      description: 'Sets the position of the icon.',
+    },
+  ],
+  'Accordion.Panel': [
+    {
+      name: 'label',
+      type: 'ReactNode',
       defaultValue: '',
       possibleValue: 'any',
       require: 'yes',
-      description: "Sets Panel's title.",
+      description: 'Sets the label.',
     },
     {
       name: 'content',
-      type: 'string',
+      type: 'ReactNode',
       defaultValue: '',
       possibleValue: 'any',
       require: 'yes',
-      description: 'Sets content.',
+      description: 'Sets the content.',
     },
   ],
 };
@@ -30,21 +40,63 @@ const AccordionStory = () => (
     title="Accordion"
     code="import { Accordion } from 'glints-aries'"
     propsObject={props}
-    usage={`<Accordion>
-  <Accordion.Panel label="..." content="..." />
-  <Accordion.Panel label="..." content="..." />
-</Accordion>`}
+    usage={`<React.Fragment>
+  <h2 style={{ marginBottom: '15px' }}>
+    <code style={{ fontSize: 'inherit' }}>iconPosition='left'</code>
+  </h2>
+  <Accordion>
+    <Accordion.Panel
+      label="What is Lorem Ipsum?"
+      content="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book."
+    />
+    <Accordion.Panel
+      label="What is Love?"
+      content="Love is the most powerful emotion a human being can experience. The strange think is, that almost nobody knows what love is. Why is it so difficult to find love? That is easy to understand, if you know that the word “love” is not the same as one’s feeling of love."
+    />
+  </Accordion>
+  <h2 style={{ marginTop: '30px', marginBottom: '15px' }}>
+    <code style={{ fontSize: 'inherit' }}>iconPosition='right'</code>
+  </h2>
+  <Accordion iconPosition="right">
+    <Accordion.Panel
+      label="What is Lorem Ipsum?"
+      content="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book."
+    />
+    <Accordion.Panel
+      label="What is Love?"
+      content="Love is the most powerful emotion a human being can experience. The strange think is, that almost nobody knows what love is. Why is it so difficult to find love? That is easy to understand, if you know that the word “love” is not the same as one’s feeling of love."
+    />
+  </Accordion>
+</React.Fragment>`}
   >
-    <Accordion>
-      <Accordion.Panel
-        label="What is Lorem Ipsum?"
-        content="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book."
-      />
-      <Accordion.Panel
-        label="What is Love?"
-        content="Love is the most powerful emotion a human being can experience. The strange think is, that almost nobody knows what love is. Why is it so difficult to find love? That is easy to understand, if you know that the word “love” is not the same as one’s feeling of love."
-      />
-    </Accordion>
+    <React.Fragment>
+      <h2 style={{ marginBottom: '15px' }}>
+        <code style={{ fontSize: 'inherit' }}>iconPosition='left'</code>
+      </h2>
+      <Accordion>
+        <Accordion.Panel
+          label="What is Lorem Ipsum?"
+          content="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book."
+        />
+        <Accordion.Panel
+          label="What is Love?"
+          content="Love is the most powerful emotion a human being can experience. The strange think is, that almost nobody knows what love is. Why is it so difficult to find love? That is easy to understand, if you know that the word “love” is not the same as one’s feeling of love."
+        />
+      </Accordion>
+      <h2 style={{ marginTop: '30px', marginBottom: '15px' }}>
+        <code style={{ fontSize: 'inherit' }}>iconPosition='right'</code>
+      </h2>
+      <Accordion iconPosition="right">
+        <Accordion.Panel
+          label="What is Lorem Ipsum?"
+          content="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book."
+        />
+        <Accordion.Panel
+          label="What is Love?"
+          content="Love is the most powerful emotion a human being can experience. The strange think is, that almost nobody knows what love is. Why is it so difficult to find love? That is easy to understand, if you know that the word “love” is not the same as one’s feeling of love."
+        />
+      </Accordion>
+    </React.Fragment>
   </StorybookComponent>
 );
 


### PR DESCRIPTION
https://github.com/glints-dev/glints-aries/issues/183

- Add `iconPosition` prop to display the icon on the `right` and `left`. According to our designers, the icons used will be fixed as they do not need to be customizable. 
- Currently, the minus icon jumps when it switches from the plus icon. This will be fixed when the minus icon is replaced with a vertically centered minus icon. 

Note: DO NOT MERGE until the Accordion has been tested to be backwards compatible. 