### PR TITLE
Modal: children should not be mounted when visible

### DIFF
--- a/src/Display/Modal/Modal.test.tsx
+++ b/src/Display/Modal/Modal.test.tsx
@@ -94,6 +94,16 @@ describe('when modal is closed', () => {
     const { modalContainer } = setupModal(false);
     expect(modalContainer).toHaveStyle('visibility: hidden');
   });
+
+  it('children should not be mounted', () => {
+    const { queryByTestId } = render(
+      <Modal isVisible={false} onClose={props.onClose}>
+        <p data-testid="modal-children">{props.content}</p>
+      </Modal>
+    );
+    const children = queryByTestId('modal-children');
+    expect(children).not.toBeInTheDocument();
+  });
 });
 
 const escapeEvent = {

--- a/src/Display/Modal/Modal.tsx
+++ b/src/Display/Modal/Modal.tsx
@@ -123,7 +123,7 @@ const Modal = (props: Props) => {
             </ModalHeader>
           )}
           <ModalBody className="modal-body" hideContentArea={hideContentArea}>
-            {children}
+            {isVisible && children}
           </ModalBody>
           {footer !== undefined && (
             <ModalFooter className="modal-footer">{footer}</ModalFooter>


### PR DESCRIPTION
To avoid unmounting the children manually, e.g. https://gitlab.glints.com/glints/glints-dst/-/blob/staging/app/modules/Login/Components/LoginModal.js#L18