### PR TITLE
Tabs.Pane and Dropdown.Item: Add the classname property to these components

### DIFF
--- a/src/Display/Tabs/TabPane.tsx
+++ b/src/Display/Tabs/TabPane.tsx
@@ -17,6 +17,7 @@ export interface Props
   children: React.ReactNode;
   tab?: string;
   label?: string | number;
+  tabClassName?: string;
 }
 
 export default TabPane;

--- a/src/Display/Tabs/Tabs.tsx
+++ b/src/Display/Tabs/Tabs.tsx
@@ -53,13 +53,15 @@ const Tabs: Tabs = ({
             children,
             (data: React.ReactElement<TabPaneProps>, index) => {
               const tabLabel = data.props.label || index;
+              const tabClassName = data.props.tabClassName || '';
               return (
                 <li
                   className={classNames(
                     `tab-${tabLabel}`,
                     { active: activeTabOrIndex === tabLabel },
                     `${alignment}-tab`,
-                    `${variant}`
+                    `${variant}`,
+                    `${tabClassName}`
                   )}
                   key={data.props.tab}
                   role="tab"

--- a/src/Navigation/Dropdown/Dropdown.tsx
+++ b/src/Navigation/Dropdown/Dropdown.tsx
@@ -211,20 +211,26 @@ class Dropdown extends React.Component<Props, State> {
           >
             {React.Children.map(
               children,
-              (item: React.ReactElement<DropdownItemProps>, index) => (
-                <DropdownItemWrapper
-                  className={classNames({ active: cursor === index })}
-                  role="option"
-                  data-value={item.props.value}
-                  key={item.key}
-                  onMouseDown={this.handleClickItem(item.props.onClick)}
-                  onMouseEnter={() => this.handleMouseEnter(index)}
-                  tabIndex={0}
-                  showFullWidth={showFullWidth}
-                >
-                  {item.props.children}
-                </DropdownItemWrapper>
-              )
+              (item: React.ReactElement<DropdownItemProps>, index) => {
+                const dropDownItemClassName = item.props.className || '';
+                return (
+                  <DropdownItemWrapper
+                    className={classNames(
+                      {active: cursor === index},
+                      `${dropDownItemClassName}`
+                    )}
+                    role="option"
+                    data-value={item.props.value}
+                    key={item.key}
+                    onMouseDown={this.handleClickItem(item.props.onClick)}
+                    onMouseEnter={() => this.handleMouseEnter(index)}
+                    tabIndex={0}
+                    showFullWidth={showFullWidth}
+                  >
+                    {item.props.children}
+                  </DropdownItemWrapper>
+                );
+              }
             )}
           </DropdownBody>
         </DropdownWrapper>


### PR DESCRIPTION
Fixes: #232 

For the following components, on adding className="class-name" the property wasn't set and the style couldn't be manipulated through it:
1. Tabs.Pane
2. Dropdown.Item