### PR TITLE
Revert "Modal: children should not be mounted when visible"

### DIFF
--- a/src/Display/Modal/Modal.test.tsx
+++ b/src/Display/Modal/Modal.test.tsx
@@ -94,16 +94,6 @@ describe('when modal is closed', () => {
     const { modalContainer } = setupModal(false);
     expect(modalContainer).toHaveStyle('visibility: hidden');
   });
-
-  it('children should not be mounted', () => {
-    const { queryByTestId } = render(
-      <Modal isVisible={false} onClose={props.onClose}>
-        <p data-testid="modal-children">{props.content}</p>
-      </Modal>
-    );
-    const children = queryByTestId('modal-children');
-    expect(children).not.toBeInTheDocument();
-  });
 });
 
 const escapeEvent = {

--- a/src/Display/Modal/Modal.tsx
+++ b/src/Display/Modal/Modal.tsx
@@ -123,7 +123,7 @@ const Modal = (props: Props) => {
             </ModalHeader>
           )}
           <ModalBody className="modal-body" hideContentArea={hideContentArea}>
-            {isVisible && children}
+            {children}
           </ModalBody>
           {footer !== undefined && (
             <ModalFooter className="modal-footer">{footer}</ModalFooter>


### PR DESCRIPTION
Reverts glints-dev/glints-aries#311

Because this PR breaks the `Gallery`.