### PR TITLE
Hotfix/select active element

### DIFF
--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -211,7 +211,7 @@ class Select extends React.Component<Props, State> {
       }
 
       const activeElementIndex = Number(get(activeElement, 'dataset.id'));
-      const activeChild = React.Children.toArray(children)[activeElementIndex];
+      const activeChild = filterValue[activeElementIndex];
       const onOptionClick = get(activeChild, 'props.onOptionClick');
 
       this.setState({


### PR DESCRIPTION
This PR fixes the bug:

Pressing Enter did not select the correct option after the dropdown list is filtered

Previously we used the item's `index` to get the active element but it was the wrong approach because the index changes when the list gets filtered. To fix this, we use the `data-value` to get the active element instead. This is still not full-proof as there is no guarantee the `data-value` is unique but it seems to be the only way to get the `props` of the active element.

Added some test code for the reviewer to test which will be removed before merging