### PR TITLE
Select Errors

### DIFF
--- a/src/Input/Select/Select.test.tsx
+++ b/src/Input/Select/Select.test.tsx
@@ -110,6 +110,39 @@ describe('when it is rendered', () => {
     const selectInput = getByRole('combobox');
     expect(selectInput).toHaveTextContent('');
   });
+
+  it('should not render the default error if error is falsy', () => {
+    const { getByRole } = render(<Select>{SelectChildren}</Select>);
+    const selectContainer = getByRole('combobox').parentElement.parentElement;
+    expect(selectContainer.lastChild).not.toHaveClass('select-error-default');
+  });
+
+  it('should not render the default error if error is true', () => {
+    const { getByRole } = render(
+      <Select error={true}>{SelectChildren}</Select>
+    );
+    const selectContainer = getByRole('combobox').parentElement.parentElement;
+    expect(selectContainer.lastChild).not.toHaveClass('select-error-default');
+  });
+
+  it('should render the error string in the default error', () => {
+    const { getByRole } = render(
+      <Select error={'test'}>{SelectChildren}</Select>
+    );
+    const selectContainer = getByRole('combobox').parentElement.parentElement;
+    expect(selectContainer.lastChild).toHaveClass('select-error-default');
+    expect(selectContainer.lastChild).toHaveTextContent('test');
+  });
+
+  it('should render the error component in the custom error', () => {
+    const errorComponent = <span className="errorComponent" />;
+    const { getByRole } = render(
+      <Select error={errorComponent}>{SelectChildren}</Select>
+    );
+    const selectContainer = getByRole('combobox').parentElement.parentElement;
+    expect(selectContainer.lastChild).toHaveClass('select-error-default');
+    expect(selectContainer.lastChild.firstChild).toHaveClass('errorComponent');
+  });
 });
 
 describe('when it is clicked', () => {
@@ -213,41 +246,6 @@ describe('when error is a component', () => {
     );
     const selectInput = getByRole('combobox');
     expect(selectInput).toHaveStyle(`border-color: ${PrimaryColor.glintsred}`);
-  });
-});
-
-describe('when renderError is not given', () => {
-  it('should not render the default error if error is falsy', () => {
-    const { getByRole } = render(<Select>{SelectChildren}</Select>);
-    const selectContainer = getByRole('combobox').parentElement.parentElement;
-    expect(selectContainer.lastChild).not.toHaveClass('select-error-default');
-  });
-
-  it('should not render the default error if error is true', () => {
-    const { getByRole } = render(
-      <Select error={true}>{SelectChildren}</Select>
-    );
-    const selectContainer = getByRole('combobox').parentElement.parentElement;
-    expect(selectContainer.lastChild).not.toHaveClass('select-error-default');
-  });
-
-  it('should render the error string in the default error', () => {
-    const { getByRole } = render(
-      <Select error={'test'}>{SelectChildren}</Select>
-    );
-    const selectContainer = getByRole('combobox').parentElement.parentElement;
-    expect(selectContainer.lastChild).toHaveClass('select-error-default');
-    expect(selectContainer.lastChild).toHaveTextContent('test');
-  });
-
-  it('should render the error component in the custom error', () => {
-    const errorComponent = <span className="errorComponent" />;
-    const { getByRole } = render(
-      <Select error={errorComponent}>{SelectChildren}</Select>
-    );
-    const selectContainer = getByRole('combobox').parentElement.parentElement;
-    expect(selectContainer.lastChild).toHaveClass('select-error-default');
-    expect(selectContainer.lastChild.firstChild).toHaveClass('errorComponent');
   });
 });
 

--- a/src/Input/Select/Select.test.tsx
+++ b/src/Input/Select/Select.test.tsx
@@ -186,6 +186,118 @@ describe("when status = 'error'", () => {
   });
 });
 
+describe('when error is true', () => {
+  it('should show a red border', () => {
+    const { getByRole } = render(
+      <Select error={true}>{SelectChildren}</Select>
+    );
+    const selectInput = getByRole('combobox');
+    expect(selectInput).toHaveStyle(`border-color: ${PrimaryColor.glintsred}`);
+  });
+});
+
+describe('when error is a string', () => {
+  it('should show a red border', () => {
+    const { getByRole } = render(
+      <Select error="error">{SelectChildren}</Select>
+    );
+    const selectInput = getByRole('combobox');
+    expect(selectInput).toHaveStyle(`border-color: ${PrimaryColor.glintsred}`);
+  });
+});
+
+describe('when error is a component', () => {
+  it('should show a red border', () => {
+    const { getByRole } = render(
+      <Select error={<span>error</span>}>{SelectChildren}</Select>
+    );
+    const selectInput = getByRole('combobox');
+    expect(selectInput).toHaveStyle(`border-color: ${PrimaryColor.glintsred}`);
+  });
+});
+
+describe('when renderError is not given', () => {
+  it('should not render the default error if error is falsy', () => {
+    const { getByRole } = render(<Select>{SelectChildren}</Select>);
+    const selectContainer = getByRole('combobox').parentElement.parentElement;
+    expect(selectContainer.lastChild).not.toHaveClass('select-error-default');
+  });
+
+  it('should not render the default error if error is true', () => {
+    const { getByRole } = render(
+      <Select error={true}>{SelectChildren}</Select>
+    );
+    const selectContainer = getByRole('combobox').parentElement.parentElement;
+    expect(selectContainer.lastChild).not.toHaveClass('select-error-default');
+  });
+
+  it('should render the error string in the default error', () => {
+    const { getByRole } = render(
+      <Select error={'test'}>{SelectChildren}</Select>
+    );
+    const selectContainer = getByRole('combobox').parentElement.parentElement;
+    expect(selectContainer.lastChild).toHaveClass('select-error-default');
+    expect(selectContainer.lastChild).toHaveTextContent('test');
+  });
+
+  it('should render the error component in the custom error', () => {
+    const errorComponent = <span className="errorComponent" />;
+    const { getByRole } = render(
+      <Select error={errorComponent}>{SelectChildren}</Select>
+    );
+    const selectContainer = getByRole('combobox').parentElement.parentElement;
+    expect(selectContainer.lastChild).toHaveClass('select-error-default');
+    expect(selectContainer.lastChild.firstChild).toHaveClass('errorComponent');
+  });
+});
+
+describe('when renderError is given', () => {
+  it('should not render the custom error if error is falsy', () => {
+    const customError = (e: string) => <div className="customError">{e}</div>;
+    const { getByRole } = render(
+      <Select renderError={customError}>{SelectChildren}</Select>
+    );
+    const selectContainer = getByRole('combobox').parentElement.parentElement;
+    expect(selectContainer.lastChild).not.toHaveClass('customError');
+  });
+
+  it('should not render the custom error if error is true', () => {
+    const customError = (e: string) => <div className="customError">{e}</div>;
+    const { getByRole } = render(
+      <Select renderError={customError} error={true}>
+        {SelectChildren}
+      </Select>
+    );
+    const selectContainer = getByRole('combobox').parentElement.parentElement;
+    expect(selectContainer.lastChild).not.toHaveClass('customError');
+  });
+
+  it('should render the error string in the custom error', () => {
+    const customError = (e: string) => <div className="customError">{e}</div>;
+    const { getByRole } = render(
+      <Select renderError={customError} error={'test'}>
+        {SelectChildren}
+      </Select>
+    );
+    const selectContainer = getByRole('combobox').parentElement.parentElement;
+    expect(selectContainer.lastChild).toHaveClass('customError');
+    expect(selectContainer.lastChild).toHaveTextContent('test');
+  });
+
+  it('should render the error component in the custom error', () => {
+    const customError = (e: string) => <div className="customError">{e}</div>;
+    const errorComponent = <span className="errorComponent" />;
+    const { getByRole } = render(
+      <Select renderError={customError} error={errorComponent}>
+        {SelectChildren}
+      </Select>
+    );
+    const selectContainer = getByRole('combobox').parentElement.parentElement;
+    expect(selectContainer.lastChild).toHaveClass('customError');
+    expect(selectContainer.lastChild.firstChild).toHaveClass('errorComponent');
+  });
+});
+
 describe('when isLoading = true', () => {
   it('should show a loading spinner', () => {
     const { getByRole } = render(<Select isLoading>{SelectChildren}</Select>);

--- a/src/Input/Select/Select.test.tsx
+++ b/src/Input/Select/Select.test.tsx
@@ -125,7 +125,7 @@ describe('when it is rendered', () => {
     expect(selectContainer.lastChild).not.toHaveClass('select-error-default');
   });
 
-  it('should render the error string in the default error', () => {
+  it('should render the error string in the default error container', () => {
     const { getByRole } = render(
       <Select error={'test'}>{SelectChildren}</Select>
     );
@@ -134,14 +134,28 @@ describe('when it is rendered', () => {
     expect(selectContainer.lastChild).toHaveTextContent('test');
   });
 
-  it('should render the error component in the custom error', () => {
-    const errorComponent = <span className="errorComponent" />;
-    const { getByRole } = render(
-      <Select error={errorComponent}>{SelectChildren}</Select>
+  it('should render the error component in the default error container', () => {
+    const customError = <span data-testid="custom-error">nasty error</span>;
+    const { container, getByTestId } = render(
+      <Select error={customError}>{SelectChildren}</Select>
     );
-    const selectContainer = getByRole('combobox').parentElement.parentElement;
-    expect(selectContainer.lastChild).toHaveClass('select-error-default');
-    expect(selectContainer.lastChild.firstChild).toHaveClass('errorComponent');
+    const customErrorElement = getByTestId('custom-error');
+    expect(container).toContainElement(customErrorElement);
+    expect(customErrorElement).toHaveTextContent('nasty error');
+  });
+
+  it('should render the error string in the custom error', () => {
+    const customError = (e: string) => (
+      <div data-testid="custom-error">{e}</div>
+    );
+    const { container, getByTestId } = render(
+      <Select renderError={customError} error="nasty error">
+        {SelectChildren}
+      </Select>
+    );
+    const errorElement = getByTestId('custom-error');
+    expect(container).toContainElement(errorElement);
+    expect(container).toHaveTextContent('nasty error');
   });
 });
 
@@ -270,29 +284,37 @@ describe('when renderError is given', () => {
     expect(selectContainer.lastChild).not.toHaveClass('customError');
   });
 
-  it('should render the error string in the custom error', () => {
-    const customError = (e: string) => <div className="customError">{e}</div>;
-    const { getByRole } = render(
-      <Select renderError={customError} error={'test'}>
+  it('should render the error string in the custom error container', () => {
+    const errorContainer = (e: React.ReactNode) => (
+      <div data-testid="error-component">{e}</div>
+    );
+    const { container, getByTestId } = render(
+      <Select renderError={errorContainer} error="nasty error">
         {SelectChildren}
       </Select>
     );
-    const selectContainer = getByRole('combobox').parentElement.parentElement;
-    expect(selectContainer.lastChild).toHaveClass('customError');
-    expect(selectContainer.lastChild).toHaveTextContent('test');
+    const errorContainerElement = getByTestId('error-component');
+    expect(container).toContainElement(errorContainerElement);
+    expect(errorContainerElement).toHaveTextContent('nasty error');
   });
 
-  it('should render the error component in the custom error', () => {
-    const customError = (e: string) => <div className="customError">{e}</div>;
-    const errorComponent = <span className="errorComponent" />;
-    const { getByRole } = render(
-      <Select renderError={customError} error={errorComponent}>
+  it('should render the custom error in the custom error container', () => {
+    const customError = () => (
+      <span data-testid="custom-error">nasty error</span>
+    );
+    const errorContainer = (e: () => React.ReactNode) => (
+      <div data-testid="error-component">{e()}</div>
+    );
+    const { container, getByTestId } = render(
+      <Select renderError={errorContainer} error={customError}>
         {SelectChildren}
       </Select>
     );
-    const selectContainer = getByRole('combobox').parentElement.parentElement;
-    expect(selectContainer.lastChild).toHaveClass('customError');
-    expect(selectContainer.lastChild.firstChild).toHaveClass('errorComponent');
+    const customErrorElement = getByTestId('custom-error');
+    const errorContainerElement = getByTestId('error-component');
+    expect(container).toContainElement(errorContainerElement);
+    expect(errorContainerElement).toContainElement(customErrorElement);
+    expect(customErrorElement).toHaveTextContent('nasty error');
   });
 });
 

--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -283,6 +283,15 @@ class Select extends React.Component<Props, State> {
 
     const deprecatedStatus = status || (error && 'error');
 
+    const shouldRenderError = !error || typeof error === 'boolean';
+    const completeError = shouldRenderError ? null : renderError ? (
+      renderError(error)
+    ) : (
+      <SelectErrorDefault className="select-error-default">
+        {error}
+      </SelectErrorDefault>
+    );
+
     return (
       <SelectContainer
         className={classNames('aries-select', className)}
@@ -335,12 +344,7 @@ class Select extends React.Component<Props, State> {
           handleClick={this.handleClick}
           handleMouseEnter={this.handleMouseEnter}
         />
-        {typeof error !== 'boolean' &&
-          (renderError ? (
-            renderError(error)
-          ) : (
-            <SelectErrorDefault>{error}</SelectErrorDefault>
-          ))}
+        {completeError}
       </SelectContainer>
     );
   }

--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -260,7 +260,7 @@ class Select extends React.Component<Props, State> {
       removeFloatingLabel,
       removeDropIcon,
       error,
-      ErrorComponent,
+      renderError,
       ...defaultProps
     } = this.props;
 
@@ -328,8 +328,8 @@ class Select extends React.Component<Props, State> {
           handleMouseEnter={this.handleMouseEnter}
         />
         {typeof error === 'string' &&
-          (ErrorComponent ? (
-            <ErrorComponent>{error}</ErrorComponent>
+          (renderError ? (
+            renderError(error)
           ) : (
             <SelectErrorDefault>{error}</SelectErrorDefault>
           ))}
@@ -346,7 +346,7 @@ interface Props extends React.ComponentPropsWithoutRef<typeof SelectInput> {
   removeDropIcon?: boolean;
   removeFloatingLabel?: boolean;
   error?: string | boolean;
-  ErrorComponent?: React.ElementType;
+  renderError?: React.FunctionComponent<string | boolean>;
 
   onFocus?(e: React.FocusEvent<HTMLInputElement>): void;
   onBlur?(e: React.FocusEvent<HTMLInputElement>): void;

--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -12,6 +12,7 @@ import {
   SelectWrapper,
   SelectInput,
   SelectLabel,
+  SelectErrorDefault,
 } from '../../Style/Input/SelectStyle';
 
 class Select extends React.Component<Props, State> {
@@ -258,6 +259,7 @@ class Select extends React.Component<Props, State> {
       disableTyping,
       removeFloatingLabel,
       removeDropIcon,
+      error,
       ...defaultProps
     } = this.props;
 
@@ -282,7 +284,7 @@ class Select extends React.Component<Props, State> {
             role="combobox"
             aria-expanded={isFocus}
             aria-autocomplete="list"
-            status={status}
+            status={status || (error && 'error')}
             disabled={disabled}
             onFocus={this.handleFocus(onFocus)}
             onBlur={this.handleFocusOut(onBlur)}
@@ -299,7 +301,7 @@ class Select extends React.Component<Props, State> {
             <SelectLabel
               aria-label={label}
               floating={floating}
-              status={status}
+              status={status || (error && 'error')}
               small={small}
             >
               {label}
@@ -322,6 +324,9 @@ class Select extends React.Component<Props, State> {
           handleClick={this.handleClick}
           handleMouseEnter={this.handleMouseEnter}
         />
+        {typeof error === 'string' && (
+          <SelectErrorDefault>{error}</SelectErrorDefault>
+        )}
       </SelectContainer>
     );
   }
@@ -334,6 +339,7 @@ interface Props extends React.ComponentPropsWithoutRef<typeof SelectInput> {
   noOptionResult?: string;
   removeDropIcon?: boolean;
   removeFloatingLabel?: boolean;
+  error?: string | boolean;
 
   onFocus?(e: React.FocusEvent<HTMLInputElement>): void;
   onBlur?(e: React.FocusEvent<HTMLInputElement>): void;

--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -260,6 +260,7 @@ class Select extends React.Component<Props, State> {
       removeFloatingLabel,
       removeDropIcon,
       error,
+      ErrorComponent,
       ...defaultProps
     } = this.props;
 
@@ -324,9 +325,12 @@ class Select extends React.Component<Props, State> {
           handleClick={this.handleClick}
           handleMouseEnter={this.handleMouseEnter}
         />
-        {typeof error === 'string' && (
-          <SelectErrorDefault>{error}</SelectErrorDefault>
-        )}
+        {typeof error === 'string' &&
+          (ErrorComponent ? (
+            <ErrorComponent>{error}</ErrorComponent>
+          ) : (
+            <SelectErrorDefault>{error}</SelectErrorDefault>
+          ))}
       </SelectContainer>
     );
   }
@@ -340,6 +344,7 @@ interface Props extends React.ComponentPropsWithoutRef<typeof SelectInput> {
   removeDropIcon?: boolean;
   removeFloatingLabel?: boolean;
   error?: string | boolean;
+  ErrorComponent?: React.ElementType;
 
   onFocus?(e: React.FocusEvent<HTMLInputElement>): void;
   onBlur?(e: React.FocusEvent<HTMLInputElement>): void;

--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -36,7 +36,7 @@ class Select extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    const { value, children } = this.props;
+    const { value, children, status } = this.props;
 
     // Checking if children data is exist or not.
     if (React.Children.count(children) !== 0) {
@@ -54,6 +54,14 @@ class Select extends React.Component<Props, State> {
     }
 
     document.addEventListener('click', this.handleOnBlur, false);
+
+    if (status) {
+      if (typeof console !== 'undefined') {
+        console.warn(`Warning: Select's status prop is deprecated and will be
+        removed in a future release.\n\nPlease use the error prop instead to
+        show errors and indicate an error state.`);
+      }
+    }
   }
 
   componentDidUpdate(prevProps: Props) {

--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -335,7 +335,7 @@ class Select extends React.Component<Props, State> {
           handleClick={this.handleClick}
           handleMouseEnter={this.handleMouseEnter}
         />
-        {typeof error === 'string' &&
+        {typeof error !== 'boolean' &&
           (renderError ? (
             renderError(error)
           ) : (
@@ -353,8 +353,8 @@ interface Props extends React.ComponentPropsWithoutRef<typeof SelectInput> {
   noOptionResult?: string;
   removeDropIcon?: boolean;
   removeFloatingLabel?: boolean;
-  error?: string | boolean;
-  renderError?: React.FunctionComponent<string | boolean>;
+  error?: React.ReactNode | string | boolean;
+  renderError?: (error: React.ReactNode | string | boolean) => React.ReactNode;
 
   onFocus?(e: React.FocusEvent<HTMLInputElement>): void;
   onBlur?(e: React.FocusEvent<HTMLInputElement>): void;

--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -273,6 +273,8 @@ class Select extends React.Component<Props, State> {
       isLoading,
     } = this.state;
 
+    const deprecatedStatus = status || (error && 'error');
+
     return (
       <SelectContainer
         className={classNames('aries-select', className)}
@@ -285,7 +287,7 @@ class Select extends React.Component<Props, State> {
             role="combobox"
             aria-expanded={isFocus}
             aria-autocomplete="list"
-            status={status || (error && 'error')}
+            status={deprecatedStatus}
             disabled={disabled}
             onFocus={this.handleFocus(onFocus)}
             onBlur={this.handleFocusOut(onBlur)}
@@ -302,7 +304,7 @@ class Select extends React.Component<Props, State> {
             <SelectLabel
               aria-label={label}
               floating={floating}
-              status={status || (error && 'error')}
+              status={deprecatedStatus}
               small={small}
             >
               {label}

--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -283,14 +283,20 @@ class Select extends React.Component<Props, State> {
 
     const deprecatedStatus = status || (error && 'error');
 
-    const shouldRenderError = !error || typeof error === 'boolean';
-    const completeError = shouldRenderError ? null : renderError ? (
-      renderError(error)
-    ) : (
-      <SelectErrorDefault className="select-error-default">
-        {error}
-      </SelectErrorDefault>
-    );
+    const shouldShowError = error && typeof error !== 'boolean';
+
+    let completeError = null;
+    if (shouldShowError) {
+      if (renderError) {
+        completeError = renderError(error);
+      } else {
+        completeError = (
+          <SelectErrorDefault className="select-error-default">
+            {error}
+          </SelectErrorDefault>
+        );
+      }
+    }
 
     return (
       <SelectContainer

--- a/src/Style/Input/SelectStyle.ts
+++ b/src/Style/Input/SelectStyle.ts
@@ -236,3 +236,7 @@ export const SelectItemWrapper = styled.li<SelectItemWrapperProps>`
 interface SelectItemWrapperProps {
   disabled?: boolean;
 }
+
+export const SelectErrorDefault = styled.span`
+  color:${PrimaryColor.glintsred};
+`

--- a/stories/Input/SelectStory.tsx
+++ b/stories/Input/SelectStory.tsx
@@ -34,7 +34,7 @@ const props = {
     },
     {
       name: 'error',
-      type: 'boolean | string',
+      type: 'ReactNode | boolean | string',
       defaultValue: '',
       possibleValue: 'any',
       require: 'no',
@@ -43,7 +43,7 @@ const props = {
     },
     {
       name: 'renderError',
-      type: 'Component',
+      type: 'ReactNode',
       defaultValue: '<span color="#EC272B" />',
       possibleValue: 'any',
       require: 'no',
@@ -162,6 +162,17 @@ const Story = (
     </div>
     <div style={{ width: '300px' }}>
       <Select label="Jobs" error="I am an error message 🙀">
+        <Select.Option value="accountant">Accountant</Select.Option>
+        <Select.Option value="business development">
+          Business Development
+        </Select.Option>
+        <Select.Option value="software engineer">
+          Software Engineer
+        </Select.Option>
+      </Select>
+    </div>
+    <div style={{ width: '300px' }}>
+      <Select label="Jobs" error={<strong>I am a custom error</strong>}>
         <Select.Option value="accountant">Accountant</Select.Option>
         <Select.Option value="business development">
           Business Development

--- a/stories/Input/SelectStory.tsx
+++ b/stories/Input/SelectStory.tsx
@@ -32,6 +32,15 @@ const props = {
       description: 'Sets different style for Select based on status.',
     },
     {
+      name: 'error',
+      type: 'boolean | string',
+      defaultValue: '',
+      possibleValue: 'any',
+      require: 'no',
+      description:
+        'Sets error state on component. If string, the error will be shown below the select',
+    },
+    {
       name: 'isLoading',
       type: 'boolean',
       defaultValue: <code>false</code>,
@@ -118,16 +127,41 @@ const props = {
 };
 
 const Story = (
-  <Select label="Jobs">
-    <Select.Option value="accountant">Accountant</Select.Option>
-    <Select.Option value="business development">
-      Business Development
-    </Select.Option>
-    <Select.Option value="software engineer">Software Engineer</Select.Option>
-    <Select.Option value="finance">Finance</Select.Option>
-    <Select.Option value="design">Design</Select.Option>
-    <Select.Option value="human resources">Human Resources</Select.Option>
-  </Select>
+  <div>
+    <div style={{ width: '300px', marginBottom: '1rem' }}>
+      <Select label="Jobs">
+        <Select.Option value="accountant">Accountant</Select.Option>
+        <Select.Option value="business development">
+          Business Development
+        </Select.Option>
+        <Select.Option value="software engineer">
+          Software Engineer
+        </Select.Option>
+      </Select>
+    </div>
+    <div style={{ width: '300px', marginBottom: '1rem' }}>
+      <Select label="Jobs" error={true}>
+        <Select.Option value="accountant">Accountant</Select.Option>
+        <Select.Option value="business development">
+          Business Development
+        </Select.Option>
+        <Select.Option value="software engineer">
+          Software Engineer
+        </Select.Option>
+      </Select>
+    </div>
+    <div style={{ width: '300px' }}>
+      <Select label="Jobs" error="I am an error message 🙀">
+        <Select.Option value="accountant">Accountant</Select.Option>
+        <Select.Option value="business development">
+          Business Development
+        </Select.Option>
+        <Select.Option value="software engineer">
+          Software Engineer
+        </Select.Option>
+      </Select>
+    </div>
+  </div>
 );
 
 const SelectStory = () => {

--- a/stories/Input/SelectStory.tsx
+++ b/stories/Input/SelectStory.tsx
@@ -27,9 +27,10 @@ const props = {
       name: 'status',
       type: 'string',
       defaultValue: '',
-      possibleValue: <code>success | error</code>,
+      possibleValue: <code>error</code>,
       require: 'no',
-      description: 'Sets different style for Select based on status.',
+      description:
+        '(DEPRECATED) Sets different style for Select based on status.',
     },
     {
       name: 'error',

--- a/stories/Input/SelectStory.tsx
+++ b/stories/Input/SelectStory.tsx
@@ -42,6 +42,15 @@ const props = {
         'Sets error state on component. If string, the error will be shown below the select',
     },
     {
+      name: 'ErrorComponent',
+      type: 'Component',
+      defaultValue: '<DefaultError />',
+      possibleValue: 'any',
+      require: 'no',
+      description:
+        'Replaces the default error component. Receives `error` as children.',
+    },
+    {
       name: 'isLoading',
       type: 'boolean',
       defaultValue: <code>false</code>,
@@ -153,6 +162,23 @@ const Story = (
     </div>
     <div style={{ width: '300px' }}>
       <Select label="Jobs" error="I am an error message 🙀">
+        <Select.Option value="accountant">Accountant</Select.Option>
+        <Select.Option value="business development">
+          Business Development
+        </Select.Option>
+        <Select.Option value="software engineer">
+          Software Engineer
+        </Select.Option>
+      </Select>
+    </div>
+    <div style={{ width: '300px' }}>
+      <Select
+        label="Jobs"
+        error="🎂 I am a custom error message"
+        ErrorComponent={({ children }) => (
+          <div style={{ color: 'orange', textAlign: 'right' }}>{children}</div>
+        )}
+      >
         <Select.Option value="accountant">Accountant</Select.Option>
         <Select.Option value="business development">
           Business Development

--- a/stories/Input/SelectStory.tsx
+++ b/stories/Input/SelectStory.tsx
@@ -42,9 +42,9 @@ const props = {
         'Sets error state on component. If string, the error will be shown below the select',
     },
     {
-      name: 'ErrorComponent',
+      name: 'renderError',
       type: 'Component',
-      defaultValue: '<DefaultError />',
+      defaultValue: '<span color="#EC272B" />',
       possibleValue: 'any',
       require: 'no',
       description:

--- a/stories/Input/SelectStory.tsx
+++ b/stories/Input/SelectStory.tsx
@@ -175,8 +175,8 @@ const Story = (
       <Select
         label="Jobs"
         error="🎂 I am a custom error message"
-        ErrorComponent={({ children }) => (
-          <div style={{ color: 'orange', textAlign: 'right' }}>{children}</div>
+        renderError={error => (
+          <div style={{ color: 'orange', textAlign: 'right' }}>{error}</div>
         )}
       >
         <Select.Option value="accountant">Accountant</Select.Option>


### PR DESCRIPTION
This adds properties `error` and `CustomError` to Select. When `error` is set to `true`, the Select will behave just like when setting `status` to `error`. When set to a string, the message will be displayed below the Select. By default, the message will be shown in a `span` with red text color, but supplying a `CustomError` component will render the message inside the `CustomError` instead.

This will be useful for unifying the behaviour in the frontend and will allow us to revert the Selects in the profile page modals back to the Glints Aries Select.