### PR TITLE
Swipeable: Hide scrollbar on firefox

### DIFF
--- a/src/Style/Display/SwipeableStyle.ts
+++ b/src/Style/Display/SwipeableStyle.ts
@@ -1,10 +1,12 @@
 import styled from 'styled-components';
+
 import { SecondaryColor } from '../Colors';
 
 export const SwipeableContainer = styled.div`
   display: flex;
   position: relative;
   overflow-x: auto;
+  scrollbar-width: none; /* hide scrollbar on firefox */
 
   &::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/35050056/80954665-69091a00-8e30-11ea-8570-fe99f86a2840.png)

After:

![image](https://user-images.githubusercontent.com/35050056/80954687-72928200-8e30-11ea-9e4d-893f0391a381.png)

Note that the component is not scrollable on firefox in responsive design mode (I have no idea why but I suspect that on desktop, firefox cannot mimic touch gestures 100% accurately). However, it is scrollable on desktop using the scroll wheel and on mobile using touch gestures.

- Related Jira issue: https://glints.atlassian.net/browse/QA-110
- Review App: https://dst-feature-hotfix-firefox-scrollbar.dev.glints.com/opportunities/jobs/explore
- Reference: https://stackoverflow.com/questions/20997183/how-to-hide-scrollbar-in-firefox
