### PR TITLE
Modal: Don't Call onClose When Closed

### DIFF
--- a/src/Display/Modal/Modal.test.tsx
+++ b/src/Display/Modal/Modal.test.tsx
@@ -90,6 +90,11 @@ describe('when modal is closed', () => {
   });
 });
 
+const escapeEvent = {
+  key: 'Escape',
+  keyCode: 27,
+};
+
 describe('onClose should be called once when:', () => {
   it('close icon is clicked', () => {
     const { closeButton, onClose } = setupModal(true);
@@ -109,11 +114,16 @@ describe('onClose should be called once when:', () => {
 
   it('escape key is pressed', () => {
     const { modalContainer, onClose } = setupModal(true);
-    fireEvent.keyDown(modalContainer, {
-      key: 'Escape',
-      keyCode: 27,
-    });
+    fireEvent.keyDown(modalContainer, escapeEvent);
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('onClose should not have been called when:', () => {
+  it('escape key is pressed on closed modal', () => {
+    const { modalContainer, onClose } = setupModal(false);
+    fireEvent.keyDown(modalContainer, escapeEvent);
+    expect(onClose).toHaveBeenCalledTimes(0);
   });
 });
 

--- a/src/Display/Modal/Modal.tsx
+++ b/src/Display/Modal/Modal.tsx
@@ -32,9 +32,13 @@ class Modal extends React.Component<Props, State> {
     if (this.state.isOpen) onClose();
   }
 
-  componentDidMount() {
+  registerEventEscapeListener() {
     this.escEvent = escEvent(this.guardedOnClose.bind(this));
     document.addEventListener('keydown', this.escEvent, false);
+  }
+
+  componentDidMount() {
+    this.registerEventEscapeListener();
   }
 
   static getDerivedStateFromProps(nextProps: Props, prevState: State) {

--- a/src/Display/Modal/Modal.tsx
+++ b/src/Display/Modal/Modal.tsx
@@ -26,9 +26,17 @@ class Modal extends React.Component<Props, State> {
     this.modalContentAreaRef = React.createRef();
   }
 
-  componentDidMount() {
+  guardedOnClose() {
     const { onClose } = this.props;
-    document.addEventListener('keydown', escEvent(onClose), false);
+    if (this.state.isOpen) onClose();
+  }
+
+  componentDidMount() {
+    document.addEventListener(
+      'keydown',
+      escEvent(this.guardedOnClose.bind(this)),
+      false
+    );
   }
 
   static getDerivedStateFromProps(nextProps: Props, prevState: State) {
@@ -52,8 +60,11 @@ class Modal extends React.Component<Props, State> {
   }
 
   componentWillUnmount() {
-    const { onClose } = this.props;
-    document.removeEventListener('keydown', escEvent(onClose), false);
+    document.removeEventListener(
+      'keydown',
+      escEvent(this.guardedOnClose),
+      false
+    );
     document.body.removeAttribute('style');
   }
 

--- a/src/Display/Modal/Modal.tsx
+++ b/src/Display/Modal/Modal.tsx
@@ -57,8 +57,12 @@ class Modal extends React.Component<Props, State> {
     }
   }
 
-  componentWillUnmount() {
+  removeEscapeEventListener() {
     document.removeEventListener('keydown', this.escEvent, false);
+  }
+
+  componentWillUnmount() {
+    this.removeEscapeEventListener();
     document.body.removeAttribute('style');
   }
 

--- a/src/Display/Modal/Modal.tsx
+++ b/src/Display/Modal/Modal.tsx
@@ -58,6 +58,7 @@ class Modal extends React.Component<Props, State> {
     const { isVisible } = this.props;
     if (!prevProps.isVisible && isVisible) {
       this.modalContentAreaRef.current.focus();
+      this.registerEventEscapeListener();
     }
     if (prevProps.isVisible && !isVisible) {
       this.removeEscapeEventListener();

--- a/src/Display/Modal/Modal.tsx
+++ b/src/Display/Modal/Modal.tsx
@@ -27,13 +27,9 @@ class Modal extends React.Component<Props, State> {
     this.modalContentAreaRef = React.createRef();
   }
 
-  guardedOnClose() {
-    const { onClose } = this.props;
-    if (this.state.isOpen) onClose();
-  }
-
   registerEventEscapeListener() {
-    this.escEvent = escEvent(this.guardedOnClose.bind(this));
+    if (!this.props.isVisible) return;
+    this.escEvent = escEvent(this.props.onClose);
     document.addEventListener('keydown', this.escEvent, false);
   }
 

--- a/src/Display/Modal/Modal.tsx
+++ b/src/Display/Modal/Modal.tsx
@@ -16,6 +16,7 @@ import {
 class Modal extends React.Component<Props, State> {
   modalContentAreaRef: React.RefObject<HTMLDivElement>;
   mouseDownTarget: HTMLElement;
+  escEvent: (e: KeyboardEvent) => any;
 
   state = {
     isOpen: false,
@@ -32,11 +33,8 @@ class Modal extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    document.addEventListener(
-      'keydown',
-      escEvent(this.guardedOnClose.bind(this)),
-      false
-    );
+    this.escEvent = escEvent(this.guardedOnClose.bind(this));
+    document.addEventListener('keydown', this.escEvent, false);
   }
 
   static getDerivedStateFromProps(nextProps: Props, prevState: State) {
@@ -60,11 +58,7 @@ class Modal extends React.Component<Props, State> {
   }
 
   componentWillUnmount() {
-    document.removeEventListener(
-      'keydown',
-      escEvent(this.guardedOnClose),
-      false
-    );
+    document.removeEventListener('keydown', this.escEvent, false);
     document.body.removeAttribute('style');
   }
 

--- a/src/Display/Modal/Modal.tsx
+++ b/src/Display/Modal/Modal.tsx
@@ -55,6 +55,9 @@ class Modal extends React.Component<Props, State> {
     if (!prevProps.isVisible && isVisible) {
       this.modalContentAreaRef.current.focus();
     }
+    if (prevProps.isVisible && !isVisible) {
+      this.removeEscapeEventListener();
+    }
   }
 
   removeEscapeEventListener() {


### PR DESCRIPTION
In some cases the onClose function is being called even when the modal is already closed.

For instance, this can happen because the escape event listener does not get unregistered when the modal closes. This is a bug but I've decided to treat the symptom rather than the root cause because this component will likely get rewritten soon anyway.

I tried fixing the root cause before in https://github.com/glints-dev/glints-aries/pull/220 but the state management of Modal is more complex than I realized at first. A more thorough redesign of this component's API will be necessary to define the desired behavior and implement it, with or without the internal state.