### PR TITLE
Select: Use min-width over width for options

### DIFF
--- a/src/Input/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/Input/Select/__snapshots__/Select.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`<Select> should render with 3 options 1`] = `
   </div>
   <ul
     aria-hidden={true}
-    className="select-listbox sc-ifAKCX krCAU"
+    className="select-listbox sc-ifAKCX skPpr"
     open={false}
     role="listbox"
   >

--- a/src/Style/Input/SelectStyle.ts
+++ b/src/Style/Input/SelectStyle.ts
@@ -181,7 +181,7 @@ export const SelectListWrapper = styled.ul<SelectListWrapperProps>`
   transform-origin: center top;
   transition: ${({ open }) => (open ? 'all .2s ease' : 'all .1s ease')};
   background: ${SecondaryColor.white};
-  width: 100%;
+  min-width: 100%;
   height: auto;
   box-shadow: 0 6px 12px 0 rgba(0, 0, 0, 0.12);
   z-index: 9999;


### PR DESCRIPTION
Fix for #186 

This will ensure that the options take up as much space as they need when the available width is low while growing them to match the input if there is a lot of space.

Letting them be bigger than the input is okay because the options are floating anyway.

This can be visually tested by applying the following patch and looking at the Select story:

```
diff --git a/stories/Input/SelectStory.tsx b/stories/Input/SelectStory.tsx
index 619f854..8a9c9c6 100644
--- a/stories/Input/SelectStory.tsx
+++ b/stories/Input/SelectStory.tsx
@@ -134,7 +134,7 @@ const SelectStory = () => (
   <Select.Option value="software engineer">Software Engineer</Select.Option>
 </Select>`}
   >
-    <div style={{ width: '300px' }}>
+    <div style={{ width: '60px', border: '1px dotted black' }}>
       <Select label="Jobs">
         <Select.Option value="accountant">Accountant</Select.Option>
         <Select.Option value="business development">

```