### PR TITLE
Render Button as Configurable Tag

### DIFF
--- a/src/General/Button/Button.test.tsx
+++ b/src/General/Button/Button.test.tsx
@@ -15,6 +15,25 @@ it('<Button> should render with text "click me" and an onClick handler', () => {
   expect(ButtonSnapshot).toMatchSnapshot();
 });
 
+it('<Button> should render as button by default', () => {
+  const tag = 'a';
+  const { container } = render(<Button tag={tag}>test</Button>);
+  expect(container.querySelector(tag)).toBeTruthy();
+});
+
+describe('<Button> should render as the given tag', () => {
+  const tags = ['a', 'h1', 'div'];
+  tags.forEach((tag: string) => {
+    it(`<Button> should render as ${tag}`, () => {
+      const { container } = render(
+        <Button tag={tag as React.ElementType}>button</Button>
+      );
+      const tagRegexp = new RegExp(tag, 'i');
+      expect(container.querySelector(tag).tagName).toMatch(tagRegexp);
+    });
+  });
+});
+
 it('should call onClick once when it is clicked', () => {
   const onClick = jest.fn();
   const { getByText } = render(<Button onClick={onClick}>click me</Button>);

--- a/src/General/Button/Button.test.tsx
+++ b/src/General/Button/Button.test.tsx
@@ -16,9 +16,10 @@ it('<Button> should render with text "click me" and an onClick handler', () => {
 });
 
 it('<Button> should render as button by default', () => {
-  const tag = 'a';
-  const { container } = render(<Button tag={tag}>test</Button>);
-  expect(container.querySelector(tag)).toBeTruthy();
+  const { getByTestId } = render(
+    <Button data-testid="test-button">test</Button>
+  );
+  expect(getByTestId('test-button').tagName).toBe('BUTTON');
 });
 
 describe('<Button> should render as the given tag', () => {

--- a/src/General/Button/Button.tsx
+++ b/src/General/Button/Button.tsx
@@ -108,6 +108,7 @@ export interface Props {
   small?: boolean;
   theme?: string;
   variant?: string;
+  tag?: React.ElementType;
 }
 
 export default Button;

--- a/src/General/Button/DefaultButton.tsx
+++ b/src/General/Button/DefaultButton.tsx
@@ -13,6 +13,7 @@ const DefaultButton: React.FunctionComponent<Props> = ({
   block,
   small,
   removeHoverEffect,
+  tag,
   ...defaultProps
 }) => (
   <DefaultBtnContainer
@@ -28,6 +29,7 @@ const DefaultButton: React.FunctionComponent<Props> = ({
       disabled={disabled}
       block={block}
       small={small}
+      as={(tag as React.ElementType) || 'button'}
       {...defaultProps}
     >
       {children}
@@ -43,6 +45,7 @@ interface Props extends React.ComponentPropsWithoutRef<typeof DefaultBtn> {
   block?: boolean;
   small?: boolean;
   removeHoverEffect?: boolean;
+  tag?: React.ElementType;
 }
 
 export default DefaultButton;

--- a/src/General/Button/GhostButton.tsx
+++ b/src/General/Button/GhostButton.tsx
@@ -10,6 +10,7 @@ const GhostButton: React.FunctionComponent<Props> = ({
   block,
   small,
   removeHoverEffect,
+  tag,
   ...defaultProps
 }) => (
   <GhostBtnContainer
@@ -25,6 +26,7 @@ const GhostButton: React.FunctionComponent<Props> = ({
       disabled={disabled}
       block={block}
       small={small}
+      as={(tag as React.ElementType) || 'button'}
       {...defaultProps}
     >
       {children}
@@ -40,6 +42,7 @@ interface Props extends React.ComponentPropsWithoutRef<typeof GhostBtn> {
   block?: boolean;
   small?: boolean;
   removeHoverEffect?: boolean;
+  tag?: React.ElementType;
 }
 
 export default GhostButton;

--- a/src/General/Button/LinkButton.tsx
+++ b/src/General/Button/LinkButton.tsx
@@ -6,9 +6,14 @@ import { LinkBtn } from '../../Style/General/ButtonStyle';
 const LinkButton: React.FunctionComponent<Props> = ({
   children,
   className,
+  tag,
   ...defaultProps
 }) => (
-  <LinkBtn className={classNames('aries-linkbtn', className)} {...defaultProps}>
+  <LinkBtn
+    className={classNames('aries-linkbtn', className)}
+    as={(tag as React.ElementType) || 'button'}
+    {...defaultProps}
+  >
     {children}
   </LinkBtn>
 );
@@ -17,6 +22,7 @@ interface Props extends React.ComponentPropsWithoutRef<typeof LinkBtn> {
   children: React.ReactNode;
   className: string;
   block?: boolean;
+  tag?: React.ElementType;
 }
 
 export default LinkButton;

--- a/src/General/Button/PrimaryButton.tsx
+++ b/src/General/Button/PrimaryButton.tsx
@@ -9,6 +9,7 @@ const PrimaryButton: React.FunctionComponent<Props> = ({
   disabled,
   block,
   small,
+  tag,
   ...defaultProps
 }) => (
   <PrimaryContainer
@@ -23,6 +24,7 @@ const PrimaryButton: React.FunctionComponent<Props> = ({
       disabled={disabled}
       block={block}
       small={small}
+      as={(tag as React.ElementType) || 'button'}
       {...defaultProps}
     >
       {children}
@@ -38,6 +40,7 @@ interface Props extends React.ComponentPropsWithoutRef<typeof PrimaryBtn> {
   block?: boolean;
   small?: boolean;
   removeHoverEffect?: boolean;
+  tag?: React.ElementType;
 }
 
 export default PrimaryButton;

--- a/src/General/Button/SecondaryButton.tsx
+++ b/src/General/Button/SecondaryButton.tsx
@@ -11,6 +11,7 @@ const SecondaryButton: React.FunctionComponent<Props> = ({
   block,
   small,
   disabled,
+  tag,
   ...defaultProps
 }) => (
   <SecondaryContainer
@@ -23,6 +24,7 @@ const SecondaryButton: React.FunctionComponent<Props> = ({
       block={block}
       small={small}
       disabled={disabled}
+      as={(tag as React.ElementType) || 'button'}
       {...defaultProps}
     >
       {children}
@@ -36,6 +38,7 @@ interface Props extends React.ComponentPropsWithoutRef<typeof SecondaryBtn> {
   block?: boolean;
   small?: boolean;
   disabled?: boolean;
+  tag?: React.ElementType;
 }
 
 export default SecondaryButton;

--- a/src/General/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/General/Button/__snapshots__/Button.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<Button> should render with text "click me" and an onClick handler 1`] 
   className="aries-defaultbtn ButtonStyle__DefaultBtnContainer-gw4ytw-2 jOFFLF"
 >
   <button
-    className="ButtonStyle__Button-gw4ytw-0 defaultbtn-content ButtonStyle__DefaultBtn-gw4ytw-1 eGboJv"
+    className="ButtonStyle__Button-gw4ytw-0 defaultbtn-content ButtonStyle__DefaultBtn-gw4ytw-1 biANeV"
     onClick={[MockFunction]}
   >
     click me

--- a/src/Input/SearchFilter/__snapshots__/SearchFilter.test.tsx.snap
+++ b/src/Input/SearchFilter/__snapshots__/SearchFilter.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`<SearchFilter> should render with an input with a button, and a list wi
       className="aries-defaultbtn SearchFilterStyle__SearchFilterButton-b75szs-2 gluDQb ButtonStyle__DefaultBtnContainer-gw4ytw-2 jOFFLF"
     >
       <button
-        className="ButtonStyle__Button-gw4ytw-0 defaultbtn-content ButtonStyle__DefaultBtn-gw4ytw-1 bJjOgz"
+        className="ButtonStyle__Button-gw4ytw-0 defaultbtn-content ButtonStyle__DefaultBtn-gw4ytw-1 dMpybm"
       >
         Search
       </button>

--- a/src/Style/General/ButtonStyle.ts
+++ b/src/Style/General/ButtonStyle.ts
@@ -27,6 +27,7 @@ const Button = styled.button<ButtonProps>`
       : `${generalButtonPadding[0]}px ${generalButtonPadding[1]}px`};
   background: transparent;
   transition: all 0.2s;
+  text-decoration: none;
 `;
 
 /*
@@ -92,6 +93,7 @@ export const DefaultBtn = styled(Button) <DefaultBtnProps>`
   }}
 
   &:hover {
+    text-decoration: none;
     ${({ disabled }) => {
     if (disabled) {
       return `
@@ -192,6 +194,10 @@ export const PrimaryBtn = styled(Button) <PrimaryBtnProps>`
   cursor: pointer;
   position: relative;
   width: 100%;
+
+  &:hover {
+    text-decoration: none;
+  }
 
   ${props => {
     if (props.disabled) {
@@ -355,6 +361,10 @@ export const SecondaryBtn = styled(Button) <SecondaryBtnProps>`
   z-index: 2;
   width: ${({ block }) => block && '100%'};
 
+  &:hover {
+    text-decoration: none;
+  }
+
   ${({ disabled }) => {
     if (disabled) {
       return `
@@ -478,6 +488,7 @@ export const GhostBtn = styled(Button) <GhostBtnProps>`
 
   &:hover {
     transition: background-color 0.5s;
+    text-decoration: none;
 
     ${({ disabled, theme }) => {
     if (!disabled) {
@@ -605,6 +616,7 @@ export const LinkBtn = styled(Button) <LinkBtnProps>`
 
   &:hover {
     color: ${SecondaryColor.darkblue};
+    text-decoration: none;
   }
 
   &:active {

--- a/src/Style/General/ButtonStyle.ts
+++ b/src/Style/General/ButtonStyle.ts
@@ -43,7 +43,7 @@ interface DefaultBtnProps {
   block?: boolean;
 }
 
-export const DefaultBtn = styled(Button)<DefaultBtnProps>`
+export const DefaultBtn = styled(Button) <DefaultBtnProps>`
   width: ${({ block }) => block && '100%'};
 
   &:active {
@@ -93,13 +93,13 @@ export const DefaultBtn = styled(Button)<DefaultBtnProps>`
 
   &:hover {
     ${({ disabled }) => {
-      if (disabled) {
-        return `
+    if (disabled) {
+      return `
           background-color: ${SecondaryColor.lightgrey};
           color: ${SecondaryColor.white};
         `;
-      }
-    }}
+    }
+  }}
   }
 `;
 
@@ -148,28 +148,28 @@ export const DefaultBtnContainer = styled.div<DefaultBtnContainerProps>`
   &:hover {
     ${DefaultBtn} {
       ${props => {
-        if (props.disabled) {
-          return `
+    if (props.disabled) {
+      return `
             background-color: none;
           `;
-        }
-      }}
+    }
+  }}
     }
   }
 
   &:active {
     ${DefaultBtn} {
       ${props => {
-        if (props.disabled) {
-          return `
+    if (props.disabled) {
+      return `
             background-color: none;
           `;
-        }
-        return `
+    }
+    return `
           background-color: ${SecondaryColor.black};
           color: ${SecondaryColor.white};
         `;
-      }}
+  }}
     }
   }
 `;
@@ -187,7 +187,7 @@ interface PrimaryBtnProps {
   block?: boolean;
 }
 
-export const PrimaryBtn = styled(Button)<PrimaryBtnProps>`
+export const PrimaryBtn = styled(Button) <PrimaryBtnProps>`
   transition: all 0.2s;
   cursor: pointer;
   position: relative;
@@ -243,41 +243,41 @@ export const PrimaryContainer = styled.div<PrimaryContainerProps>`
 
   &:hover {
     ${props => {
-      if (props.disabled) {
-        return 'transform: none';
-      }
-      return `
+    if (props.disabled) {
+      return 'transform: none';
+    }
+    return `
       transform: translate(2px, 2px);
       transition: all .2s;
     `;
-    }}
+  }}
   }
 
   &:active {
     ${props => {
-      if (!props.disabled) {
-        return `
+    if (!props.disabled) {
+      return `
         transform: translate(4px, 4px);
         transition: all .2s;
         color: ${SecondaryColor.white};
       `;
-      }
+    }
 
-      return 'transform: none';
-    }}
+    return 'transform: none';
+  }}
 
     ${PrimaryBtn} {
       ${props => {
-        if (props.disabled) {
-          return `
+    if (props.disabled) {
+      return `
             background-color: none;
           `;
-        }
-        return `
+    }
+    return `
           background-color: ${SecondaryColor.black};
           color: ${SecondaryColor.white};
         `;
-      }}
+  }}
     }
   }
 
@@ -291,47 +291,47 @@ export const PrimaryContainer = styled.div<PrimaryContainerProps>`
     transition: all 0.2s;
 
     ${props => {
-      const themeBackgrounds = {
-        [Theme.BLUE_RED]: PrimaryColor.glintsred,
-        [Theme.YELLOW]: PrimaryColor.glintsred,
-      };
-      if (props.disabled) {
-        return 'background-color: none';
-      }
-      if (props.theme && themeBackgrounds[props.theme]) {
-        return `background-color: ${themeBackgrounds[props.theme]};`;
-      }
-      return `background-color: ${PrimaryColor.glintsyellow};`;
-    }}
+    const themeBackgrounds = {
+      [Theme.BLUE_RED]: PrimaryColor.glintsred,
+      [Theme.YELLOW]: PrimaryColor.glintsred,
+    };
+    if (props.disabled) {
+      return 'background-color: none';
+    }
+    if (props.theme && themeBackgrounds[props.theme]) {
+      return `background-color: ${themeBackgrounds[props.theme]};`;
+    }
+    return `background-color: ${PrimaryColor.glintsyellow};`;
+  }}
   }
 
   &:hover:before {
     ${props => {
-      if (props.disabled) {
-        return `
+    if (props.disabled) {
+      return `
           cursor: default;
           background-color: none;
         `;
-      }
-      return `
+    }
+    return `
       background: ${SecondaryColor.black};
       transform: translate(-4px, -4px);
       transition: all .2s;
     `;
-    }}
+  }}
   }
 
   &:active:before {
     ${props => {
-      if (!props.disabled) {
-        return `
+    if (!props.disabled) {
+      return `
         transform: translate(-8px, -8px);
         transition: all .2s;
       `;
-      }
+    }
 
-      return false;
-    }}
+    return false;
+  }}
   }
 `;
 
@@ -349,7 +349,7 @@ const Bouncing = keyframes`
   }
 `;
 
-export const SecondaryBtn = styled(Button)<SecondaryBtnProps>`
+export const SecondaryBtn = styled(Button) <SecondaryBtnProps>`
   background-color: ${SecondaryColor.whitesmoke};
   color: ${SecondaryColor.black};
   z-index: 2;
@@ -392,14 +392,14 @@ export const SecondaryContainer = styled.div<SecondaryContainerProps>`
   &:hover {
     ${SecondaryBtn} {
       ${({ disabled }) => {
-        if (!disabled) {
-          return `
+    if (!disabled) {
+      return `
           background-color: ${PrimaryColor.glintsyellow};
           transform: translate3d(-4px, -4px, 0);
           transition: transform .2s;
         `;
-        }
-      }}
+    }
+  }}
     }
   }
 
@@ -440,7 +440,7 @@ interface SecondaryContainerProps {
  * Ghost Button
  */
 
-export const GhostBtn = styled(Button)<GhostBtnProps>`
+export const GhostBtn = styled(Button) <GhostBtnProps>`
   transition: background-color 0.5s;
   width: ${({ block }) => block && '100%'};
   background: ${SecondaryColor.white};
@@ -480,33 +480,33 @@ export const GhostBtn = styled(Button)<GhostBtnProps>`
     transition: background-color 0.5s;
 
     ${({ disabled, theme }) => {
-      if (!disabled) {
-        switch (theme) {
-          case `${Theme.RED}`:
-            return `
+    if (!disabled) {
+      switch (theme) {
+        case `${Theme.RED}`:
+          return `
             background-color: ${PrimaryColor.glintsred};
             color: ${SecondaryColor.white};
           `;
-          case `${Theme.YELLOW}`:
-            return `
+        case `${Theme.YELLOW}`:
+          return `
             background-color: ${PrimaryColor.glintsyellow};
             color: ${SecondaryColor.white};
           `;
-          case `${Theme.BLUE}`:
-            return `
+        case `${Theme.BLUE}`:
+          return `
             background-color: ${SecondaryColor.actionblue};
             color: ${SecondaryColor.white};
           `;
-          case `${Theme.WHITE}`:
-            return `
+        case `${Theme.WHITE}`:
+          return `
             background-color: ${SecondaryColor.white};
             color: ${PrimaryColor.glintsblue};
           `;
-          default:
-            return null;
-        }
+        default:
+          return null;
       }
-    }}
+    }
+  }}
   }
 
   ${({ disabled }) => {
@@ -568,16 +568,16 @@ export const GhostBtnContainer = styled.div<GhostBtnContainerProps>`
 
   ${GhostBtn} {
     ${({ disabled }) => {
-      if (!disabled) {
-        return `
+    if (!disabled) {
+      return `
         &:active {
           background-color: ${SecondaryColor.black};
           color: ${SecondaryColor.white};
           border: 2px solid ${SecondaryColor.black};
         }
       `;
-      }
-    }}
+    }
+  }}
   }
 `;
 
@@ -591,7 +591,7 @@ interface GhostBtnContainerProps {
  * Link Button
  */
 
-export const LinkBtn = styled(Button)<LinkBtnProps>`
+export const LinkBtn = styled(Button) <LinkBtnProps>`
   font-weight: normal;
   text-transform: inherit;
   width: ${({ block }) => block && '100%'};

--- a/stories/General/ButtonStory.tsx
+++ b/stories/General/ButtonStory.tsx
@@ -44,6 +44,14 @@ const buttonProps = [
     require: 'no',
     description: 'Sets Button to small version.',
   },
+  {
+    name: 'tag',
+    type: 'React.ElementType',
+    defaultValue: <code>button</code>,
+    possibleValue: 'any valid html tag e.g. "a"',
+    require: 'no',
+    description: 'Changes the tag with which the button will render.',
+  },
 ];
 
 const removeHoverEffectProp = {

--- a/stories/General/ButtonStory.tsx
+++ b/stories/General/ButtonStory.tsx
@@ -125,6 +125,8 @@ const ButtonStories = () => (
     <Divider theme="grey" />
     <GhostButtonStory />
     <Divider theme="grey" />
+    <TagButtonStory />
+    <Divider theme="grey" />
     <LinkButtonStory />
   </React.Fragment>
 );
@@ -303,6 +305,32 @@ const GhostButtonStory = () => (
         onClick={action('Ghost Button')}
       >
         Ghost
+      </Button>
+    </div>
+  </StorybookComponent>
+);
+
+const TagButtonStory = () => (
+  <StorybookComponent
+    usage={`<Button
+  variant="ghost"
+  theme="blue"
+  tag="a"
+>
+  Ghost
+</Button>`}
+  >
+    <div style={{ marginBottom: '2em' }}>
+      <Heading style={{ fontSize: '20px', marginBottom: '1em' }}>
+        Ghost Button with Different Tag
+      </Heading>
+      <Button
+        variant={Variant.GHOST}
+        theme={Theme.BLUE}
+        onClick={action('Tag Button')}
+        tag="a"
+      >
+        Ghost Button as Anchor
       </Button>
     </div>
   </StorybookComponent>


### PR DESCRIPTION
Adds a property 'tag' to all Button components. When specified, the button will render as the specified tag. I chose the name 'tag" because react-intl uses the same name.

Closes #83 