### PR TITLE
TextField: Refactor export statement for TextFieldProps

### DIFF
--- a/src/Input/TextField/index.ts
+++ b/src/Input/TextField/index.ts
@@ -1,5 +1,7 @@
 import TextField, { Props } from './TextField';
 
-export { TextField, Props as TextFieldProps };
+export type TextFieldProps = Props;
+
+export { TextField };
 
 export default TextField;


### PR DESCRIPTION
- `export { Props as TextFieldProps };` was causing the webpack build to fail when we migrated to Next.js
- Fixed it by refactoring to `export type TextFieldProps = Props;`

Related issue: https://github.com/babel/babel/issues/8361