### PR TITLE
Modal: won't mount children when visible

### DIFF
--- a/src/Application/Gallery/Gallery.test.tsx
+++ b/src/Application/Gallery/Gallery.test.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { fireEvent, render } from '@testing-library/react';
+
+import Gallery from './Gallery';
+
+const Component = () => (
+  <Gallery>
+    <img src="mockImageSrc" />
+  </Gallery>
+);
+
+describe('<Gallery>', () => {
+  it('Slider should be focused when Modal is open', () => {
+    render(<Component />);
+    const item = document.querySelector('.gallery-item');
+    fireEvent.click(item);
+    const slider = document.querySelector('.aries-slider');
+    expect(slider).toHaveFocus();
+  });
+});

--- a/src/Application/Gallery/Gallery.tsx
+++ b/src/Application/Gallery/Gallery.tsx
@@ -64,7 +64,12 @@ class Gallery extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
-    if (!prevState.visible && this.state.visible) {
+    if (
+      !prevState.visible &&
+      this.state.visible &&
+      this.sliderRef.current &&
+      this.sliderRef.current.sliderContainerRef.current
+    ) {
       this.sliderRef.current.sliderContainerRef.current.focus();
     }
   }

--- a/src/Application/Gallery/Gallery.tsx
+++ b/src/Application/Gallery/Gallery.tsx
@@ -69,10 +69,6 @@ class Gallery extends React.Component<Props, State> {
     }
   }
 
-  componentWillUnmount() {
-    this.sliderRef.current.sliderContainerRef.current.blur();
-  }
-
   render() {
     const { children, imagesDisplayed = defaultImagesDisplayed } = this.props;
     const { visible, currentIndex, imageLeft } = this.state;

--- a/src/Application/Gallery/Gallery.tsx
+++ b/src/Application/Gallery/Gallery.tsx
@@ -63,8 +63,8 @@ class Gallery extends React.Component<Props, State> {
     }
   }
 
-  componentDidUpdate(prevProps: Props, nextState: State) {
-    if (!nextState.visible) {
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    if (!prevState.visible && this.state.visible) {
       this.sliderRef.current.sliderContainerRef.current.focus();
     }
   }

--- a/src/Display/Modal/Modal.test.tsx
+++ b/src/Display/Modal/Modal.test.tsx
@@ -96,6 +96,16 @@ describe('when modal is closed', () => {
   });
 });
 
+it('children should not be mounted', () => {
+  const { queryByTestId } = render(
+    <Modal isVisible={false} onClose={props.onClose}>
+      <p data-testid="modal-children">{props.content}</p>
+    </Modal>
+  );
+  const children = queryByTestId('modal-children');
+  expect(children).not.toBeInTheDocument();
+});
+
 const escapeEvent = {
   key: 'Escape',
   keyCode: 27,

--- a/src/Display/Modal/Modal.test.tsx
+++ b/src/Display/Modal/Modal.test.tsx
@@ -94,16 +94,16 @@ describe('when modal is closed', () => {
     const { modalContainer } = setupModal(false);
     expect(modalContainer).toHaveStyle('visibility: hidden');
   });
-});
 
-it('children should not be mounted', () => {
-  const { queryByTestId } = render(
-    <Modal isVisible={false} onClose={props.onClose}>
-      <p data-testid="modal-children">{props.content}</p>
-    </Modal>
-  );
-  const children = queryByTestId('modal-children');
-  expect(children).not.toBeInTheDocument();
+  it('children should not be mounted', () => {
+    const { queryByTestId } = render(
+      <Modal isVisible={false} onClose={props.onClose}>
+        <p data-testid="modal-children">{props.content}</p>
+      </Modal>
+    );
+    const children = queryByTestId('modal-children');
+    expect(children).not.toBeInTheDocument();
+  });
 });
 
 const escapeEvent = {

--- a/src/Display/Modal/Modal.tsx
+++ b/src/Display/Modal/Modal.tsx
@@ -123,7 +123,7 @@ const Modal = (props: Props) => {
             </ModalHeader>
           )}
           <ModalBody className="modal-body" hideContentArea={hideContentArea}>
-            {children}
+            {isVisible && children}
           </ModalBody>
           {footer !== undefined && (
             <ModalFooter className="modal-footer">{footer}</ModalFooter>


### PR DESCRIPTION
## Why
- To avoid unmounting the children manually, e.g. https://gitlab.glints.com/glints/glints-dst/-/blob/staging/app/modules/Login/Components/LoginModal.js#L18

## What changed
- Modal won't mount children when it is not visible
- Gallery add test case for the failed focus event
- Already tested the `QuestionCardGallery` component on my local