### PR TITLE
added SSR support

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -30,5 +30,11 @@ module.exports = {
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-proposal-object-rest-spread',
     '@babel/plugin-syntax-dynamic-import',
+    [
+      'babel-plugin-styled-components',
+      {
+        ssr: true,
+      },
+    ],
   ],
 };

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@types/styled-components": "^4.1.15",
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.6",
+    "babel-plugin-styled-components": "^1.10.7",
     "create-index": "^2.4.0",
     "cross-env": "^6.0.3",
     "eslint": "^5.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3020,6 +3020,16 @@ babel-plugin-react-docgen@^2.0.2:
     babel-plugin-syntax-jsx "^6.18.0"
     lodash "^4.17.10"
 
+babel-plugin-styled-components@^1.10.7:
+  version "1.10.7"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.7.tgz#3494e77914e9989b33cc2d7b3b29527a949d635c"
+  integrity sha512-MBMHGcIA22996n9hZRf/UJLVVgkEOITuR2SvjHLb5dSTUyR4ZRGn+ngITapes36FI3WLxZHfRhkA1ffHxihOrg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.11"
+
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"


### PR DESCRIPTION
Some `aries` components are failing the re-hydration process and produce a react warning: `className` mismatch between server and client. This PR adds the plugin `babel-plugin-styled-components` to `.babelrc` to fix this problem. Tested on local build.

https://styled-components.com/docs/tooling#serverside-rendering