### PR TITLE
Github Actions: fix publish failed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '10.x'
+          registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: yarn install
       - name: Build


### PR DESCRIPTION
To fix: https://github.com/glints-dev/glints-aries/runs/585780317?check_suite_focus=true

According to https://help.github.com/en/actions/language-and-framework-guides/publishing-nodejs-packages#publishing-packages-to-the-npm-registry, we need to use `setup-node` action to create a `.npmrc` file on the runner.