### PR TITLE
Alert: correct close icon position

### DIFF
--- a/src/Style/General/AlertStyle.ts
+++ b/src/Style/General/AlertStyle.ts
@@ -102,6 +102,5 @@ export const AlertMessage = styled.p`
 `;
 
 export const AlertIcon = styled.div`
-  align-self: center;
   cursor: pointer;
 `;

--- a/src/Style/General/AlertStyle.ts
+++ b/src/Style/General/AlertStyle.ts
@@ -102,8 +102,6 @@ export const AlertMessage = styled.p`
 `;
 
 export const AlertIcon = styled.div`
-  height: 1em;
-  width: 1em;
   align-self: center;
   cursor: pointer;
 `;


### PR DESCRIPTION
The position of CloseIcon on Alert was wrong.

Before:
![image](https://user-images.githubusercontent.com/13249748/77282803-de4be000-6d05-11ea-9c26-798b5901698f.png)

After:
![image](https://user-images.githubusercontent.com/13249748/77282758-c2483e80-6d05-11ea-8660-e1a7440478b2.png)
