### PR TITLE
Modal: Refactor to Handle onClose Properly

### DIFF
--- a/src/Display/Modal/Modal.test.tsx
+++ b/src/Display/Modal/Modal.test.tsx
@@ -107,12 +107,21 @@ describe('onClose should be called once when:', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  const escapeEvent = {
+    key: 'Escape',
+    keyCode: 27,
+  };
+
   it('escape key is pressed', () => {
     const { modalContainer, onClose } = setupModal(true);
-    fireEvent.keyDown(modalContainer, {
-      key: 'Escape',
-      keyCode: 27,
-    });
+    fireEvent.keyDown(modalContainer, escapeEvent);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('escape key is pressed twice', () => {
+    const { modalContainer, onClose } = setupModal(true);
+    fireEvent.keyDown(modalContainer, escapeEvent);
+    fireEvent.keyDown(modalContainer, escapeEvent);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/Display/Modal/Modal.tsx
+++ b/src/Display/Modal/Modal.tsx
@@ -23,8 +23,7 @@ class Modal extends React.Component<Props> {
   }
 
   componentDidMount() {
-    const { onClose } = this.props;
-    document.addEventListener('keydown', escEvent(onClose), false);
+    this.onOpen();
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -43,6 +42,15 @@ class Modal extends React.Component<Props> {
   }
 
   componentWillUnmount() {
+    this.onClose();
+  }
+
+  onOpen() {
+    const { onClose } = this.props;
+    document.addEventListener('keydown', escEvent(onClose), false);
+  }
+
+  onClose() {
     const { onClose } = this.props;
     document.removeEventListener('keydown', escEvent(onClose), false);
     document.body.removeAttribute('style');

--- a/src/Display/Modal/Modal.tsx
+++ b/src/Display/Modal/Modal.tsx
@@ -13,7 +13,7 @@ import {
   ModalFooter,
 } from '../../Style/Display/ModalStyle';
 
-class Modal extends React.Component<Props, State> {
+class Modal extends React.Component<Props> {
   modalContentAreaRef: React.RefObject<HTMLDivElement>;
   mouseDownTarget: HTMLElement;
 
@@ -31,23 +31,18 @@ class Modal extends React.Component<Props, State> {
     document.addEventListener('keydown', escEvent(onClose), false);
   }
 
-  static getDerivedStateFromProps(nextProps: Props, prevState: State) {
-    if (nextProps.isVisible && !prevState.isOpen) {
-      document.body.style.overflow = 'hidden';
-      return { isOpen: true };
-    }
-
-    if (!nextProps.isVisible && prevState.isOpen) {
-      document.body.removeAttribute('style');
-      return { isOpen: false };
-    }
-    return null;
-  }
-
   componentDidUpdate(prevProps: Props) {
     const { isVisible } = this.props;
+
+    // closed -> open
     if (!prevProps.isVisible && isVisible) {
       this.modalContentAreaRef.current.focus();
+      document.body.style.overflow = 'hidden';
+    }
+
+    // open -> closed
+    if (prevProps.isVisible && !isVisible) {
+      document.body.removeAttribute('style');
     }
   }
 
@@ -83,18 +78,17 @@ class Modal extends React.Component<Props, State> {
       removeAnimation,
       footer,
       size,
+      isVisible,
       hideHeader,
       ...restProps
     } = this.props;
-
-    const { isOpen } = this.state;
 
     return (
       <ModalContainer
         data-testid="modal-container"
         className={classNames('aries-modal', className)}
         centering={centering}
-        isOpen={isOpen}
+        isOpen={isVisible}
         removeAnimation={removeAnimation}
         onMouseDown={this.handleMouseDown}
         onClick={this.handleClick}
@@ -108,7 +102,7 @@ class Modal extends React.Component<Props, State> {
             centering={centering}
             onClick={e => e.stopPropagation()}
             tabIndex={0}
-            isOpen={isOpen}
+            isOpen={isVisible}
             removeAnimation={removeAnimation}
             size={size}
             ref={this.modalContentAreaRef}
@@ -153,10 +147,6 @@ interface Props
   footer?: React.ReactElement[];
   size?: sizeType;
   hideHeader?: boolean;
-}
-
-interface State {
-  isOpen: boolean;
 }
 
 export default Modal;

--- a/src/Display/Modal/Modal.tsx
+++ b/src/Display/Modal/Modal.tsx
@@ -17,10 +17,6 @@ class Modal extends React.Component<Props> {
   modalContentAreaRef: React.RefObject<HTMLDivElement>;
   mouseDownTarget: HTMLElement;
 
-  state = {
-    isOpen: false,
-  };
-
   constructor(props: Props) {
     super(props);
     this.modalContentAreaRef = React.createRef();

--- a/src/Display/Modal/Modal.tsx
+++ b/src/Display/Modal/Modal.tsx
@@ -40,6 +40,10 @@ class Modal extends React.Component<Props> {
     }
   }
 
+  componentDidMount() {
+    if (this.props.isVisible) this.handleOpen();
+  }
+
   componentWillUnmount() {
     this.handleClose();
   }

--- a/src/Display/Modal/Modal.tsx
+++ b/src/Display/Modal/Modal.tsx
@@ -16,14 +16,11 @@ import {
 class Modal extends React.Component<Props> {
   modalContentAreaRef: React.RefObject<HTMLDivElement>;
   mouseDownTarget: HTMLElement;
+  escEvent: (e: KeyboardEvent) => any;
 
   constructor(props: Props) {
     super(props);
     this.modalContentAreaRef = React.createRef();
-  }
-
-  componentDidMount() {
-    this.onOpen();
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -33,26 +30,28 @@ class Modal extends React.Component<Props> {
     if (!prevProps.isVisible && isVisible) {
       this.modalContentAreaRef.current.focus();
       document.body.style.overflow = 'hidden';
+      this.handleOpen();
     }
 
     // open -> closed
     if (prevProps.isVisible && !isVisible) {
       document.body.removeAttribute('style');
+      this.handleClose();
     }
   }
 
   componentWillUnmount() {
-    this.onClose();
+    this.handleClose();
   }
 
-  onOpen() {
+  handleOpen() {
     const { onClose } = this.props;
-    document.addEventListener('keydown', escEvent(onClose), false);
+    this.escEvent = escEvent(onClose);
+    document.addEventListener('keydown', this.escEvent, false);
   }
 
-  onClose() {
-    const { onClose } = this.props;
-    document.removeEventListener('keydown', escEvent(onClose), false);
+  handleClose() {
+    document.removeEventListener('keydown', this.escEvent, false);
     document.body.removeAttribute('style');
   }
 


### PR DESCRIPTION
This MR refactors the Modal component to remove the internal state, which before has been completely controlled by the `isVisible` prop, which made it redundant.

This MR also refactors the way `onClose` is called. Previously, the `componentWillUnmount` was supposed to unregister the escape key event handler, so that the event would not trigger while the modal was closed. This did not work because the modal's visibility is toggled through the `display` CSS prop, so the component would never actually unmount.