### PR TITLE
Convert TextField to functional component

### DIFF
--- a/src/Input/NumberInput/__snapshots__/NumberInput.test.tsx.snap
+++ b/src/Input/NumberInput/__snapshots__/NumberInput.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`<NumberInput> should render correctly to match snapshot 1`] = `
   <input
     aria-label="Number"
     className="TextFieldStyle__TextFieldInput-snd1vr-2 jTGFNv"
-    onBlur={[Function]}
     onKeyDown={[Function]}
     type="number"
   />

--- a/src/Input/TextField/TextField.test.tsx
+++ b/src/Input/TextField/TextField.test.tsx
@@ -5,7 +5,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import TextField, { textFieldType, isEmpty } from './TextField';
+import TextField, { textFieldType, isFilled } from './TextField';
 import { SecondaryColor, PrimaryColor } from '../../Style/Colors';
 
 const props = {
@@ -183,10 +183,10 @@ describe('<TextField /> forwards ref to underlying input element', () => {
 });
 
 describe('when an empty value is passed to', () => {
-  test('isEmpty, it should return true', () => {
+  test('isFilled, it should return false', () => {
     inputTypes.forEach(type => {
       emptyValueArray.forEach(emptyValue => {
-        expect(isEmpty(type, emptyValue)).toBe(true);
+        expect(isFilled(type, emptyValue)).toBe(false);
       });
     });
   });
@@ -212,11 +212,11 @@ describe('when an empty value is passed to', () => {
 });
 
 describe('when a non-empty value is passed to', () => {
-  test('isEmpty, it should return false', () => {
+  test('isFilled, it should return true', () => {
     inputTypes.forEach(type => {
       const valueArray = valueArrayMap[type];
       valueArray.forEach((value: any) => {
-        expect(isEmpty(type, value)).toBe(false);
+        expect(isFilled(type, value)).toBe(true);
       });
     });
   });

--- a/src/Input/TextField/TextField.test.tsx
+++ b/src/Input/TextField/TextField.test.tsx
@@ -5,7 +5,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import TextField, { textFieldType } from './TextField';
+import TextField, { textFieldType, isEmpty } from './TextField';
 import { SecondaryColor, PrimaryColor } from '../../Style/Colors';
 
 const props = {
@@ -15,6 +15,13 @@ const props = {
 };
 
 const inputValue = 'glintsaries';
+const inputTypes: textFieldType[] = ['text', 'password', 'number'];
+const emptyValueArray = [undefined, ''];
+const valueArrayMap = {
+  text: [inputValue, ' '],
+  password: [inputValue, ' '],
+  number: [0, 123],
+};
 
 function setupTextField(otherProps?: any) {
   const { getByLabelText, ...utils } = render(
@@ -172,5 +179,100 @@ describe('<TextField /> forwards ref to underlying input element', () => {
 
     ref.current.blur();
     expect(textInput).not.toHaveFocus();
+  });
+});
+
+describe('when an empty value is passed to', () => {
+  test('isEmpty, it should return true', () => {
+    inputTypes.forEach(type => {
+      emptyValueArray.forEach(emptyValue => {
+        expect(isEmpty(type, emptyValue)).toBe(true);
+      });
+    });
+  });
+
+  test('value prop, label should not be floating', () => {
+    inputTypes.forEach(type => {
+      emptyValueArray.forEach((emptyValue, index) => {
+        const { getAllByTestId } = render(
+          <TextField
+            value={emptyValue}
+            label="label"
+            type={type}
+            onChange={jest.fn()}
+          />
+        );
+        const textFieldLabel = getAllByTestId('textfield-label')[index];
+        expect(textFieldLabel).not.toHaveStyle(
+          `color: ${SecondaryColor.black}`
+        );
+      });
+    });
+  });
+
+  test('defaultValue prop, label should not be floating', () => {
+    inputTypes.forEach(type => {
+      emptyValueArray.forEach((emptyValue, index) => {
+        const { getAllByTestId } = render(
+          <TextField
+            defaultValue={emptyValue}
+            label="label"
+            type={type}
+            onChange={jest.fn()}
+          />
+        );
+        const textFieldLabel = getAllByTestId('textfield-label')[index];
+        expect(textFieldLabel).not.toHaveStyle(
+          `color: ${SecondaryColor.black}`
+        );
+      });
+    });
+  });
+});
+
+describe('when a non-empty value is passed to', () => {
+  test('isEmpty, it should return false', () => {
+    inputTypes.forEach(type => {
+      const valueArray = valueArrayMap[type];
+      valueArray.forEach((value: any) => {
+        expect(isEmpty(type, value)).toBe(false);
+      });
+    });
+  });
+
+  test('value prop, label should be floating', () => {
+    inputTypes.forEach(type => {
+      const valueArray = valueArrayMap[type];
+      valueArray.forEach((value: any, index: number) => {
+        const { getAllByTestId } = render(
+          <TextField
+            value={value}
+            label="label"
+            type={type}
+            onChange={jest.fn()}
+          />
+        );
+        const textFieldLabel = getAllByTestId('textfield-label')[index];
+        expect(textFieldLabel).toHaveStyle(`color: ${SecondaryColor.black}`);
+      });
+    });
+  });
+
+  test('defaultValue prop, label should be floating', () => {
+    inputTypes.forEach(type => {
+      const valueArray = valueArrayMap[type];
+      valueArray.forEach((value: any, index: number) => {
+        const { getAllByTestId } = render(
+          <TextField
+            defaultValue={value}
+            label="label"
+            type={type}
+            onChange={jest.fn()}
+          />
+        );
+        const textFieldLabel = getAllByTestId('textfield-label')[index];
+        expect(textFieldLabel).toHaveStyle(`color: ${SecondaryColor.black}`);
+      });
+    });
   });
 });

--- a/src/Input/TextField/TextField.test.tsx
+++ b/src/Input/TextField/TextField.test.tsx
@@ -209,25 +209,6 @@ describe('when an empty value is passed to', () => {
       });
     });
   });
-
-  test('defaultValue prop, label should not be floating', () => {
-    inputTypes.forEach(type => {
-      emptyValueArray.forEach((emptyValue, index) => {
-        const { getAllByTestId } = render(
-          <TextField
-            defaultValue={emptyValue}
-            label="label"
-            type={type}
-            onChange={jest.fn()}
-          />
-        );
-        const textFieldLabel = getAllByTestId('textfield-label')[index];
-        expect(textFieldLabel).not.toHaveStyle(
-          `color: ${SecondaryColor.black}`
-        );
-      });
-    });
-  });
 });
 
 describe('when a non-empty value is passed to', () => {
@@ -247,24 +228,6 @@ describe('when a non-empty value is passed to', () => {
         const { getAllByTestId } = render(
           <TextField
             value={value}
-            label="label"
-            type={type}
-            onChange={jest.fn()}
-          />
-        );
-        const textFieldLabel = getAllByTestId('textfield-label')[index];
-        expect(textFieldLabel).toHaveStyle(`color: ${SecondaryColor.black}`);
-      });
-    });
-  });
-
-  test('defaultValue prop, label should be floating', () => {
-    inputTypes.forEach(type => {
-      const valueArray = valueArrayMap[type];
-      valueArray.forEach((value: any, index: number) => {
-        const { getAllByTestId } = render(
-          <TextField
-            defaultValue={value}
             label="label"
             type={type}
             onChange={jest.fn()}

--- a/src/Input/TextField/TextField.tsx
+++ b/src/Input/TextField/TextField.tsx
@@ -10,10 +10,10 @@ import {
   TextFieldLabel,
 } from '../../Style/Input/TextFieldStyle';
 
-export const isEmpty = (type: textFieldType, value: any) => {
-  if (value === undefined || value === null) return true;
-  if (type === 'number' && isNaN(value)) return true;
-  return value === '';
+export const isFilled = (type: textFieldType, value: any) => {
+  if (value === undefined || value === null) return false;
+  if (type === 'number') return !isNaN(parseInt(value));
+  return value !== '';
 };
 
 const TextField: React.FunctionComponent<Props> = props => {
@@ -53,7 +53,7 @@ const TextField: React.FunctionComponent<Props> = props => {
   );
 
   React.useEffect(() => {
-    setFloating(!isEmpty(inputType, value));
+    setFloating(isFilled(inputType, value));
   }, [setFloating, inputType, value]);
 
   return (

--- a/src/Input/TextField/TextField.tsx
+++ b/src/Input/TextField/TextField.tsx
@@ -19,7 +19,6 @@ export const isEmpty = (type: textFieldType, value: any) => {
 const TextField: React.FunctionComponent<Props> = props => {
   const {
     value,
-    defaultValue,
     status,
     onKeyDown,
     disableTyping,
@@ -54,9 +53,8 @@ const TextField: React.FunctionComponent<Props> = props => {
   );
 
   React.useEffect(() => {
-    const checkedValue = value === undefined ? defaultValue : value;
-    setFloating(!isEmpty(inputType, checkedValue));
-  }, [value, defaultValue, setFloating, inputType]);
+    setFloating(!isEmpty(inputType, value));
+  }, [setFloating, inputType, value]);
 
   return (
     <TextFieldContainer className={classNames('aries-textfield', className)}>

--- a/src/Input/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/src/Input/TextField/__snapshots__/TextField.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`<TextField> should render with a label of Username and type of text 1`]
   <input
     aria-label="Username"
     className="TextFieldStyle__TextFieldInput-snd1vr-2 jTGFNv"
-    onBlur={[Function]}
     onKeyDown={[Function]}
     type="text"
   />

--- a/stories/Input/TextFieldStory.tsx
+++ b/stories/Input/TextFieldStory.tsx
@@ -75,33 +75,50 @@ export const props = {
   ],
 };
 
-const TextFieldStory = () => (
-  <React.Fragment>
-    <StorybookComponent
-      title="Text Field"
-      code="import { TextField } from 'glints-aries'"
-      usage={'<TextField type="text" label="Username" />'}
-    >
-      <Heading style={{ fontSize: '20px', marginBottom: '1em' }}>Text</Heading>
-      <div style={{ width: '300px' }}>
-        <TextField type="text" label="Username" />
-      </div>
-    </StorybookComponent>
+const TextFieldStory = () => {
+  const [textValue, setTextValue] = React.useState('');
+  const [passwordValue, setPasswordValue] = React.useState('');
 
-    <Divider theme="grey" />
+  return (
+    <React.Fragment>
+      <StorybookComponent
+        title="Text Field"
+        code="import { TextField } from 'glints-aries'"
+        usage={'<TextField type="text" label="Username" />'}
+      >
+        <Heading style={{ fontSize: '20px', marginBottom: '1em' }}>
+          Text
+        </Heading>
+        <div style={{ width: '300px' }}>
+          <TextField
+            type="text"
+            label="Username"
+            value={textValue}
+            onChange={e => setTextValue(e.target.value)}
+          />
+        </div>
+      </StorybookComponent>
 
-    <StorybookComponent
-      propsObject={props}
-      usage={'<TextField type="password" label="Password" value="..." />'}
-    >
-      <Heading style={{ fontSize: '20px', marginBottom: '1em' }}>
-        Password
-      </Heading>
-      <div style={{ width: '300px' }}>
-        <TextField type="password" label="Password" />
-      </div>
-    </StorybookComponent>
-  </React.Fragment>
-);
+      <Divider theme="grey" />
+
+      <StorybookComponent
+        propsObject={props}
+        usage={'<TextField type="password" label="Password" value="..." />'}
+      >
+        <Heading style={{ fontSize: '20px', marginBottom: '1em' }}>
+          Password
+        </Heading>
+        <div style={{ width: '300px' }}>
+          <TextField
+            type="password"
+            label="Password"
+            value={passwordValue}
+            onChange={e => setPasswordValue(e.target.value)}
+          />
+        </div>
+      </StorybookComponent>
+    </React.Fragment>
+  );
+};
 
 export default TextFieldStory;


### PR DESCRIPTION
Issue: https://github.com/glints-dev/glints-aries/issues/239

This conversion also refactored the TextField to be a pure controlled component by removing the defaultValue prop. So before publishing this change, we should update all defaultValue to value of TextField in Marketplace and Employers projects.

For example:
```
// in app/components/GlintsJobSearchFilter/FilterOption/FilterSalary.js
<SalaryInput
    type="number"
    onChange={this.makeSalaryHandler(
    DATA_TYPE.maxSalary,
        this.props.setMaxSalary
    )}
    label="Maximum Salary"
    defaultValue={salaryFilter.maximum} // should update to value={salaryFilter.maximum}
/>
```
