### PR TITLE
Brand tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,8 @@
   },
   "jest": {
     "moduleNameMapper": {
-      "\\.(css|scss|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "identity-obj-proxy"
+      ".+\\.(css|styl|less|sass|scss)$": "identity-obj-proxy",
+      ".+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/test/__mocks__/fileMock.js"
     }
   }
 }

--- a/src/General/Brand/Brand.test.tsx
+++ b/src/General/Brand/Brand.test.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+import 'jest-styled-components';
+import { render, fireEvent } from '@testing-library/react';
+
+import Brand from './Brand';
+
+describe('<Brand/> ', () => {
+  it('should render as expected', () => {
+    const blackLogoSnapshot = renderer
+      .create(<Brand asset="glints-black" />)
+      .toJSON();
+    expect(blackLogoSnapshot).toMatchSnapshot();
+    const white = renderer.create(<Brand asset="glints-white" />).toJSON();
+    expect(white).toMatchSnapshot();
+    const cutsom = renderer
+      .create(<Brand asset="http://example.com/example.jpg" />)
+      .toJSON();
+    expect(cutsom).toMatchSnapshot();
+  });
+
+  it('should open the given rightClickUrl', () => {
+    delete window.location;
+    window.location = {} as Location;
+
+    const url = 'https://glints.com';
+    const { getByRole } = render(
+      <Brand asset="glints-black" rightClickURL={url} />
+    );
+    const container = getByRole('presentation');
+    fireEvent.contextMenu(container);
+    expect(window.location.href).toBe(url);
+  });
+
+  it('should call onContextMenu', () => {
+    delete window.location;
+    window.location = {} as Location;
+
+    const url = 'https://glints.com';
+    const onContextMenu = jest.fn();
+    const { getByRole } = render(
+      <Brand
+        asset="glints-black"
+        rightClickURL={url}
+        onContextMenu={onContextMenu}
+      />
+    );
+    const container = getByRole('presentation');
+    expect(onContextMenu).toHaveBeenCalledTimes(0);
+    fireEvent.contextMenu(container);
+    expect(onContextMenu).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/General/Brand/__snapshots__/Brand.test.tsx.snap
+++ b/src/General/Brand/__snapshots__/Brand.test.tsx.snap
@@ -1,0 +1,118 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Brand/>  should render as expected 1`] = `
+.c0 {
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus > img {
+  outline: 5px auto -webkit-focus-ring-color;
+}
+
+.c1 {
+  object-fit: contain;
+  width: 3em;
+  height: 3em;
+  outline: none;
+}
+
+<div
+  className="c0 aries-brand"
+  onContextMenu={[Function]}
+  role="presentation"
+  tabIndex={0}
+>
+  <img
+    className="c1 brand-image"
+    src="test-file-stub"
+    tabIndex={-1}
+  />
+</div>
+`;
+
+exports[`<Brand/>  should render as expected 2`] = `
+.c0 {
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus > img {
+  outline: 5px auto -webkit-focus-ring-color;
+}
+
+.c1 {
+  object-fit: contain;
+  width: 3em;
+  height: 3em;
+  outline: none;
+}
+
+<div
+  className="c0 aries-brand"
+  onContextMenu={[Function]}
+  role="presentation"
+  tabIndex={0}
+>
+  <img
+    className="c1 brand-image"
+    src="test-file-stub"
+    tabIndex={-1}
+  />
+</div>
+`;
+
+exports[`<Brand/>  should render as expected 3`] = `
+.c0 {
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  cursor: pointer;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus > img {
+  outline: 5px auto -webkit-focus-ring-color;
+}
+
+.c1 {
+  object-fit: contain;
+  width: 3em;
+  height: 3em;
+  outline: none;
+}
+
+<div
+  className="c0 aries-brand"
+  onContextMenu={[Function]}
+  role="presentation"
+  tabIndex={0}
+>
+  <img
+    className="c1 brand-image"
+    src="http://example.com/example.jpg"
+    tabIndex={-1}
+  />
+</div>
+`;

--- a/src/General/ProfilePicture/__snapshots__/ProfilePicture.test.tsx.snap
+++ b/src/General/ProfilePicture/__snapshots__/ProfilePicture.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`<ProfilePicture/> snapshots with mouse event mouseenter and mouseleave 
   content: '';
   position: absolute;
   z-index: -1;
-  background: url(.styledComponentId);
+  background: url(test-file-stub);
   height: 100%;
   width: 100%;
   border-radius: 50%;
@@ -130,7 +130,7 @@ exports[`<ProfilePicture/> snapshots with mouse event mouseenter and mouseleave 
   content: '';
   position: absolute;
   z-index: -1;
-  background: url(.styledComponentId);
+  background: url(test-file-stub);
   height: 100%;
   width: 100%;
   border-radius: 50%;
@@ -195,7 +195,7 @@ exports[`<ProfilePicture/> snapshots with mouse event mouseenter and mouseleave 
   content: '';
   position: absolute;
   z-index: -1;
-  background: url(.styledComponentId);
+  background: url(test-file-stub);
   height: 100%;
   width: 100%;
   border-radius: 50%;
@@ -258,7 +258,7 @@ exports[`<ProfilePicture/> snapshots with mouse event mouseenter and mouseleave 
   content: '';
   position: absolute;
   z-index: -1;
-  background: url(.styledComponentId);
+  background: url(test-file-stub);
   height: 100%;
   width: 100%;
   border-radius: 50%;
@@ -321,7 +321,7 @@ exports[`<ProfilePicture/> snapshots with prop editable editable false 1`] = `
   content: '';
   position: absolute;
   z-index: -1;
-  background: url(.styledComponentId);
+  background: url(test-file-stub);
   height: 100%;
   width: 100%;
   border-radius: 50%;
@@ -397,7 +397,7 @@ exports[`<ProfilePicture/> snapshots with prop editable editable true 1`] = `
   content: '';
   position: absolute;
   z-index: -1;
-  background: url(.styledComponentId);
+  background: url(test-file-stub);
   height: 100%;
   width: 100%;
   border-radius: 50%;

--- a/test/__mocks__/fileMock.js
+++ b/test/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';


### PR DESCRIPTION
Closes #334

First of all this PR adds a config option to package.json that lets snapshots deal with references to assets like jpgs.

And then I had some trouble in the tests because `Brand` sets `window.location.href` on right-click. Of course this threw an error in the tests but I found out that I can work around that by overwriting `window.location` with my own (empty) object.