### PR TITLE
Fix Select Changed Behaviour

### DIFF
--- a/src/Input/Select/Select.test.tsx
+++ b/src/Input/Select/Select.test.tsx
@@ -186,8 +186,9 @@ describe('when it is clicked', () => {
 
 describe('when an option is clicked', () => {
   it('should call the onOptionClick function', () => {
-    setupSelectOptionFromMenu();
+    const { randomOption } = setupSelectOptionFromMenu();
     expect(props.onOptionClick).toHaveBeenCalledTimes(1);
+    expect(props.onChange).toHaveBeenCalledWith(randomOption.dataset.value);
   });
 
   it('should show the value of the option on the select input', () => {
@@ -203,8 +204,10 @@ describe('when an option is clicked', () => {
 
 describe('when the enter key is pressed on an option', () => {
   it('should call the onOptionClick function', () => {
-    setupSelectOptionFromMenuWithKeyHandling();
-    expect(props.onOptionClick).toHaveBeenCalledTimes(1);
+    const { randomOption } = setupSelectOptionFromMenuWithKeyHandling();
+    expect(props.onChange).toHaveBeenCalledWith(
+      randomOption.getAttribute('data-value')
+    );
   });
 
   it('should show the value of the option on the select input', () => {

--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -148,7 +148,7 @@ const Select: ISelect = (props: Props) => {
   // Should be called when the user selects an option
   const handleSelect = React.useCallback(
     (e?: React.ChangeEvent<HTMLInputElement>) => {
-      const activeElement = getActiveElement();
+      const activeElement = e ? e.target : getActiveElement();
       const selectedValue = activeElement.textContent;
       setSelectedValue(selectedValue);
       setFilterValue(React.Children.map(children, data => data));

--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -156,7 +156,7 @@ const Select: ISelect = (props: Props) => {
       setFloating(true);
 
       if (onChange !== undefined) {
-        onChange(selectedValue);
+        onChange(activeElement.getAttribute('data-value'));
       }
 
       const activeElementIndex = Number(get(activeElement, 'dataset.id'));

--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -135,7 +135,7 @@ const Select: ISelect = (props: Props) => {
       setCursor(0);
 
       if (onChange !== undefined) {
-        return onChange(e.target.value);
+        return onChange(e);
       }
     },
     [children, onChange]


### PR DESCRIPTION
Fixes #313 

When I converted `Select` into a functional component I made some mistakes which this PR reverts.

* First of all, this PR fixes the test that should have caught the changed behaviour.
* Reverts a change that made `handleChange` call `onChange` with the user input when the user types. Previously it called `onChange` with the whole change event. This prevents a new, unreported bug in the front-end project where typing into the select would trigger any `onChange` callback with the typed input. For example in employers there's a Select for changing a candidate status. Typing "Inter" (Interviewed) into the Select would send an API request for changing the status to "Inter").
* In handleSelect, use the triggering event as data source for selectedValue if passed. This function gets called with an event when the user clicks an option, and then there is no active element, so we have to get the data from the event. Again, this is reverting a mistake I made when converting the component.
* In handleSelect, call onChange with the value, not the text content of the selected option. This fixes #313. Again, reverting to before-conversion behaviour.