### PR TITLE
Feature/add ref to textarea and textfield

### DIFF
--- a/src/Input/TextField/TextField.test.tsx
+++ b/src/Input/TextField/TextField.test.tsx
@@ -146,3 +146,31 @@ describe('when removeFloatingLabel is true', () => {
     expect(textFieldInput).toBeTruthy();
   });
 });
+
+describe('<TextField /> forwards ref to underlying input element', () => {
+  const label = 'forward-ref';
+
+  test('ref is being forwarded correctly', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    const { queryByLabelText } = render(
+      <TextField ref={ref} label={label} type="text" />
+    );
+    const textInput = queryByLabelText(label);
+    expect(textInput).toEqual(ref.current);
+  });
+
+  test('underlying textarea can be focused/blurred through ref', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    const { queryByLabelText } = render(
+      <TextField ref={ref} label={label} type="text" />
+    );
+    const textInput = queryByLabelText(label);
+    expect(textInput).not.toHaveFocus();
+
+    ref.current.focus();
+    expect(textInput).toHaveFocus();
+
+    ref.current.blur();
+    expect(textInput).not.toHaveFocus();
+  });
+});

--- a/src/Input/TextField/TextField.tsx
+++ b/src/Input/TextField/TextField.tsx
@@ -89,6 +89,7 @@ class TextField extends React.Component<Props, State> {
       small,
       removeFloatingLabel,
       disableTyping,
+      forwardedRef,
       ...defaultProps
     } = this.props;
 
@@ -97,6 +98,7 @@ class TextField extends React.Component<Props, State> {
     return (
       <TextFieldContainer className={classNames('aries-textfield', className)}>
         <TextFieldInput
+          ref={forwardedRef}
           type={inputType}
           placeholder={removeFloatingLabel && label}
           status={status}
@@ -147,6 +149,7 @@ export interface Props
   min?: number;
   max?: number;
   step?: number;
+  forwardedRef?: React.RefObject<HTMLInputElement>;
 }
 
 interface State {
@@ -154,4 +157,10 @@ interface State {
   inputType: textFieldType;
 }
 
-export default TextField;
+const forwardRef = (props: Props, ref: React.RefObject<HTMLInputElement>) => (
+  <TextField {...props} forwardedRef={ref} />
+);
+
+forwardRef.displayName = TextField.name;
+
+export default React.forwardRef(forwardRef);

--- a/src/Input/Textarea/Textarea.test.tsx
+++ b/src/Input/Textarea/Textarea.test.tsx
@@ -115,3 +115,27 @@ describe('when removeFloatingLabel is true', () => {
     expect(textareaInput).toBeTruthy();
   });
 });
+
+describe('<Textarea /> forwards ref to underlying textarea element', () => {
+  const label = 'forward-ref';
+
+  test('ref is being forwarded correctly', () => {
+    const ref = React.createRef<HTMLTextAreaElement>();
+    const { queryByLabelText } = render(<Textarea ref={ref} label={label} />);
+    const textarea = queryByLabelText(label);
+    expect(textarea).toEqual(ref.current);
+  });
+
+  test('underlying textarea can be focused/blurred through ref', () => {
+    const ref = React.createRef<HTMLTextAreaElement>();
+    const { queryByLabelText } = render(<Textarea ref={ref} label={label} />);
+    const textarea = queryByLabelText(label);
+    expect(textarea).not.toHaveFocus();
+
+    ref.current.focus();
+    expect(textarea).toHaveFocus();
+
+    ref.current.blur();
+    expect(textarea).not.toHaveFocus();
+  });
+});

--- a/src/Input/Textarea/Textarea.tsx
+++ b/src/Input/Textarea/Textarea.tsx
@@ -22,7 +22,7 @@ class Textarea extends React.PureComponent<Props, State> {
 
   constructor(props: Props) {
     super(props);
-    this.textareaInputRef = React.createRef();
+    this.textareaInputRef = props.forwardedRef || React.createRef();
   }
 
   handleFocusChange = (
@@ -142,6 +142,7 @@ interface Props extends React.ComponentPropsWithoutRef<typeof TextareaInput> {
   onBlur?(): void;
   onChange?(e: React.ChangeEvent<HTMLTextAreaElement>): void;
   removeFloatingLabel?: boolean;
+  forwardedRef?: React.RefObject<HTMLTextAreaElement>;
 }
 
 interface State {
@@ -152,4 +153,11 @@ interface State {
   textareaMaxHeight: number;
 }
 
-export default Textarea;
+const forwardRef = (
+  props: Props,
+  ref: React.RefObject<HTMLTextAreaElement>
+) => <Textarea {...props} forwardedRef={ref} />;
+
+forwardRef.displayName = Textarea.name;
+
+export default React.forwardRef(forwardRef);


### PR DESCRIPTION
this PR implements issue #218 

wrap Textarea and TextField in `forwardRef` to let a `ref` prop can be directly passed to the underlying `textarea` and `input` element.