### PR TITLE
Feature/fix button mismatch

### DIFF
--- a/src/General/Button/Button.tsx
+++ b/src/General/Button/Button.tsx
@@ -18,6 +18,8 @@ export const DeprecatedThemeMap = {
   [Variant.PRIMARY]: [Theme.RED, Theme.BLUE, Theme.BLUE_RED],
 };
 
+export const DeprecatedSecondayVariant = 'secondary';
+
 const renderButton: React.FunctionComponent<Props> = ({
   children,
   block,
@@ -61,7 +63,7 @@ const renderButton: React.FunctionComponent<Props> = ({
           {content}
         </PrimaryButton>
       );
-    case Variant.SECONDARY:
+    case DeprecatedSecondayVariant:
       console.warn(
         `Warning: Secondary Button is deprecated and will be removed in v5.\nPlease use the Primary Button instead.`
       );

--- a/src/General/Button/Button.tsx
+++ b/src/General/Button/Button.tsx
@@ -48,6 +48,9 @@ const renderButton: React.FunctionComponent<Props> = ({
         </PrimaryButton>
       );
     case Variant.SECONDARY:
+      console.warn(
+        `Warning: Secondary Button is deprecated and will be removed in v5.\nPlease use the Primary Button instead.`
+      );
       return (
         <SecondaryButton
           className={className}

--- a/src/General/Button/Button.tsx
+++ b/src/General/Button/Button.tsx
@@ -58,7 +58,6 @@ const renderButton: React.FunctionComponent<Props> = ({
           block={block}
           small={small}
           removeHoverEffect={removeHoverEffect}
-          theme={theme}
           {...defaultProps}
         >
           {children}

--- a/src/General/Button/Button.tsx
+++ b/src/General/Button/Button.tsx
@@ -8,6 +8,10 @@ import GhostButton from './GhostButton';
 import LinkButton from './LinkButton';
 
 import { Variant, Theme } from '../../Utils/StyleConfig';
+import {
+  StartIconContainer,
+  EndIconContainer,
+} from '../../Style/General/ButtonStyle';
 
 export const DeprecatedThemeMap = {
   [Variant.DEFAULT]: [Theme.RED, Theme.YELLOW],
@@ -24,8 +28,18 @@ const renderButton: React.FunctionComponent<Props> = ({
   small,
   theme,
   variant,
+  startIcon,
+  endIcon,
   ...defaultProps
 }) => {
+  const content = (
+    <>
+      {startIcon && <StartIconContainer>{startIcon}</StartIconContainer>}
+      {children}
+      {endIcon && <EndIconContainer>{endIcon}</EndIconContainer>}
+    </>
+  );
+
   switch (variant) {
     case Variant.PRIMARY:
       if (get(DeprecatedThemeMap, Variant.PRIMARY, []).includes(theme)) {
@@ -44,7 +58,7 @@ const renderButton: React.FunctionComponent<Props> = ({
           theme={theme}
           {...defaultProps}
         >
-          {children}
+          {content}
         </PrimaryButton>
       );
     case Variant.SECONDARY:
@@ -74,7 +88,7 @@ const renderButton: React.FunctionComponent<Props> = ({
           removeHoverEffect={removeHoverEffect}
           {...defaultProps}
         >
-          {children}
+          {content}
         </GhostButton>
       );
     case Variant.LINK:
@@ -106,7 +120,7 @@ const renderButton: React.FunctionComponent<Props> = ({
           removeHoverEffect={removeHoverEffect}
           {...defaultProps}
         >
-          {children}
+          {content}
         </DefaultButton>
       );
   }
@@ -127,6 +141,8 @@ export interface Props {
   theme?: string;
   variant?: string;
   tag?: React.ElementType;
+  startIcon?: React.ReactNode;
+  endIcon?: React.ReactNode;
 }
 
 export default Button;

--- a/src/General/Button/Button.tsx
+++ b/src/General/Button/Button.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { get } from 'lodash';
 
 import DefaultButton from './DefaultButton';
 import PrimaryButton from './PrimaryButton';
@@ -6,7 +7,12 @@ import SecondaryButton from './SecondaryButton';
 import GhostButton from './GhostButton';
 import LinkButton from './LinkButton';
 
-import { Variant } from '../../Utils/StyleConfig';
+import { Variant, Theme } from '../../Utils/StyleConfig';
+
+export const DeprecatedThemeMap = {
+  [Variant.DEFAULT]: [Theme.RED, Theme.YELLOW],
+  [Variant.PRIMARY]: [Theme.RED, Theme.BLUE, Theme.BLUE_RED],
+};
 
 const renderButton: React.FunctionComponent<Props> = ({
   children,
@@ -22,6 +28,11 @@ const renderButton: React.FunctionComponent<Props> = ({
 }) => {
   switch (variant) {
     case Variant.PRIMARY:
+      if (get(DeprecatedThemeMap, Variant.PRIMARY, []).includes(theme)) {
+        console.warn(
+          `Warning: Primary Button's theme prop is deprecated and will be removed in v5.`
+        );
+      }
       return (
         <PrimaryButton
           className={className}
@@ -76,6 +87,11 @@ const renderButton: React.FunctionComponent<Props> = ({
         </LinkButton>
       );
     default:
+      if (get(DeprecatedThemeMap, Variant.DEFAULT, []).includes(theme)) {
+        console.warn(
+          `Warning: Default Button's ${theme} theme is deprecated and will be removed in v5.\nPlease use another theme instead.`
+        );
+      }
       return (
         <DefaultButton
           theme={theme}

--- a/src/General/Button/Button.tsx
+++ b/src/General/Button/Button.tsx
@@ -56,7 +56,6 @@ const renderButton: React.FunctionComponent<Props> = ({
           onClick={onClick}
           block={block}
           small={small}
-          removeHoverEffect={removeHoverEffect}
           theme={theme}
           {...defaultProps}
         >

--- a/src/General/Button/PrimaryButton.tsx
+++ b/src/General/Button/PrimaryButton.tsx
@@ -39,7 +39,6 @@ interface Props extends React.ComponentPropsWithoutRef<typeof PrimaryBtn> {
   disabled?: boolean;
   block?: boolean;
   small?: boolean;
-  removeHoverEffect?: boolean;
   tag?: React.ElementType;
 }
 

--- a/src/General/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/General/Button/__snapshots__/Button.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<Button> should render with text "click me" and an onClick handler 1`] 
   className="ButtonStyle__DefaultBtnContainer-gw4ytw-2 jOFFLF aries-defaultbtn"
 >
   <button
-    className="ButtonStyle__Button-gw4ytw-0 ButtonStyle__DefaultBtn-gw4ytw-1 chTUsY defaultbtn-content"
+    className="ButtonStyle__Button-gw4ytw-0 ButtonStyle__DefaultBtn-gw4ytw-1 ixCkld defaultbtn-content"
     onClick={[MockFunction]}
   >
     click me

--- a/src/General/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/General/Button/__snapshots__/Button.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<Button> should render with text "click me" and an onClick handler 1`] 
   className="ButtonStyle__DefaultBtnContainer-gw4ytw-2 jOFFLF aries-defaultbtn"
 >
   <button
-    className="ButtonStyle__Button-gw4ytw-0 ButtonStyle__DefaultBtn-gw4ytw-1 biANeV defaultbtn-content"
+    className="ButtonStyle__Button-gw4ytw-0 ButtonStyle__DefaultBtn-gw4ytw-1 chTUsY defaultbtn-content"
     onClick={[MockFunction]}
   >
     click me

--- a/src/General/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/General/Button/__snapshots__/Button.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<Button> should render with text "click me" and an onClick handler 1`] 
   className="ButtonStyle__DefaultBtnContainer-gw4ytw-2 jOFFLF aries-defaultbtn"
 >
   <button
-    className="ButtonStyle__Button-gw4ytw-0 ButtonStyle__DefaultBtn-gw4ytw-1 ixCkld defaultbtn-content"
+    className="ButtonStyle__Button-gw4ytw-0 ButtonStyle__DefaultBtn-gw4ytw-1 byLBcK defaultbtn-content"
     onClick={[MockFunction]}
   >
     click me

--- a/src/General/Button/index.tsx
+++ b/src/General/Button/index.tsx
@@ -1,5 +1,8 @@
-import Button, { DeprecatedThemeMap } from './Button';
+import Button, {
+  DeprecatedThemeMap,
+  DeprecatedSecondayVariant,
+} from './Button';
 
-export { Button, DeprecatedThemeMap };
+export { Button, DeprecatedThemeMap, DeprecatedSecondayVariant };
 
 export default Button;

--- a/src/General/Button/index.tsx
+++ b/src/General/Button/index.tsx
@@ -1,5 +1,5 @@
-import Button from './Button';
+import Button, { DeprecatedThemeMap } from './Button';
 
-export { Button };
+export { Button, DeprecatedThemeMap };
 
 export default Button;

--- a/src/Input/SearchFilter/__snapshots__/SearchFilter.test.tsx.snap
+++ b/src/Input/SearchFilter/__snapshots__/SearchFilter.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`<SearchFilter> should render with an input with a button, and a list wi
       className="ButtonStyle__DefaultBtnContainer-gw4ytw-2 jOFFLF aries-defaultbtn SearchFilterStyle__SearchFilterButton-b75szs-2 gluDQb"
     >
       <button
-        className="ButtonStyle__Button-gw4ytw-0 ButtonStyle__DefaultBtn-gw4ytw-1 dMpybm defaultbtn-content"
+        className="ButtonStyle__Button-gw4ytw-0 ButtonStyle__DefaultBtn-gw4ytw-1 jqDZdK defaultbtn-content"
       >
         Search
       </button>

--- a/src/Input/SearchFilter/__snapshots__/SearchFilter.test.tsx.snap
+++ b/src/Input/SearchFilter/__snapshots__/SearchFilter.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`<SearchFilter> should render with an input with a button, and a list wi
       className="ButtonStyle__DefaultBtnContainer-gw4ytw-2 jOFFLF aries-defaultbtn SearchFilterStyle__SearchFilterButton-b75szs-2 gluDQb"
     >
       <button
-        className="ButtonStyle__Button-gw4ytw-0 ButtonStyle__DefaultBtn-gw4ytw-1 jqDZdK defaultbtn-content"
+        className="ButtonStyle__Button-gw4ytw-0 ButtonStyle__DefaultBtn-gw4ytw-1 efFgZq defaultbtn-content"
       >
         Search
       </button>

--- a/src/Style/General/ButtonStyle.ts
+++ b/src/Style/General/ButtonStyle.ts
@@ -19,7 +19,7 @@ const Button = styled.button<ButtonProps>`
   outline: none;
   cursor: pointer;
   font-weight: bold;
-  font-size: 1em;
+  font-size: ${({ small }) => (small ? '14px' : '16px')};
   line-height: 1.5;
   padding: ${({ small }) =>
     small

--- a/src/Style/General/ButtonStyle.ts
+++ b/src/Style/General/ButtonStyle.ts
@@ -216,9 +216,6 @@ export const PrimaryBtn = styled(Button)<PrimaryBtnProps>`
         background-color: ${PrimaryColor.glintsblue};
         color: ${SecondaryColor.white};
       `,
-      [Theme.YELLOW]: `
-        background-color: ${PrimaryColor.glintsyellow};
-      `,
     };
 
     if (props.theme && themeColors[props.theme]) {
@@ -226,12 +223,7 @@ export const PrimaryBtn = styled(Button)<PrimaryBtnProps>`
     }
 
     return `
-      background-color: ${SecondaryColor.white};
-      color: ${PrimaryColor.glintsblue};
-
-      &:active {
-        color: ${SecondaryColor.white};
-      }
+      background-color: ${PrimaryColor.glintsyellow};
     `;
   }}
 `;
@@ -294,7 +286,8 @@ export const PrimaryContainer = styled.div<PrimaryContainerProps>`
     ${props => {
       const themeBackgrounds = {
         [Theme.BLUE_RED]: PrimaryColor.glintsred,
-        [Theme.YELLOW]: PrimaryColor.glintsred,
+        [Theme.BLUE]: PrimaryColor.glintsyellow,
+        [Theme.RED]: PrimaryColor.glintsyellow,
       };
       if (props.disabled) {
         return 'background-color: none';
@@ -302,7 +295,7 @@ export const PrimaryContainer = styled.div<PrimaryContainerProps>`
       if (props.theme && themeBackgrounds[props.theme]) {
         return `background-color: ${themeBackgrounds[props.theme]};`;
       }
-      return `background-color: ${PrimaryColor.glintsyellow};`;
+      return `background-color: ${PrimaryColor.glintsred};`;
     }}
   }
 

--- a/src/Style/General/ButtonStyle.ts
+++ b/src/Style/General/ButtonStyle.ts
@@ -453,64 +453,19 @@ export const GhostBtn = styled(Button)<GhostBtnProps>`
     small
       ? `${smallButtonPadding[0] - 2}px ${smallButtonPadding[1] - 2}px`
       : `${generalButtonPadding[0] - 2}px ${generalButtonPadding[1] - 2}px`};
-
-  ${props => {
-    switch (props.theme) {
-      case `${Theme.RED}`:
-        return `
-          border: 2px solid ${PrimaryColor.glintsred};
-          color: ${PrimaryColor.glintsred};
-        `;
-      case `${Theme.YELLOW}`:
-        return `
-          border: 2px solid ${PrimaryColor.glintsyellow};
-          color: ${PrimaryColor.glintsyellow};
-        `;
-      case `${Theme.BLUE}`:
-        return `
-          border: 2px solid ${SecondaryColor.actionblue};
-          color: ${SecondaryColor.actionblue};
-        `;
-      case `${Theme.WHITE}`:
-        return `
-          border: 2px solid ${SecondaryColor.white};
-          color: ${SecondaryColor.white};
-        `;
-      default:
-        return null;
-    }
-  }}
+  border: 2px solid ${SecondaryColor.actionblue};
+  color: ${SecondaryColor.actionblue};
 
   &:hover {
     transition: background-color 0.5s;
     text-decoration: none;
 
-    ${({ disabled, theme }) => {
+    ${({ disabled }) => {
       if (!disabled) {
-        switch (theme) {
-          case `${Theme.RED}`:
-            return `
-            background-color: ${PrimaryColor.glintsred};
-            color: ${SecondaryColor.white};
-          `;
-          case `${Theme.YELLOW}`:
-            return `
-            background-color: ${PrimaryColor.glintsyellow};
-            color: ${SecondaryColor.white};
-          `;
-          case `${Theme.BLUE}`:
-            return `
-            background-color: ${SecondaryColor.actionblue};
-            color: ${SecondaryColor.white};
-          `;
-          case `${Theme.WHITE}`:
-            return `
-            background-color: ${SecondaryColor.white};
-            color: ${PrimaryColor.glintsblue};
-          `;
-          default:
-            return null;
-        }
+        return `
+          background-color: ${SecondaryColor.actionblue};
+          color: ${SecondaryColor.white};
+        `;
       }
     }}
   }

--- a/src/Style/General/ButtonStyle.ts
+++ b/src/Style/General/ButtonStyle.ts
@@ -58,21 +58,37 @@ export const DefaultBtn = styled(Button)<DefaultBtnProps>`
         return `
           background-color: ${PrimaryColor.glintsred};
           color: ${SecondaryColor.white};
+
+          &:hover {
+            color: ${SecondaryColor.white};
+          }
         `;
       case `${Theme.BLUE}`:
         return `
           background-color: ${SecondaryColor.actionblue};
           color: ${SecondaryColor.white};
+
+          &:hover {
+            color: ${SecondaryColor.white};
+          }
         `;
       case `${Theme.YELLOW}`:
         return `
           background-color: ${PrimaryColor.glintsyellow};
           color: ${SecondaryColor.black};
+
+          &:hover {
+            color: ${SecondaryColor.black};
+          }
         `;
       default:
         return `
           background-color: ${SecondaryColor.white};
           color: ${SecondaryColor.actionblue};
+
+          &:hover {
+            color: ${SecondaryColor.actionblue};
+          }
         `;
     }
   }}
@@ -224,6 +240,7 @@ export const PrimaryBtn = styled(Button)<PrimaryBtnProps>`
 
     return `
       background-color: ${PrimaryColor.glintsyellow};
+      color: ${SecondaryColor.black};
     `;
   }}
 `;

--- a/src/Style/General/ButtonStyle.ts
+++ b/src/Style/General/ButtonStyle.ts
@@ -72,12 +72,7 @@ export const DefaultBtn = styled(Button)<DefaultBtnProps>`
       default:
         return `
           background-color: ${SecondaryColor.white};
-          color: ${SecondaryColor.black};
-
-          &:active {
-            background-color: ${SecondaryColor.black};
-            color: ${SecondaryColor.white};
-          }
+          color: ${SecondaryColor.actionblue};
         `;
     }
   }}

--- a/src/Style/General/ButtonStyle.ts
+++ b/src/Style/General/ButtonStyle.ts
@@ -1,5 +1,5 @@
 import styled, { css, keyframes } from 'styled-components';
-import { PrimaryColor, SecondaryColor } from '../Colors';
+import { PrimaryColor, SecondaryColor, Greyscale } from '../Colors';
 import { Theme } from '../../Utils/StyleConfig';
 
 const generalButtonPadding = [15, 40];
@@ -48,8 +48,8 @@ export const DefaultBtn = styled(Button)<DefaultBtnProps>`
   width: ${({ block }) => block && '100%'};
 
   &:active {
-    background-color: ${SecondaryColor.black};
-    color: ${SecondaryColor.white};
+    background-color: ${Greyscale.black};
+    color: ${Greyscale.white};
   }
 
   ${props => {
@@ -57,33 +57,33 @@ export const DefaultBtn = styled(Button)<DefaultBtnProps>`
       case `${Theme.RED}`:
         return `
           background-color: ${PrimaryColor.glintsred};
-          color: ${SecondaryColor.white};
+          color: ${Greyscale.white};
 
           &:hover {
-            color: ${SecondaryColor.white};
+            color: ${Greyscale.white};
           }
         `;
       case `${Theme.BLUE}`:
         return `
           background-color: ${SecondaryColor.actionblue};
-          color: ${SecondaryColor.white};
+          color: ${Greyscale.white};
 
           &:hover {
-            color: ${SecondaryColor.white};
+            color: ${Greyscale.white};
           }
         `;
       case `${Theme.YELLOW}`:
         return `
           background-color: ${PrimaryColor.glintsyellow};
-          color: ${SecondaryColor.black};
+          color: ${Greyscale.black};
 
           &:hover {
-            color: ${SecondaryColor.black};
+            color: ${Greyscale.black};
           }
         `;
       default:
         return `
-          background-color: ${SecondaryColor.white};
+          background-color: ${Greyscale.white};
           color: ${SecondaryColor.actionblue};
 
           &:hover {
@@ -96,8 +96,8 @@ export const DefaultBtn = styled(Button)<DefaultBtnProps>`
   ${({ disabled }) => {
     if (disabled) {
       return `
-        background-color: ${SecondaryColor.lightgrey};
-        color: ${SecondaryColor.white};
+        background-color: ${Greyscale.lightgrey};
+        color: ${Greyscale.white};
         cursor: not-allowed;
       `;
     }
@@ -108,8 +108,8 @@ export const DefaultBtn = styled(Button)<DefaultBtnProps>`
     ${({ disabled }) => {
       if (disabled) {
         return `
-          background-color: ${SecondaryColor.lightgrey};
-          color: ${SecondaryColor.white};
+          background-color: ${Greyscale.lightgrey};
+          color: ${Greyscale.white};
         `;
       }
     }}
@@ -125,8 +125,8 @@ export const DefaultBtnContainer = styled.div<DefaultBtnContainerProps>`
     if (!disabled && !removeHoverEffect) {
       return `
       &:active {
-        background: ${SecondaryColor.black};
-        color: ${SecondaryColor.white};
+        background: ${Greyscale.black};
+        color: ${Greyscale.white};
         transform: translate3d(2px, 2px, 0);
         transition: all .2s;
       }
@@ -179,8 +179,8 @@ export const DefaultBtnContainer = styled.div<DefaultBtnContainerProps>`
           `;
         }
         return `
-          background-color: ${SecondaryColor.black};
-          color: ${SecondaryColor.white};
+          background-color: ${Greyscale.black};
+          color: ${Greyscale.white};
         `;
       }}
     }
@@ -214,23 +214,23 @@ export const PrimaryBtn = styled(Button)<PrimaryBtnProps>`
     if (props.disabled) {
       return `
         cursor: not-allowed;
-        background-color: ${SecondaryColor.lightgrey};
-        color: ${SecondaryColor.white};
+        background-color: ${Greyscale.lightgrey};
+        color: ${Greyscale.white};
       `;
     }
 
     const themeColors = {
       [Theme.RED]: `
         background-color: ${PrimaryColor.glintsred};
-        color: ${SecondaryColor.white};
+        color: ${Greyscale.white};
       `,
       [Theme.BLUE]: `
         background-color: ${PrimaryColor.glintsblue};
-        color: ${SecondaryColor.white};
+        color: ${Greyscale.white};
       `,
       [Theme.BLUE_RED]: `
         background-color: ${PrimaryColor.glintsblue};
-        color: ${SecondaryColor.white};
+        color: ${Greyscale.white};
       `,
     };
 
@@ -240,7 +240,7 @@ export const PrimaryBtn = styled(Button)<PrimaryBtnProps>`
 
     return `
       background-color: ${PrimaryColor.glintsyellow};
-      color: ${SecondaryColor.black};
+      color: ${Greyscale.black};
     `;
   }}
 `;
@@ -269,7 +269,7 @@ export const PrimaryContainer = styled.div<PrimaryContainerProps>`
         return `
         transform: translate(4px, 4px);
         transition: all .2s;
-        color: ${SecondaryColor.white};
+        color: ${Greyscale.white};
       `;
       }
 
@@ -284,8 +284,8 @@ export const PrimaryContainer = styled.div<PrimaryContainerProps>`
           `;
         }
         return `
-          background-color: ${SecondaryColor.black};
-          color: ${SecondaryColor.white};
+          background-color: ${Greyscale.black};
+          color: ${Greyscale.white};
         `;
       }}
     }
@@ -325,7 +325,7 @@ export const PrimaryContainer = styled.div<PrimaryContainerProps>`
         `;
       }
       return `
-      background: ${SecondaryColor.black};
+      background: ${Greyscale.black};
       transform: translate(-4px, -4px);
       transition: all .2s;
     `;
@@ -362,7 +362,7 @@ const Bouncing = keyframes`
 
 export const SecondaryBtn = styled(Button)<SecondaryBtnProps>`
   background-color: ${SecondaryColor.whitesmoke};
-  color: ${SecondaryColor.black};
+  color: ${Greyscale.black};
   z-index: 2;
   width: ${({ block }) => block && '100%'};
 
@@ -373,8 +373,8 @@ export const SecondaryBtn = styled(Button)<SecondaryBtnProps>`
   ${({ disabled }) => {
     if (disabled) {
       return `
-        background-color: ${SecondaryColor.lightgrey};
-        color: ${SecondaryColor.white};
+        background-color: ${Greyscale.lightgrey};
+        color: ${Greyscale.white};
         cursor: not-allowed;
       `;
     }
@@ -420,15 +420,15 @@ export const SecondaryContainer = styled.div<SecondaryContainerProps>`
 
   &:active {
     ${SecondaryBtn} {
-      background-color: ${SecondaryColor.black};
-      color: ${SecondaryColor.white};
+      background-color: ${Greyscale.black};
+      color: ${Greyscale.white};
       transition: all 0.2s;
       transform: translate3d(0, 0, 0);
     }
   }
 
   &:active:after {
-    background-color: ${SecondaryColor.black};
+    background-color: ${Greyscale.black};
     transform: translate3d(-6px, -6px, 0);
     transition: all 0.2s;
   }
@@ -458,7 +458,7 @@ interface SecondaryContainerProps {
 export const GhostBtn = styled(Button)<GhostBtnProps>`
   transition: background-color 0.5s;
   width: ${({ block }) => block && '100%'};
-  background: ${SecondaryColor.white};
+  background: ${Greyscale.white};
   padding: ${({ small }) =>
     small
       ? `${smallButtonPadding[0] - 2}px ${smallButtonPadding[1] - 2}px`
@@ -474,7 +474,7 @@ export const GhostBtn = styled(Button)<GhostBtnProps>`
       if (!disabled) {
         return `
           background-color: ${SecondaryColor.actionblue};
-          color: ${SecondaryColor.white};
+          color: ${Greyscale.white};
         `;
       }
     }}
@@ -542,9 +542,9 @@ export const GhostBtnContainer = styled.div<GhostBtnContainerProps>`
       if (!disabled) {
         return `
         &:active {
-          background-color: ${SecondaryColor.black};
-          color: ${SecondaryColor.white};
-          border: 2px solid ${SecondaryColor.black};
+          background-color: ${Greyscale.black};
+          color: ${Greyscale.white};
+          border: 2px solid ${Greyscale.black};
         }
       `;
       }
@@ -580,7 +580,7 @@ export const LinkBtn = styled(Button)<LinkBtnProps>`
   }
 
   &:active {
-    color: ${SecondaryColor.black};
+    color: ${Greyscale.black};
   }
 `;
 

--- a/src/Style/General/ButtonStyle.ts
+++ b/src/Style/General/ButtonStyle.ts
@@ -577,3 +577,13 @@ export const LinkBtn = styled(Button)<LinkBtnProps>`
 interface LinkBtnProps {
   block?: boolean;
 }
+
+export const StartIconContainer = styled.span`
+  display: inline-flex;
+  margin-right: 10px;
+`;
+
+export const EndIconContainer = styled.span`
+  display: inline-flex;
+  margin-left: 10px;
+`;

--- a/src/Utils/StyleConfig.ts
+++ b/src/Utils/StyleConfig.ts
@@ -16,6 +16,7 @@ export enum ETooltipPosition {
 }
 
 export const Variant = {
+  DEFAULT: 'default',
   PRIMARY: 'primary',
   SECONDARY: 'secondary',
   GHOST: 'ghost',

--- a/src/Utils/StyleConfig.ts
+++ b/src/Utils/StyleConfig.ts
@@ -1,3 +1,4 @@
+import { DeprecatedThemeMap } from './../General/Button/Button';
 export enum ETabAlignment {
   HORIZONTAL = 'horizontal',
   VERTICAL = 'vertical',
@@ -18,7 +19,6 @@ export enum ETooltipPosition {
 export const Variant = {
   DEFAULT: 'default',
   PRIMARY: 'primary',
-  SECONDARY: 'secondary',
   GHOST: 'ghost',
   LINK: 'link',
 };

--- a/stories/General/ButtonStory.tsx
+++ b/stories/General/ButtonStory.tsx
@@ -74,7 +74,7 @@ const defaultButtonProps = {
       name: 'theme',
       type: 'string',
       defaultValue: <code>white</code>,
-      possibleValue: <code>red | blue | yellow</code>,
+      possibleValue: <code>white | red | blue | yellow</code>,
       require: 'no',
       description: "Sets the Button's theme",
     },
@@ -88,7 +88,7 @@ const primaryButtonProps = {
     {
       name: 'theme',
       type: 'string',
-      defaultValue: <code>white</code>,
+      defaultValue: <code>yellow</code>,
       possibleValue: <code>red | blue | blue-red | yellow</code>,
       require: 'no',
       description: "Sets the Button's theme",
@@ -102,18 +102,7 @@ const secondaryButtonProps = {
 };
 
 const ghostButtonProps = {
-  'Ghost Button': [
-    {
-      name: 'theme',
-      type: 'string',
-      defaultValue: <code>white</code>,
-      possibleValue: <code>red | blue | yellow | white</code>,
-      require: 'no',
-      description: "Sets the Button's theme",
-    },
-    ...buttonProps,
-    removeHoverEffectProp,
-  ],
+  'Ghost Button': [...buttonProps, removeHoverEffectProp],
 };
 
 const linkButtonProps = {
@@ -149,14 +138,14 @@ const ButtonSizeStory = () => {
 <Button theme="${Theme.BLUE}" block>Block</Button>
 
 /* Primary Button */
-<Button variant="${Variant.PRIMARY}" theme="${Theme.YELLOW}" small>Small</Button>
-<Button variant="${Variant.PRIMARY}" theme="${Theme.YELLOW}">Normal</Button>
-<Button variant="${Variant.PRIMARY}" theme="${Theme.YELLOW}" block>Block</Button>
+<Button variant="${Variant.PRIMARY}" small>Small</Button>
+<Button variant="${Variant.PRIMARY}">Normal</Button>
+<Button variant="${Variant.PRIMARY}" block>Block</Button>
 
 /* Ghost Button */
-<Button variant="${Variant.GHOST}" theme="${Theme.BLUE}" small>Small</Button>
-<Button variant="${Variant.GHOST}" theme="${Theme.BLUE}">Normal</Button>
-<Button variant="${Variant.GHOST}" theme="${Theme.BLUE}" block>Block</Button>
+<Button variant="${Variant.GHOST}" small>Small</Button>
+<Button variant="${Variant.GHOST}">Normal</Button>
+<Button variant="${Variant.GHOST}" block>Block</Button>
 `;
   const propsObject = {
     'Default Button, Primary Button, Ghost Button': [smallProp, blockProp],
@@ -177,27 +166,23 @@ const ButtonSizeStory = () => {
         </BlockButtonContainer>
       </ButtonRow>
       <ButtonRow>
-        <Button variant={Variant.PRIMARY} theme={Theme.YELLOW} small>
+        <Button variant={Variant.PRIMARY} small>
           Small
         </Button>
-        <Button variant={Variant.PRIMARY} theme={Theme.YELLOW}>
-          Normal
-        </Button>
+        <Button variant={Variant.PRIMARY}>Normal</Button>
         <BlockButtonContainer>
-          <Button variant={Variant.PRIMARY} theme={Theme.YELLOW} block>
+          <Button variant={Variant.PRIMARY} block>
             Block
           </Button>
         </BlockButtonContainer>
       </ButtonRow>
       <ButtonRow>
-        <Button variant={Variant.GHOST} theme={Theme.BLUE} small>
+        <Button variant={Variant.GHOST} small>
           Small
         </Button>
-        <Button variant={Variant.GHOST} theme={Theme.BLUE}>
-          Normal
-        </Button>
+        <Button variant={Variant.GHOST}>Normal</Button>
         <BlockButtonContainer>
-          <Button variant={Variant.GHOST} theme={Theme.BLUE} block>
+          <Button variant={Variant.GHOST} block>
             Block
           </Button>
         </BlockButtonContainer>

--- a/stories/General/ButtonStory.tsx
+++ b/stories/General/ButtonStory.tsx
@@ -70,7 +70,6 @@ const ButtonVariantStory = () => {
       propsObject={propsObject}
     >
       <Heading>Variants</Heading>
-      <h3></h3>
       <ButtonRow>
         <Button>{Variant.DEFAULT}</Button>
       </ButtonRow>
@@ -112,7 +111,6 @@ const ButtonDisableStory = () => {
   return (
     <StorybookComponent usage={usage} propsObject={propsObject}>
       <Heading>Disabled</Heading>
-      <h3></h3>
       <ButtonRow>
         <Button disabled>{Variant.DEFAULT}</Button>
       </ButtonRow>
@@ -368,7 +366,6 @@ const ButtonRemoveHoverEffectStory = () => {
   return (
     <StorybookComponent usage={usage} propsObject={propsObject}>
       <Heading>Button without hovered background</Heading>
-      <h3></h3>
       <ButtonRow>
         <Button removeHoverEffect>{Variant.DEFAULT}</Button>
       </ButtonRow>

--- a/stories/General/ButtonStory.tsx
+++ b/stories/General/ButtonStory.tsx
@@ -116,6 +116,8 @@ const ButtonStories = () => (
   <React.Fragment>
     <ButtonVariantStory />
     <Divider theme="grey" />
+    <ButtonDisableStory />
+    <Divider theme="grey" />
     <ButtonSizeStory />
     <Divider theme="grey" />
     <ButtonThemeStory />
@@ -123,6 +125,8 @@ const ButtonStories = () => (
     <ButtonWithIconStory />
     <Divider theme="grey" />
     <ButtonWithTagStory />
+    <Divider theme="grey" />
+    <ButtonRemoveHoverEffectStory />
     <Divider theme="grey" />
     <DefaultButtonStory />
     <Divider theme="grey" />
@@ -183,6 +187,49 @@ const ButtonVariantStory = () => {
       </ButtonRow>
       <ButtonRow>
         <Button variant={Variant.LINK}>{Variant.LINK}</Button>
+      </ButtonRow>
+    </StorybookComponent>
+  );
+};
+
+const ButtonDisableStory = () => {
+  const usage = `/* Default Button */
+<Button disabled>${Variant.DEFAULT}</Button>
+
+/* Primary Button */
+<Button variant="${Variant.PRIMARY}" disabled>${Variant.PRIMARY}</Button>
+
+/* Ghost Button */
+<Button variant="${Variant.GHOST} disabled">${Variant.GHOST}</Button>
+`;
+  const propsObject = {
+    'Default Button, Primary Button, Ghost Button': [
+      {
+        name: 'disabled',
+        type: 'boolean',
+        defaultValue: <code>false</code>,
+        possibleValue: <code>true | false</code>,
+        require: 'no',
+        description: 'Sets Button to disable state.',
+      },
+    ],
+  };
+  return (
+    <StorybookComponent usage={usage} propsObject={propsObject}>
+      <Heading>Disabled</Heading>
+      <h3></h3>
+      <ButtonRow>
+        <Button disabled>{Variant.DEFAULT}</Button>
+      </ButtonRow>
+      <ButtonRow>
+        <Button variant={Variant.PRIMARY} disabled>
+          {Variant.PRIMARY}
+        </Button>
+      </ButtonRow>
+      <ButtonRow>
+        <Button variant={Variant.GHOST} disabled>
+          {Variant.GHOST}
+        </Button>
       </ButtonRow>
     </StorybookComponent>
   );
@@ -383,6 +430,41 @@ const ButtonWithTagStory = () => {
           </Button>
         </ButtonRow>
       ))}
+    </StorybookComponent>
+  );
+};
+
+const ButtonRemoveHoverEffectStory = () => {
+  const usage = `/* Default Button */
+<Button removeHoverEffect>${Variant.DEFAULT}</Button>
+
+/* Ghost Button */
+<Button variant="${Variant.GHOST} removeHoverEffect">${Variant.GHOST}</Button>
+`;
+  const propsObject = {
+    'Default Button, Ghost Button': [
+      {
+        name: 'removeHoverEffect',
+        type: 'boolean',
+        defaultValue: <code>false</code>,
+        possibleValue: <code>true | false</code>,
+        require: 'no',
+        description: "Removes Button's effect when hovered",
+      },
+    ],
+  };
+  return (
+    <StorybookComponent usage={usage} propsObject={propsObject}>
+      <Heading>Button without hovered background</Heading>
+      <h3></h3>
+      <ButtonRow>
+        <Button removeHoverEffect>{Variant.DEFAULT}</Button>
+      </ButtonRow>
+      <ButtonRow>
+        <Button variant={Variant.GHOST} removeHoverEffect>
+          {Variant.GHOST}
+        </Button>
+      </ButtonRow>
     </StorybookComponent>
   );
 };

--- a/stories/General/ButtonStory.tsx
+++ b/stories/General/ButtonStory.tsx
@@ -126,13 +126,13 @@ const ButtonStories = () => (
     <Divider theme="grey" />
     <PrimaryButtonStory />
     <Divider theme="grey" />
-    <SecondaryButtonStory />
-    <Divider theme="grey" />
     <GhostButtonStory />
     <Divider theme="grey" />
     <TagButtonStory />
     <Divider theme="grey" />
     <LinkButtonStory />
+    <Divider theme="grey" />
+    <SecondaryButtonStory />
   </React.Fragment>
 );
 
@@ -382,7 +382,7 @@ const SecondaryButtonStory = () => (
   >
     <div style={{ marginBottom: '2em' }}>
       <Heading style={{ fontSize: '20px', marginBottom: '1em' }}>
-        Secondary Button
+        [DEPRECATED] Secondary Button
       </Heading>
       <Button variant={Variant.SECONDARY} onClick={() => null}>
         Secondary

--- a/stories/General/ButtonStory.tsx
+++ b/stories/General/ButtonStory.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import styled from 'styled-components';
 
 import StorybookComponent from '../StorybookComponent';
-import Button from '../../src/General/Button';
+import Button, { DeprecatedThemeMap } from '../../src/General/Button';
 import Heading from '../../src/General/Heading';
 import Divider from '../../src/General/Divider';
 
@@ -228,21 +228,15 @@ const ButtonThemeStory = () => {
       <Heading style={{ fontSize: '20px' }}>Deprecated themes</Heading>
       The following themes will be deprecated in v5 after we refactor out all
       uses of them in our codebases, so please avoid using them altogether.
-      <ButtonRow>
-        <Button theme={Theme.RED}>{Theme.RED}</Button>
-        <Button theme={Theme.YELLOW}>{Theme.YELLOW}</Button>
-      </ButtonRow>
-      <ButtonRow>
-        <Button variant={Variant.PRIMARY} theme={Theme.RED}>
-          {Theme.RED}
-        </Button>
-        <Button variant={Variant.PRIMARY} theme={Theme.BLUE}>
-          {Theme.BLUE}
-        </Button>
-        <Button variant={Variant.PRIMARY} theme={Theme.BLUE_RED}>
-          {Theme.BLUE_RED}
-        </Button>
-      </ButtonRow>
+      {Object.keys(DeprecatedThemeMap).map(variant => (
+        <ButtonRow key={variant}>
+          {DeprecatedThemeMap[variant].map(theme => (
+            <Button key={theme} variant={variant} theme={theme}>
+              {theme}
+            </Button>
+          ))}
+        </ButtonRow>
+      ))}
     </StorybookComponent>
   );
 };

--- a/stories/General/ButtonStory.tsx
+++ b/stories/General/ButtonStory.tsx
@@ -120,6 +120,8 @@ const ButtonStories = () => (
   <React.Fragment>
     <ButtonSizeStory />
     <Divider theme="grey" />
+    <ButtonThemeStory />
+    <Divider theme="grey" />
     <DefaultButtonStory />
     <Divider theme="grey" />
     <PrimaryButtonStory />
@@ -135,21 +137,20 @@ const ButtonStories = () => (
 );
 
 const ButtonSizeStory = () => {
-  const usage = `<div>
-  <Button theme="${Theme.BLUE}" small>Small</Button>
-  <Button theme="${Theme.BLUE}">Normal</Button>
-  <Button theme="${Theme.BLUE}" block>Block</Button>
-</div>
-<div>
-  <Button variant="${Variant.PRIMARY}" theme="${Theme.YELLOW}" small>Small</Button>
-  <Button variant="${Variant.PRIMARY}" theme="${Theme.YELLOW}">Normal</Button>
-  <Button variant="${Variant.PRIMARY}" theme="${Theme.YELLOW}" block>Block</Button>
-</div>
-<div>
-  <Button variant="${Variant.GHOST}" theme="${Theme.BLUE}" small>Small</Button>
-  <Button variant="${Variant.GHOST}" theme="${Theme.BLUE}">Normal</Button>
-  <Button variant="${Variant.GHOST}" theme="${Theme.BLUE}" block>Block</Button>
-</div>
+  const usage = `/* Default Button */
+<Button theme="${Theme.BLUE}" small>Small</Button>
+<Button theme="${Theme.BLUE}">Normal</Button>
+<Button theme="${Theme.BLUE}" block>Block</Button>
+
+/* Primary Button */
+<Button variant="${Variant.PRIMARY}" theme="${Theme.YELLOW}" small>Small</Button>
+<Button variant="${Variant.PRIMARY}" theme="${Theme.YELLOW}">Normal</Button>
+<Button variant="${Variant.PRIMARY}" theme="${Theme.YELLOW}" block>Block</Button>
+
+/* Ghost Button */
+<Button variant="${Variant.GHOST}" theme="${Theme.BLUE}" small>Small</Button>
+<Button variant="${Variant.GHOST}" theme="${Theme.BLUE}">Normal</Button>
+<Button variant="${Variant.GHOST}" theme="${Theme.BLUE}" block>Block</Button>
 `;
   const propsObject = {
     'Default Button, Primary Button, Ghost Button': [smallProp, blockProp],
@@ -194,6 +195,53 @@ const ButtonSizeStory = () => {
             Block
           </Button>
         </BlockButtonContainer>
+      </ButtonRow>
+    </StorybookComponent>
+  );
+};
+
+const ButtonThemeStory = () => {
+  const usage = `<Button theme="${Theme.BLUE}">Blue</Button>
+<Button theme="${Theme.WHITE}">White</Button>
+`;
+
+  const propsObject = {
+    'Default Button': [
+      {
+        name: 'theme',
+        type: 'string',
+        defaultValue: '"white"',
+        possibleValue: '"white" | "blue"',
+        require: 'no',
+        description: "Sets the Button's theme",
+      },
+    ],
+  };
+
+  return (
+    <StorybookComponent usage={usage} propsObject={propsObject}>
+      <Heading>Themes</Heading>
+      <ButtonRow>
+        <Button theme={Theme.BLUE}>{Theme.BLUE}</Button>
+        <Button theme={Theme.WHITE}>{Theme.WHITE}</Button>
+      </ButtonRow>
+      <Heading style={{ fontSize: '20px' }}>Deprecated themes</Heading>
+      The following themes will be deprecated in v5 after we refactor out all
+      uses of them in our codebases, so please avoid using them altogether.
+      <ButtonRow>
+        <Button theme={Theme.RED}>{Theme.RED}</Button>
+        <Button theme={Theme.YELLOW}>{Theme.YELLOW}</Button>
+      </ButtonRow>
+      <ButtonRow>
+        <Button variant={Variant.PRIMARY} theme={Theme.RED}>
+          {Theme.RED}
+        </Button>
+        <Button variant={Variant.PRIMARY} theme={Theme.BLUE}>
+          {Theme.BLUE}
+        </Button>
+        <Button variant={Variant.PRIMARY} theme={Theme.BLUE_RED}>
+          {Theme.BLUE_RED}
+        </Button>
       </ButtonRow>
     </StorybookComponent>
   );

--- a/stories/General/ButtonStory.tsx
+++ b/stories/General/ButtonStory.tsx
@@ -15,103 +15,6 @@ import {
 
 import { Variant, Theme } from '../../src/Utils/StyleConfig';
 
-const blockProp = {
-  name: 'block',
-  type: 'boolean',
-  defaultValue: <code>false</code>,
-  possibleValue: <code>true | false</code>,
-  require: 'no',
-  description: 'Make the button fit to its parent width.',
-};
-
-const smallProp = {
-  name: 'small',
-  type: 'boolean',
-  defaultValue: <code>false</code>,
-  possibleValue: <code>true | false</code>,
-  require: 'no',
-  description: 'Sets Button to small version.',
-};
-
-const buttonProps = [
-  {
-    name: 'variant',
-    type: 'string',
-    defaultValue: 'default',
-    possibleValue: <code>default | primary | secondary | ghost | link</code>,
-    require: 'no',
-    description: 'Sets the Default Button.',
-  },
-  {
-    name: 'disabled',
-    type: 'boolean',
-    defaultValue: <code>false</code>,
-    possibleValue: <code>true | false</code>,
-    require: 'no',
-    description: 'Sets Button to disable state.',
-  },
-  blockProp,
-  smallProp,
-  {
-    name: 'tag',
-    type: 'React.ElementType',
-    defaultValue: <code>button</code>,
-    possibleValue: 'any valid html tag e.g. "a"',
-    require: 'no',
-    description: 'Changes the tag with which the button will render.',
-  },
-];
-
-const removeHoverEffectProp = {
-  name: 'removeHoverEffect',
-  type: 'boolean',
-  defaultValue: <code>false</code>,
-  possibleValue: <code>true | false</code>,
-  require: 'no',
-  description: "Removes Button's effect when hovered",
-};
-
-const defaultButtonProps = {
-  'Default Button': [
-    {
-      name: 'theme',
-      type: 'string',
-      defaultValue: <code>white</code>,
-      possibleValue: <code>white | red | blue | yellow</code>,
-      require: 'no',
-      description: "Sets the Button's theme",
-    },
-    ...buttonProps,
-    removeHoverEffectProp,
-  ],
-};
-
-const primaryButtonProps = {
-  'Primary Button': [
-    {
-      name: 'theme',
-      type: 'string',
-      defaultValue: <code>yellow</code>,
-      possibleValue: <code>red | blue | blue-red | yellow</code>,
-      require: 'no',
-      description: "Sets the Button's theme",
-    },
-    ...buttonProps,
-  ],
-};
-
-const secondaryButtonProps = {
-  'Secondary Button': buttonProps,
-};
-
-const ghostButtonProps = {
-  'Ghost Button': [...buttonProps, removeHoverEffectProp],
-};
-
-const linkButtonProps = {
-  'Link Button': [blockProp],
-};
-
 const ButtonStories = () => (
   <React.Fragment>
     <ButtonVariantStory />
@@ -127,14 +30,6 @@ const ButtonStories = () => (
     <ButtonWithTagStory />
     <Divider theme="grey" />
     <ButtonRemoveHoverEffectStory />
-    <Divider theme="grey" />
-    <DefaultButtonStory />
-    <Divider theme="grey" />
-    <PrimaryButtonStory />
-    <Divider theme="grey" />
-    <GhostButtonStory />
-    <Divider theme="grey" />
-    <LinkButtonStory />
     <Divider theme="grey" />
     <SecondaryButtonStory />
   </React.Fragment>
@@ -252,7 +147,24 @@ const ButtonSizeStory = () => {
 <Button variant="${Variant.GHOST}" block>Block</Button>
 `;
   const propsObject = {
-    'Default Button, Primary Button, Ghost Button': [smallProp, blockProp],
+    'Default Button, Primary Button, Ghost Button': [
+      {
+        name: 'small',
+        type: 'boolean',
+        defaultValue: <code>false</code>,
+        possibleValue: <code>true | false</code>,
+        require: 'no',
+        description: 'Sets Button to small version.',
+      },
+      {
+        name: 'block',
+        type: 'boolean',
+        defaultValue: <code>false</code>,
+        possibleValue: <code>true | false</code>,
+        require: 'no',
+        description: 'Make the button fit to its parent width.',
+      },
+    ],
   };
 
   return (
@@ -469,139 +381,8 @@ const ButtonRemoveHoverEffectStory = () => {
   );
 };
 
-const DefaultButtonStory = () => (
-  <StorybookComponent
-    title="Button"
-    code="import { Button } from 'glints-aries'"
-    propsObject={defaultButtonProps}
-    usage={`<Button
-theme="blue"
->
-Default
-</Button>`}
-  >
-    <div style={{ marginBottom: '2em' }}>
-      <Heading style={{ fontSize: '20px', marginBottom: '1em' }}>
-        Default Button
-      </Heading>
-      <ButtonRow>
-        <ButtonContainer>
-          <Button theme={Theme.WHITE} onClick={() => null}>
-            Default
-          </Button>
-        </ButtonContainer>
-        <ButtonContainer>
-          <Button theme={Theme.RED} onClick={() => null}>
-            Red
-          </Button>
-        </ButtonContainer>
-      </ButtonRow>
-      <ButtonRow>
-        <ButtonContainer>
-          <Button theme={Theme.BLUE} onClick={() => null}>
-            Blue
-          </Button>
-        </ButtonContainer>
-        <ButtonContainer>
-          <Button theme={Theme.YELLOW} onClick={() => null}>
-            Yellow
-          </Button>
-        </ButtonContainer>
-      </ButtonRow>
-      <ButtonRow>
-        <ButtonContainer>
-          <Button disabled onClick={() => null}>
-            Disabled
-          </Button>
-        </ButtonContainer>
-        <BlockButtonContainer>
-          <Button theme={Theme.YELLOW} block onClick={() => null}>
-            Block
-          </Button>
-        </BlockButtonContainer>
-      </ButtonRow>
-    </div>
-  </StorybookComponent>
-);
-
-const PrimaryButtonStory = () => (
-  <StorybookComponent
-    propsObject={primaryButtonProps}
-    usage={`<Button
-variant='primary'
-theme='yellow'
->
-Primary
-</Button>`}
-  >
-    <div style={{ marginBottom: '2em' }}>
-      <Heading style={{ fontSize: '20px', marginBottom: '1em' }}>
-        Primary Button
-      </Heading>
-      <ButtonRow>
-        <ButtonContainer>
-          <Button
-            variant={Variant.PRIMARY}
-            theme={Theme.YELLOW}
-            onClick={() => null}
-          >
-            Yellow
-          </Button>
-        </ButtonContainer>
-        <ButtonContainer>
-          <Button
-            variant={Variant.PRIMARY}
-            theme={Theme.RED}
-            onClick={() => null}
-          >
-            Red
-          </Button>
-        </ButtonContainer>
-      </ButtonRow>
-      <ButtonRow>
-        <ButtonContainer>
-          <Button
-            variant={Variant.PRIMARY}
-            theme={Theme.BLUE}
-            onClick={() => null}
-          >
-            Blue
-          </Button>
-        </ButtonContainer>
-        <ButtonContainer>
-          <Button
-            variant={Variant.PRIMARY}
-            theme={Theme.BLUE_RED}
-            onClick={() => null}
-          >
-            Blue-Red
-          </Button>
-        </ButtonContainer>
-      </ButtonRow>
-      <ButtonRow>
-        <BlockButtonContainer>
-          <Button
-            variant={Variant.PRIMARY}
-            theme={Theme.YELLOW}
-            block
-            onClick={() => null}
-          >
-            Block
-          </Button>
-        </BlockButtonContainer>
-        <ButtonContainer>
-          <Button variant={Variant.PRIMARY} disabled onClick={() => null}>
-            Disabled
-          </Button>
-        </ButtonContainer>
-      </ButtonRow>
-    </div>
-  </StorybookComponent>
-);
-
 const SecondaryButtonStory = () => (
   <StorybookComponent
-    propsObject={secondaryButtonProps}
     usage={`<Button
   variant="secondary"
 >
@@ -619,62 +400,6 @@ const SecondaryButtonStory = () => (
   </StorybookComponent>
 );
 
-const GhostButtonStory = () => (
-  <StorybookComponent
-    propsObject={ghostButtonProps}
-    usage={`<Button
-  variant="ghost"
-  theme="blue"
->
-  Ghost
-</Button>`}
-  >
-    <div style={{ marginBottom: '2em' }}>
-      <Heading style={{ fontSize: '20px', marginBottom: '1em' }}>
-        Ghost Button
-      </Heading>
-      <Button variant={Variant.GHOST} theme={Theme.BLUE} onClick={() => null}>
-        Ghost
-      </Button>
-    </div>
-  </StorybookComponent>
-);
-
-const LinkButtonStory = () => (
-  <StorybookComponent
-    propsObject={linkButtonProps}
-    usage={`<Button
-  variant="link"
-  theme="blue"
->
-  Link
-</Button>`}
-  >
-    <div style={{ marginBottom: '2em' }}>
-      <Heading style={{ fontSize: '20px', marginBottom: '1em' }}>
-        Link Button
-      </Heading>
-      <Button variant={Variant.LINK} onClick={() => null}>
-        Link
-      </Button>
-    </div>
-  </StorybookComponent>
-);
-
-// const ButtonRow: React.FunctionComponent = ({ children }) => (
-//   <div
-//     style={{
-//       display: 'flex',
-//       flexDirection: 'row',
-//       alignItems: 'center',
-//       marginTop: '15px',
-//       marginBottom: '15px',
-//     }}
-//   >
-//     {children}
-//   </div>
-// );
-
 const ButtonRow = styled.div`
   display: flex;
   flex-direction: row;
@@ -689,12 +414,6 @@ const ButtonRow = styled.div`
 
 const BlockButtonContainer: React.FunctionComponent = ({ children }) => (
   <div style={{ flex: '0 0 40%' }}>{children}</div>
-);
-
-const ButtonContainer: React.FunctionComponent = ({ children }) => (
-  <div style={{ flex: '0 0 40%', display: 'flex', justifyContent: 'center' }}>
-    {children}
-  </div>
 );
 
 export default ButtonStories;

--- a/stories/General/ButtonStory.tsx
+++ b/stories/General/ButtonStory.tsx
@@ -5,6 +5,10 @@ import StorybookComponent from '../StorybookComponent';
 import Button, { DeprecatedThemeMap } from '../../src/General/Button';
 import Heading from '../../src/General/Heading';
 import Divider from '../../src/General/Divider';
+import {
+  ViewIcon,
+  ArrowRoundForwardIcon,
+} from '../../src/General/Icon/components';
 
 import { Variant, Theme } from '../../src/Utils/StyleConfig';
 
@@ -122,6 +126,8 @@ const ButtonStories = () => (
     <Divider theme="grey" />
     <ButtonThemeStory />
     <Divider theme="grey" />
+    <ButtonWithIconStory />
+    <Divider theme="grey" />
     <DefaultButtonStory />
     <Divider theme="grey" />
     <PrimaryButtonStory />
@@ -237,6 +243,70 @@ const ButtonThemeStory = () => {
           ))}
         </ButtonRow>
       ))}
+    </StorybookComponent>
+  );
+};
+
+const ButtonWithIconStory = () => {
+  const usage = `/* Default Button */
+<Button startIcon={<ViewIcon />}>Button</Button>
+<Button endIcon={<ArrowRoundForwardIcon />}>Button</Button>
+
+/* Primary Button */
+<Button variant="${Variant.PRIMARY}" startIcon={<ViewIcon />}>Button</Button>
+<Button variant="${Variant.PRIMARY}" endIcon={<ArrowRoundForwardIcon />}>Button</Button>
+
+/* Ghost Button */
+<Button variant="${Variant.GHOST}" startIcon={<ViewIcon />}>Button</Button>
+<Button variant="${Variant.GHOST}" endIcon={<ArrowRoundForwardIcon />}>Button</Button>`;
+  const propsObject = {
+    All: [
+      {
+        name: 'startIcon',
+        type: 'node',
+        defaultValue: '-',
+        possibleValue: 'any',
+        require: 'no',
+        description: 'Element placed before the children.',
+      },
+      {
+        name: 'endIcon',
+        type: 'node',
+        defaultValue: '-',
+        possibleValue: 'any',
+        require: 'no',
+        description: 'Element placed after the children.',
+      },
+    ],
+  };
+
+  return (
+    <StorybookComponent usage={usage} propsObject={propsObject}>
+      <Heading>Button with Icon</Heading>
+      <ButtonRow>
+        <Button theme={Theme.BLUE} startIcon={<ViewIcon />}>
+          Button Icon Left
+        </Button>
+        <Button theme={Theme.BLUE} endIcon={<ArrowRoundForwardIcon />}>
+          Button Icon Right
+        </Button>
+      </ButtonRow>
+      <ButtonRow>
+        <Button variant={Variant.PRIMARY} startIcon={<ViewIcon />}>
+          Button Icon Left
+        </Button>
+        <Button variant={Variant.PRIMARY} endIcon={<ArrowRoundForwardIcon />}>
+          Button Icon Right
+        </Button>
+      </ButtonRow>
+      <ButtonRow>
+        <Button variant={Variant.GHOST} startIcon={<ViewIcon />}>
+          Button Icon Left
+        </Button>
+        <Button variant={Variant.GHOST} endIcon={<ArrowRoundForwardIcon />}>
+          Button Icon Right
+        </Button>
+      </ButtonRow>
     </StorybookComponent>
   );
 };

--- a/stories/General/ButtonStory.tsx
+++ b/stories/General/ButtonStory.tsx
@@ -114,6 +114,8 @@ const linkButtonProps = {
 
 const ButtonStories = () => (
   <React.Fragment>
+    <ButtonVariantStory />
+    <Divider theme="grey" />
     <ButtonSizeStory />
     <Divider theme="grey" />
     <ButtonThemeStory />
@@ -133,6 +135,58 @@ const ButtonStories = () => (
     <SecondaryButtonStory />
   </React.Fragment>
 );
+
+const ButtonVariantStory = () => {
+  const usage = `/* Default Button */
+<Button>${Variant.DEFAULT}</Button>
+
+/* Primary Button */
+<Button variant="${Variant.PRIMARY}">${Variant.PRIMARY}</Button>
+
+/* Ghost Button */
+<Button variant="${Variant.GHOST}">${Variant.GHOST}</Button>
+
+/* Link Button */
+<Button variant="${Variant.LINK}">${Variant.LINK}</Button>
+`;
+  const propsObject = {
+    All: [
+      {
+        name: 'variant',
+        type: 'string',
+        defaultValue: `"${Variant.DEFAULT}"`,
+        possibleValue: `${Object.values(Variant)
+          .map(value => `"${value}"`)
+          .join(' | ')}`,
+        require: 'no',
+        description: "Sets the Button's type.",
+      },
+    ],
+  };
+  return (
+    <StorybookComponent
+      title="Button"
+      code="import { Button } from 'glints-aries'"
+      usage={usage}
+      propsObject={propsObject}
+    >
+      <Heading>Variants</Heading>
+      <h3></h3>
+      <ButtonRow>
+        <Button>{Variant.DEFAULT}</Button>
+      </ButtonRow>
+      <ButtonRow>
+        <Button variant={Variant.PRIMARY}>{Variant.PRIMARY}</Button>
+      </ButtonRow>
+      <ButtonRow>
+        <Button variant={Variant.GHOST}>{Variant.GHOST}</Button>
+      </ButtonRow>
+      <ButtonRow>
+        <Button variant={Variant.LINK}>{Variant.LINK}</Button>
+      </ButtonRow>
+    </StorybookComponent>
+  );
+};
 
 const ButtonSizeStory = () => {
   const usage = `/* Default Button */

--- a/stories/General/ButtonStory.tsx
+++ b/stories/General/ButtonStory.tsx
@@ -2,7 +2,10 @@ import * as React from 'react';
 import styled from 'styled-components';
 
 import StorybookComponent from '../StorybookComponent';
-import Button, { DeprecatedThemeMap } from '../../src/General/Button';
+import Button, {
+  DeprecatedThemeMap,
+  DeprecatedSecondayVariant,
+} from '../../src/General/Button';
 import Heading from '../../src/General/Heading';
 import Divider from '../../src/General/Divider';
 import {
@@ -117,13 +120,13 @@ const ButtonStories = () => (
     <Divider theme="grey" />
     <ButtonWithIconStory />
     <Divider theme="grey" />
+    <ButtonWithTagStory />
+    <Divider theme="grey" />
     <DefaultButtonStory />
     <Divider theme="grey" />
     <PrimaryButtonStory />
     <Divider theme="grey" />
     <GhostButtonStory />
-    <Divider theme="grey" />
-    <TagButtonStory />
     <Divider theme="grey" />
     <LinkButtonStory />
     <Divider theme="grey" />
@@ -296,6 +299,40 @@ const ButtonWithIconStory = () => {
   );
 };
 
+const ButtonWithTagStory = () => {
+  const usage = `<Button tag="a">Button as Anchor</Button>`;
+  const propsObject = {
+    All: [
+      {
+        name: 'tag',
+        type: 'string',
+        defaultValue: '"button"',
+        possibleValue: 'any valid html tag e.g. "a"',
+        require: 'no',
+        description: 'Changes the tag with which the button will render.',
+      },
+    ],
+  };
+
+  return (
+    <StorybookComponent usage={usage} propsObject={propsObject}>
+      <Heading>Button with Different Tag</Heading>
+      <ButtonRow>
+        <Button theme={Theme.BLUE} tag="a">
+          Button as Anchor
+        </Button>
+      </ButtonRow>
+      {Object.values(Variant).map(type => (
+        <ButtonRow key={type}>
+          <Button variant={type} tag="a">
+            Button as Anchor
+          </Button>
+        </ButtonRow>
+      ))}
+    </StorybookComponent>
+  );
+};
+
 const DefaultButtonStory = () => (
   <StorybookComponent
     title="Button"
@@ -439,7 +476,7 @@ const SecondaryButtonStory = () => (
       <Heading style={{ fontSize: '20px', marginBottom: '1em' }}>
         [DEPRECATED] Secondary Button
       </Heading>
-      <Button variant={Variant.SECONDARY} onClick={() => null}>
+      <Button variant={DeprecatedSecondayVariant} onClick={() => null}>
         Secondary
       </Button>
     </div>
@@ -462,32 +499,6 @@ const GhostButtonStory = () => (
       </Heading>
       <Button variant={Variant.GHOST} theme={Theme.BLUE} onClick={() => null}>
         Ghost
-      </Button>
-    </div>
-  </StorybookComponent>
-);
-
-const TagButtonStory = () => (
-  <StorybookComponent
-    usage={`<Button
-  variant="ghost"
-  theme="blue"
-  tag="a"
->
-  Ghost
-</Button>`}
-  >
-    <div style={{ marginBottom: '2em' }}>
-      <Heading style={{ fontSize: '20px', marginBottom: '1em' }}>
-        Ghost Button with Different Tag
-      </Heading>
-      <Button
-        variant={Variant.GHOST}
-        theme={Theme.BLUE}
-        onClick={() => null}
-        tag="a"
-      >
-        Ghost Button as Anchor
       </Button>
     </div>
   </StorybookComponent>

--- a/stories/General/ButtonStory.tsx
+++ b/stories/General/ButtonStory.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import styled from 'styled-components';
 
 import StorybookComponent from '../StorybookComponent';
 import Button from '../../src/General/Button';
@@ -13,7 +14,16 @@ const blockProp = {
   defaultValue: <code>false</code>,
   possibleValue: <code>true | false</code>,
   require: 'no',
-  description: '	Sets Button to block type.',
+  description: 'Make the button fit to its parent width.',
+};
+
+const smallProp = {
+  name: 'small',
+  type: 'boolean',
+  defaultValue: <code>false</code>,
+  possibleValue: <code>true | false</code>,
+  require: 'no',
+  description: 'Sets Button to small version.',
 };
 
 const buttonProps = [
@@ -34,14 +44,7 @@ const buttonProps = [
     description: 'Sets Button to disable state.',
   },
   blockProp,
-  {
-    name: 'small',
-    type: 'boolean',
-    defaultValue: <code>false</code>,
-    possibleValue: <code>true | false</code>,
-    require: 'no',
-    description: 'Sets Button to small version.',
-  },
+  smallProp,
   {
     name: 'tag',
     type: 'React.ElementType',
@@ -115,6 +118,8 @@ const linkButtonProps = {
 
 const ButtonStories = () => (
   <React.Fragment>
+    <ButtonSizeStory />
+    <Divider theme="grey" />
     <DefaultButtonStory />
     <Divider theme="grey" />
     <PrimaryButtonStory />
@@ -128,6 +133,71 @@ const ButtonStories = () => (
     <LinkButtonStory />
   </React.Fragment>
 );
+
+const ButtonSizeStory = () => {
+  const usage = `<div>
+  <Button theme="${Theme.BLUE}" small>Small</Button>
+  <Button theme="${Theme.BLUE}">Normal</Button>
+  <Button theme="${Theme.BLUE}" block>Block</Button>
+</div>
+<div>
+  <Button variant="${Variant.PRIMARY}" theme="${Theme.YELLOW}" small>Small</Button>
+  <Button variant="${Variant.PRIMARY}" theme="${Theme.YELLOW}">Normal</Button>
+  <Button variant="${Variant.PRIMARY}" theme="${Theme.YELLOW}" block>Block</Button>
+</div>
+<div>
+  <Button variant="${Variant.GHOST}" theme="${Theme.BLUE}" small>Small</Button>
+  <Button variant="${Variant.GHOST}" theme="${Theme.BLUE}">Normal</Button>
+  <Button variant="${Variant.GHOST}" theme="${Theme.BLUE}" block>Block</Button>
+</div>
+`;
+  const propsObject = {
+    'Default Button, Primary Button, Ghost Button': [smallProp, blockProp],
+  };
+
+  return (
+    <StorybookComponent usage={usage} propsObject={propsObject}>
+      <Heading>Sizes</Heading>
+      <ButtonRow>
+        <Button theme={Theme.BLUE} small>
+          Small
+        </Button>
+        <Button theme={Theme.BLUE}>Normal</Button>
+        <BlockButtonContainer>
+          <Button theme={Theme.BLUE} block>
+            Block
+          </Button>
+        </BlockButtonContainer>
+      </ButtonRow>
+      <ButtonRow>
+        <Button variant={Variant.PRIMARY} theme={Theme.YELLOW} small>
+          Small
+        </Button>
+        <Button variant={Variant.PRIMARY} theme={Theme.YELLOW}>
+          Normal
+        </Button>
+        <BlockButtonContainer>
+          <Button variant={Variant.PRIMARY} theme={Theme.YELLOW} block>
+            Block
+          </Button>
+        </BlockButtonContainer>
+      </ButtonRow>
+      <ButtonRow>
+        <Button variant={Variant.GHOST} theme={Theme.BLUE} small>
+          Small
+        </Button>
+        <Button variant={Variant.GHOST} theme={Theme.BLUE}>
+          Normal
+        </Button>
+        <BlockButtonContainer>
+          <Button variant={Variant.GHOST} theme={Theme.BLUE} block>
+            Block
+          </Button>
+        </BlockButtonContainer>
+      </ButtonRow>
+    </StorybookComponent>
+  );
+};
 
 const DefaultButtonStory = () => (
   <StorybookComponent
@@ -347,17 +417,31 @@ const LinkButtonStory = () => (
   </StorybookComponent>
 );
 
-const ButtonRow: React.FunctionComponent = ({ children }) => (
-  <div
-    style={{
-      display: 'flex',
-      justifyContent: 'space-around',
-      marginBottom: '2em',
-    }}
-  >
-    {children}
-  </div>
-);
+// const ButtonRow: React.FunctionComponent = ({ children }) => (
+//   <div
+//     style={{
+//       display: 'flex',
+//       flexDirection: 'row',
+//       alignItems: 'center',
+//       marginTop: '15px',
+//       marginBottom: '15px',
+//     }}
+//   >
+//     {children}
+//   </div>
+// );
+
+const ButtonRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-top: 15px;
+  margin-bottom: 15px;
+
+  > div {
+    margin-right: 20px;
+  }
+`;
 
 const BlockButtonContainer: React.FunctionComponent = ({ children }) => (
   <div style={{ flex: '0 0 40%' }}>{children}</div>


### PR DESCRIPTION
Related Issues: 
- https://github.com/glints-dev/glints-aries/issues/193
- https://github.com/glints-dev/glints-aries/issues/265

What changed:
- Fix the text color of the `Primary Button` with `a` tag
- Fix the `font-size` of the button with `small` prop
- Change the text color of `Default White Button` to blue
- Add warning message for deprecated`Secondary Button` and some `theme` values
- Add `startIcon` and `endIcon` props because the margin between icon and text is defined in GDS.
- Revamp the button story to be categorized by props instead of types
