### PR TITLE
RadioButton: Extend component props and styles

### DIFF
--- a/src/Input/RadioButton/RadioButton.tsx
+++ b/src/Input/RadioButton/RadioButton.tsx
@@ -5,17 +5,33 @@ import classNames from 'classnames';
 import { RadioContainer, RadioLabel } from '../../Style/Input/RadioButtonStyle';
 
 const RadioButton: React.FunctionComponent<Props> = props => {
-  const { label, theme, className, ...defaultProps } = props;
+  const {
+    className,
+    children,
+    error,
+    label,
+    labelProps,
+    theme,
+    ...inputProps
+  } = props;
 
   return (
     <React.Fragment>
       <RadioContainer
         className={classNames('aries-radiobtn', className)}
+        error={error}
         tabIndex={0}
+        theme={theme}
+        {...labelProps}
       >
-        <input type="radio" {...defaultProps} />
-        <RadioLabel className="radiobtn-content" theme={theme} tabIndex={-1}>
-          {label}
+        <input type="radio" {...inputProps} />
+        <RadioLabel
+          className="radiobtn-content"
+          error={error}
+          theme={theme}
+          tabIndex={-1}
+        >
+          {label || children}
         </RadioLabel>
       </RadioContainer>
     </React.Fragment>
@@ -23,8 +39,10 @@ const RadioButton: React.FunctionComponent<Props> = props => {
 };
 
 interface Props extends React.ComponentProps<'input'> {
-  label: string;
-  theme?: string;
+  error?: boolean;
+  label?: React.ReactNode;
+  labelProps?: React.LabelHTMLAttributes<{}>;
+  theme?: 'white';
 }
 
 export default RadioButton;

--- a/src/Input/RadioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/Input/RadioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<RadioButton> should render as expected 1`] = `
 <label
-  className="RadioButtonStyle__RadioContainer-sc-1xclcfi-1 llKmen aries-radiobtn"
+  className="RadioButtonStyle__RadioContainer-sc-1xclcfi-1 jwGjPn aries-radiobtn"
   tabIndex={0}
 >
   <input
@@ -11,7 +11,7 @@ exports[`<RadioButton> should render as expected 1`] = `
     value="full-time"
   />
   <span
-    className="RadioButtonStyle__RadioLabel-sc-1xclcfi-0 nYOUk radiobtn-content"
+    className="RadioButtonStyle__RadioLabel-sc-1xclcfi-0 jqDYWd radiobtn-content"
     tabIndex={-1}
   >
     Full Time
@@ -21,7 +21,7 @@ exports[`<RadioButton> should render as expected 1`] = `
 
 exports[`<RadioButton> should render as expected 2`] = `
 <label
-  className="RadioButtonStyle__RadioContainer-sc-1xclcfi-1 llKmen aries-radiobtn"
+  className="RadioButtonStyle__RadioContainer-sc-1xclcfi-1 jePPMf aries-radiobtn"
   tabIndex={0}
 >
   <input
@@ -30,7 +30,7 @@ exports[`<RadioButton> should render as expected 2`] = `
     value="full-time"
   />
   <span
-    className="RadioButtonStyle__RadioLabel-sc-1xclcfi-0 cQeeCd radiobtn-content"
+    className="RadioButtonStyle__RadioLabel-sc-1xclcfi-0 icUGCb radiobtn-content"
     tabIndex={-1}
   >
     Full Time
@@ -41,7 +41,7 @@ exports[`<RadioButton> should render as expected 2`] = `
 exports[`<RadioButton> should render as expected 3`] = `
 Array [
   <label
-    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-1 llKmen aries-radiobtn"
+    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-1 jwGjPn aries-radiobtn"
     tabIndex={0}
   >
     <input
@@ -50,14 +50,14 @@ Array [
       value="full-time"
     />
     <span
-      className="RadioButtonStyle__RadioLabel-sc-1xclcfi-0 nYOUk radiobtn-content"
+      className="RadioButtonStyle__RadioLabel-sc-1xclcfi-0 jqDYWd radiobtn-content"
       tabIndex={-1}
     >
       Full Time
     </span>
   </label>,
   <label
-    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-1 llKmen aries-radiobtn"
+    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-1 jwGjPn aries-radiobtn"
     tabIndex={0}
   >
     <input
@@ -66,7 +66,7 @@ Array [
       value="intership"
     />
     <span
-      className="RadioButtonStyle__RadioLabel-sc-1xclcfi-0 nYOUk radiobtn-content"
+      className="RadioButtonStyle__RadioLabel-sc-1xclcfi-0 jqDYWd radiobtn-content"
       tabIndex={-1}
     >
       Intership
@@ -78,7 +78,7 @@ Array [
 exports[`<RadioButton> should render as expected 4`] = `
 Array [
   <label
-    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-1 llKmen aries-radiobtn"
+    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-1 jwGjPn aries-radiobtn"
     tabIndex={0}
   >
     <input
@@ -88,14 +88,14 @@ Array [
       value="full-time"
     />
     <span
-      className="RadioButtonStyle__RadioLabel-sc-1xclcfi-0 nYOUk radiobtn-content"
+      className="RadioButtonStyle__RadioLabel-sc-1xclcfi-0 jqDYWd radiobtn-content"
       tabIndex={-1}
     >
       Full Time
     </span>
   </label>,
   <label
-    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-1 llKmen aries-radiobtn"
+    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-1 jwGjPn aries-radiobtn"
     tabIndex={0}
   >
     <input
@@ -104,7 +104,7 @@ Array [
       value="intership"
     />
     <span
-      className="RadioButtonStyle__RadioLabel-sc-1xclcfi-0 nYOUk radiobtn-content"
+      className="RadioButtonStyle__RadioLabel-sc-1xclcfi-0 jqDYWd radiobtn-content"
       tabIndex={-1}
     >
       Intership

--- a/src/Style/Input/RadioButtonStyle.ts
+++ b/src/Style/Input/RadioButtonStyle.ts
@@ -1,12 +1,19 @@
-import styled from 'styled-components';
-import { SecondaryColor } from '../Colors';
+import styled, { css } from 'styled-components';
 
-export const RadioLabel = styled.span`
+import { PrimaryColor, SecondaryColor } from '../Colors';
+
+interface Props {
+  error?: boolean;
+  theme?: string;
+}
+
+export const RadioLabel = styled.span<Props>`
   display: inline-flex;
+  align-items: center;
   position: relative;
   font-size: 1em;
   color: ${({ theme }) =>
-    theme === 'white' ? `${SecondaryColor.white}` : `${SecondaryColor.black}`};
+    theme === 'white' ? SecondaryColor.white : SecondaryColor.black};
   outline: none;
 
   &:before {
@@ -17,42 +24,85 @@ export const RadioLabel = styled.span`
     left: 0;
     margin-right: 8px;
     border-radius: 50%;
-    width: 1.4em;
-    height: 1.4em;
-    border: ${({ theme }) =>
-      theme === 'white'
-        ? `1px solid ${SecondaryColor.white}`
-        : `1px solid ${SecondaryColor.lightgrey}`};
-    background: ${({ theme }) =>
-      theme === 'white' ? 'transparent' : `${SecondaryColor.white}`};
+    height: 18px;
+    width: 18px;
+    flex-shrink: 0;
+
+    ${({ error, theme }) => {
+      if (error) {
+        return css`
+          border: solid 2px ${PrimaryColor.glintsred};
+        `;
+      } else if (theme === 'white') {
+        return css`
+          border: solid 2px ${SecondaryColor.white};
+        `;
+      } else {
+        return css`
+          border: solid 2px ${SecondaryColor.grey};
+        `;
+      }
+    }}
   }
+
   &:after {
     content: '';
     display: block;
-    width: 1em;
-    height: 1em;
-    background: ${({ theme }) =>
-      theme === 'white'
-        ? `${SecondaryColor.white}`
-        : `${SecondaryColor.darkgreen}`};
+    height: 8px;
+    width: 8px;
     position: absolute;
     border-radius: 50%;
-    top: 0.2em;
-    left: 0.2em;
+    left: 5px;
+    top: 50%;
+    margin-top: -4px;
     opacity: 0;
     transform: scale(0, 0);
     transition: all 0.2s cubic-bezier(0.64, 0.57, 0.67, 1.53);
+
+    ${({ error, theme }) => {
+      if (error) {
+        return css`
+          background: ${PrimaryColor.glintsred};
+        `;
+      } else if (theme === 'white') {
+        return css`
+          background: ${SecondaryColor.white};
+        `;
+      } else {
+        return css`
+          background: ${SecondaryColor.darkgreen};
+        `;
+      }
+    }}
   }
 `;
 
-export const RadioContainer = styled.label`
+export const RadioContainer = styled.label<Props>`
   display: inline-flex;
   cursor: pointer;
   user-select: none;
   text-align: left;
 
   input {
-    display: none;
+    opacity: 0;
+
+    &:checked + span:before {
+      ${({ error, theme }) => {
+        if (error) {
+          return css`
+            border-color: solid 2px ${PrimaryColor.glintsred};
+          `;
+        } else if (theme === 'white') {
+          return css`
+            border-color: ${SecondaryColor.white};
+          `;
+        } else {
+          return css`
+            border-color: ${SecondaryColor.darkgreen};
+          `;
+        }
+      }}
+    }
 
     &:checked + span:after {
       opacity: 1;

--- a/stories/Input/RadioButtonStory.tsx
+++ b/stories/Input/RadioButtonStory.tsx
@@ -4,6 +4,8 @@ import StorybookComponent from '../StorybookComponent';
 
 import RadioButton from '../../src/Input/RadioButton';
 
+const jsxToString = require('jsx-to-string');
+
 const props = {
   RadioButton: [
     {
@@ -39,30 +41,47 @@ const props = {
       description: '',
     },
     {
+      name: 'error',
+      type: 'boolean',
+      defaultValue: <code>false</code>,
+      possibleValue: <code>true | false</code>,
+      require: 'no',
+      description: 'Displays the error styles',
+    },
+    {
+      name: 'labelProps',
+      type: 'object',
+      defaultValue: '',
+      possibleValue: '',
+      require: 'no',
+      description: 'Sets the props on the label element.',
+    },
+    {
       name: 'theme',
       type: 'boolean',
-      defaultValue: <code>black</code>,
-      possibleValue: <code>black | white</code>,
+      defaultValue: '',
+      possibleValue: <code>white</code>,
       require: 'no',
       description: 'Sets theme for Radio Button.',
     },
   ],
 };
 
+const Story = (
+  <div>
+    <RadioButton label="Full Time" name="job-type" value="full-time" />
+    <RadioButton label="Intership" name="job-type" value="intership" error />
+  </div>
+);
+
 const RadioButtonStory = () => (
   <StorybookComponent
     title="Radio Button"
     code="import { RadioButton } from 'glints-aries'"
     propsObject={props}
-    usage={`<RadioButton 
-  label="Full Time" 
-  name="job-type" 
-  value="full-time"
-/>`}
+    usage={jsxToString(Story)}
   >
-    <RadioButton label="Full Time" name="job-type" value="full-time" />
-    <div style={{ display: 'inline-flex', marginRight: '1em' }} />
-    <RadioButton label="Intership" name="job-type" value="intership" />
+    {Story}
   </StorybookComponent>
 );
 


### PR DESCRIPTION
https://github.com/glints-dev/glints-aries/issues/339

- Add children prop to render a ReactNode instead of just a string
- Add error prop to display the error styles
- Fix some UI mismatches
- Edit styles to improve reusbility

This affects the Switch component as well.