### PR TITLE
Icon: Add more props to increase customizability

### DIFF
--- a/src/General/Icon/Icon.tsx
+++ b/src/General/Icon/Icon.tsx
@@ -1,18 +1,38 @@
 import * as React from 'react';
 
 const Icon: React.FunctionComponent<Props> = props => {
-  const { children, color } = props;
+  const {
+    className,
+    children,
+    color,
+    width = '1em',
+    height = '1em',
+    onClick,
+    ...restProps
+  } = props;
 
   return (
-    <svg width="1em" height="1em" fill={color} viewBox="0 0 100 100">
+    <svg
+      className={className}
+      width={width}
+      height={height}
+      onClick={onClick}
+      fill={color}
+      viewBox="0 0 100 100"
+      {...restProps}
+    >
       {children}
     </svg>
   );
 };
 
 export interface Props {
+  className?: string;
   children: React.ReactNode;
   color?: string;
+  width?: string | number;
+  height?: string | number;
+  onClick?(e: React.MouseEvent<SVGSVGElement, MouseEvent>): void;
 }
 
 export default Icon;

--- a/stories/General/IconStory.tsx
+++ b/stories/General/IconStory.tsx
@@ -1,10 +1,28 @@
 import * as React from 'react';
+import styled from 'styled-components';
 
 import StorybookComponent from '../StorybookComponent';
+import { PrimaryColor } from '../../src/Style/Colors';
 import * as AllIcons from '../../src/General/Icon/components';
 
 const props = {
   Icon: [
+    {
+      name: 'width',
+      type: 'string | number',
+      defaultValue: <code>1em</code>,
+      possibleValue: <code>any</code>,
+      require: 'no',
+      description: 'Sets width of icon.',
+    },
+    {
+      name: 'height',
+      type: 'string | number',
+      defaultValue: <code>1em</code>,
+      possibleValue: <code>any</code>,
+      require: 'no',
+      description: 'Sets height of icon.',
+    },
     {
       name: 'color',
       type: 'string',
@@ -16,26 +34,53 @@ const props = {
   ],
 };
 
+const LikeButton = styled(AllIcons.ThumbsUpOutlineIcon)`
+  cursor: pointer;
+  :hover {
+    fill: ${PrimaryColor.glintsred};
+  }
+`;
+
 const IconStory = () => (
-  <StorybookComponent
-    title="Icon"
-    code="import { AddCircleOutlineIcon } from 'glints-aries'"
-    propsObject={props}
-    usage={'<AddCircleOutlineIcon />'}
-  >
-    <div style={{ display: 'flex', flexWrap: 'wrap', fontSize: '20px' }}>
-      {Object.values(AllIcons)
-        .sort()
-        .map(Icon => (
-          <div style={{ flex: '1 1 20%', margin: '1em' }} key={Icon.name}>
-            <Icon />
-            <p style={{ marginTop: '1em', fontSize: '12px' }}>
-              <code style={{ fontSize: '14px' }}>{Icon.name}</code>
-            </p>
-          </div>
-        ))}
-    </div>
-  </StorybookComponent>
+  <React.Fragment>
+    <StorybookComponent
+      title="Icon"
+      code="import { AddCircleOutlineIcon } from 'glints-aries'"
+      propsObject={props}
+      usage={'<AddCircleOutlineIcon />'}
+    >
+      <div style={{ display: 'flex', flexWrap: 'wrap', fontSize: '20px' }}>
+        {Object.values(AllIcons)
+          .sort()
+          .map(Icon => (
+            <div style={{ flex: '1 1 20%', margin: '1em' }} key={Icon.name}>
+              <Icon />
+              <p style={{ marginTop: '1em', fontSize: '12px' }}>
+                <code style={{ fontSize: '14px' }}>{Icon.name}</code>
+              </p>
+            </div>
+          ))}
+      </div>
+    </StorybookComponent>
+    <StorybookComponent
+      title="Custom Icon"
+      usage={`
+import styled from 'styled-components';
+import { ThumbsUpOutlineIcon, PrimaryColor } from 'glints-aries';
+
+const LikeButton = styled(ThumbsUpOutlineIcon)\`
+  cursor: pointer;
+  :hover {
+    fill: ${PrimaryColor.glintsred};
+  }
+\`;
+
+<LikeButton width={50} height="100%" onClick={() => alert('Liked!')} />
+    `}
+    >
+      <LikeButton width={50} height="100%" onClick={() => alert('Liked!')} />
+    </StorybookComponent>
+  </React.Fragment>
 );
 
 export default IconStory;


### PR DESCRIPTION
Previously, devs would have to create wrapper components to style the Icon. E.g.:
```
<IconWrapper>
  <GlintsAriesIcon />
</IconWrapper>
```

Added props to fix this issue and allow for better customization.
- width, height, className, onClick