### PR TITLE
RadioButton: GDS aligment

### DIFF
--- a/src/Input/RadioButton/RadioButton.test.tsx
+++ b/src/Input/RadioButton/RadioButton.test.tsx
@@ -4,7 +4,8 @@ import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import userEvent from '@testing-library/user-event';
 
-import RadioButton from './RadioButton';
+import { PrimaryColor, SecondaryColor, Greyscale } from '../../Style/Colors';
+import RadioButton, { Props } from './RadioButton';
 
 const singleRadioButton = (
   <RadioButton label="Full Time" name="job-type" value="full-time" />
@@ -119,5 +120,89 @@ describe('<RadioButton>', () => {
     const radioButton = getByTestId('radio');
     userEvent.click(radioButton);
     expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('<RadioButton /> color', () => {
+  const onChange = jest.fn();
+  const Component = (props: Props) => (
+    <RadioButton
+      label="Full Time"
+      name="job-type"
+      value="full-time"
+      onChange={onChange}
+      {...props}
+    />
+  );
+  it('should be grey by default', () => {
+    const { getByTestId } = render(<Component />);
+    const radioIcon = getByTestId('radio-icon');
+    expect(radioIcon).toHaveStyle(`border-color: ${Greyscale.grey}`);
+  });
+
+  it('should be green when checked', () => {
+    const { getByTestId } = render(<Component checked />);
+    const radioIcon = getByTestId('radio-icon');
+    expect(radioIcon).toHaveStyle(`border-color: ${SecondaryColor.darkgreen}`);
+  });
+
+  it('should be red when has error', () => {
+    const { getByTestId } = render(<Component error />);
+    const radioIcon = getByTestId('radio-icon');
+    expect(radioIcon).toHaveStyle(`border-color: ${PrimaryColor.glintsred}`);
+  });
+
+  it('should be light grey when disabled', () => {
+    const { getByTestId } = render(<Component disabled />);
+    const radioIcon = getByTestId('radio-icon');
+    expect(radioIcon).toHaveStyle(`border-color: ${Greyscale.lightgrey}`);
+  });
+});
+
+describe('<RadioButton border /> color', () => {
+  const onChange = jest.fn();
+  const Component = (props: Props) => (
+    <RadioButton
+      label="Full Time"
+      name="job-type"
+      value="full-time"
+      onChange={onChange}
+      border={true}
+      {...props}
+    />
+  );
+  it('should be grey by default', () => {
+    const { getByTestId } = render(<Component />);
+    const radioIcon = getByTestId('radio-icon');
+    const radioBorder = getByTestId('radio-border');
+    expect(radioIcon).toHaveStyle(`border-color: ${Greyscale.grey}`);
+    expect(radioBorder).toHaveStyle('border-color: #aaa');
+  });
+
+  it('should be blue when checked', () => {
+    const { getByTestId } = render(<Component checked />);
+    const radioIcon = getByTestId('radio-icon');
+    const radioBorder = getByTestId('radio-border');
+    expect(radioIcon).toHaveStyle(`border-color: ${SecondaryColor.actionblue}`);
+    expect(radioBorder).toHaveStyle(
+      `border-color: ${SecondaryColor.actionblue}`
+    );
+  });
+
+  it('should be blue when error', () => {
+    const { getByTestId } = render(<Component error />);
+    const radioIcon = getByTestId('radio-icon');
+    const radioBorder = getByTestId('radio-border');
+    expect(radioIcon).toHaveStyle(`border-color: ${Greyscale.grey}`);
+    expect(radioBorder).toHaveStyle(`border-color: ${PrimaryColor.glintsred}`);
+    expect(radioBorder).toHaveStyle('background-color: rgba(236, 39, 43, 0.1)');
+  });
+
+  it('should be light grey when disabled', () => {
+    const { getByTestId } = render(<Component disabled />);
+    const radioIcon = getByTestId('radio-icon');
+    const radioBorder = getByTestId('radio-border');
+    expect(radioIcon).toHaveStyle(`border-color: ${Greyscale.lightgrey}`);
+    expect(radioBorder).toHaveStyle(`border-color: ${Greyscale.lightgrey}`);
   });
 });

--- a/src/Input/RadioButton/RadioButton.test.tsx
+++ b/src/Input/RadioButton/RadioButton.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import userEvent from '@testing-library/user-event';
 
 import RadioButton from './RadioButton';
 
@@ -101,5 +102,22 @@ describe('<RadioButton>', () => {
     fireEvent.click(radioButton2);
     expect(radioButton1).not.toBeChecked();
     expect(radioButton2).toBeChecked();
+  });
+
+  it('should not call onChange again when disabled', () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <RadioButton
+        label="Full Time"
+        name="job-type"
+        value="full-time"
+        data-testid="radio"
+        onChange={onChange}
+        disabled={true}
+      />
+    );
+    const radioButton = getByTestId('radio');
+    userEvent.click(radioButton);
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/src/Input/RadioButton/RadioButton.tsx
+++ b/src/Input/RadioButton/RadioButton.tsx
@@ -26,9 +26,10 @@ const RadioButton: React.FunctionComponent<Props> = props => {
   const content = (
     <>
       <RadioIcon
-        size={size}
-        border={border}
         error={error}
+        theme={theme}
+        border={border}
+        size={size}
         disabled={disabled}
       />
       <RadioLabel
@@ -37,8 +38,8 @@ const RadioButton: React.FunctionComponent<Props> = props => {
         theme={theme}
         tabIndex={-1}
         border={border}
-        disabled={disabled}
         size={size}
+        disabled={disabled}
       >
         {label || children}
       </RadioLabel>

--- a/src/Input/RadioButton/RadioButton.tsx
+++ b/src/Input/RadioButton/RadioButton.tsx
@@ -13,6 +13,7 @@ const RadioButton: React.FunctionComponent<Props> = props => {
     labelProps,
     theme,
     border,
+    disabled,
     ...inputProps
   } = props;
 
@@ -24,15 +25,17 @@ const RadioButton: React.FunctionComponent<Props> = props => {
         tabIndex={0}
         theme={theme}
         border={border}
+        disabled={disabled}
         {...labelProps}
       >
-        <input type="radio" {...inputProps} />
+        <input type="radio" disabled={disabled} {...inputProps} />
         <RadioLabel
           className="radiobtn-content"
           error={error}
           theme={theme}
           tabIndex={-1}
           border={border}
+          disabled={disabled}
         >
           {label || children}
         </RadioLabel>
@@ -47,6 +50,7 @@ interface Props extends React.ComponentProps<'input'> {
   labelProps?: React.LabelHTMLAttributes<{}>;
   theme?: 'white';
   border?: boolean;
+  disabled?: boolean;
 }
 
 export default RadioButton;

--- a/src/Input/RadioButton/RadioButton.tsx
+++ b/src/Input/RadioButton/RadioButton.tsx
@@ -31,6 +31,7 @@ const RadioButton: React.FunctionComponent<Props> = props => {
         border={border}
         size={size}
         disabled={disabled}
+        data-testid="radio-icon"
       />
       <RadioLabel
         className="radiobtn-content"
@@ -58,7 +59,7 @@ const RadioButton: React.FunctionComponent<Props> = props => {
     >
       <input type="radio" disabled={disabled} {...inputProps} />
       {border ? (
-        <Border error={error} disabled={disabled}>
+        <Border error={error} disabled={disabled} data-testid="radio-border">
           {content}
         </Border>
       ) : (
@@ -70,7 +71,7 @@ const RadioButton: React.FunctionComponent<Props> = props => {
 
 type HTMLInputProps = Omit<React.HTMLProps<HTMLInputElement>, 'size' | 'label'>;
 
-interface Props extends HTMLInputProps {
+export interface Props extends HTMLInputProps {
   error?: boolean;
   label?: React.ReactNode;
   labelProps?: React.LabelHTMLAttributes<{}>;

--- a/src/Input/RadioButton/RadioButton.tsx
+++ b/src/Input/RadioButton/RadioButton.tsx
@@ -14,6 +14,7 @@ const RadioButton: React.FunctionComponent<Props> = props => {
     theme,
     border,
     disabled,
+    size = 'regular',
     ...inputProps
   } = props;
 
@@ -36,6 +37,7 @@ const RadioButton: React.FunctionComponent<Props> = props => {
           tabIndex={-1}
           border={border}
           disabled={disabled}
+          size={size}
         >
           {label || children}
         </RadioLabel>
@@ -44,13 +46,16 @@ const RadioButton: React.FunctionComponent<Props> = props => {
   );
 };
 
-interface Props extends React.ComponentProps<'input'> {
+type HTMLInputProps = Omit<React.HTMLProps<HTMLInputElement>, 'size' | 'label'>;
+
+interface Props extends HTMLInputProps {
   error?: boolean;
   label?: React.ReactNode;
   labelProps?: React.LabelHTMLAttributes<{}>;
   theme?: 'white';
   border?: boolean;
   disabled?: boolean;
+  size?: 'regular' | 'small';
 }
 
 export default RadioButton;

--- a/src/Input/RadioButton/RadioButton.tsx
+++ b/src/Input/RadioButton/RadioButton.tsx
@@ -12,6 +12,7 @@ const RadioButton: React.FunctionComponent<Props> = props => {
     label,
     labelProps,
     theme,
+    border,
     ...inputProps
   } = props;
 
@@ -22,6 +23,7 @@ const RadioButton: React.FunctionComponent<Props> = props => {
         error={error}
         tabIndex={0}
         theme={theme}
+        border={border}
         {...labelProps}
       >
         <input type="radio" {...inputProps} />
@@ -30,6 +32,7 @@ const RadioButton: React.FunctionComponent<Props> = props => {
           error={error}
           theme={theme}
           tabIndex={-1}
+          border={border}
         >
           {label || children}
         </RadioLabel>
@@ -43,6 +46,7 @@ interface Props extends React.ComponentProps<'input'> {
   label?: React.ReactNode;
   labelProps?: React.LabelHTMLAttributes<{}>;
   theme?: 'white';
+  border?: boolean;
 }
 
 export default RadioButton;

--- a/src/Input/RadioButton/RadioButton.tsx
+++ b/src/Input/RadioButton/RadioButton.tsx
@@ -2,7 +2,12 @@ import * as React from 'react';
 
 import classNames from 'classnames';
 
-import { RadioContainer, RadioLabel } from '../../Style/Input/RadioButtonStyle';
+import {
+  RadioContainer,
+  RadioLabel,
+  RadioIcon,
+  Border,
+} from '../../Style/Input/RadioButtonStyle';
 
 const RadioButton: React.FunctionComponent<Props> = props => {
   const {
@@ -18,31 +23,42 @@ const RadioButton: React.FunctionComponent<Props> = props => {
     ...inputProps
   } = props;
 
-  return (
-    <React.Fragment>
-      <RadioContainer
-        className={classNames('aries-radiobtn', className)}
+  const content = (
+    <>
+      <RadioIcon border={border} error={error} disabled={disabled} />
+      <RadioLabel
+        className="radiobtn-content"
         error={error}
-        tabIndex={0}
         theme={theme}
+        tabIndex={-1}
         border={border}
         disabled={disabled}
-        {...labelProps}
+        size={size}
       >
-        <input type="radio" disabled={disabled} {...inputProps} />
-        <RadioLabel
-          className="radiobtn-content"
-          error={error}
-          theme={theme}
-          tabIndex={-1}
-          border={border}
-          disabled={disabled}
-          size={size}
-        >
-          {label || children}
-        </RadioLabel>
-      </RadioContainer>
-    </React.Fragment>
+        {label || children}
+      </RadioLabel>
+    </>
+  );
+
+  return (
+    <RadioContainer
+      className={classNames('aries-radiobtn', className)}
+      error={error}
+      tabIndex={0}
+      theme={theme}
+      border={border}
+      disabled={disabled}
+      {...labelProps}
+    >
+      <input type="radio" disabled={disabled} {...inputProps} />
+      {border ? (
+        <Border error={error} disabled={disabled}>
+          {content}
+        </Border>
+      ) : (
+        content
+      )}
+    </RadioContainer>
   );
 };
 

--- a/src/Input/RadioButton/RadioButton.tsx
+++ b/src/Input/RadioButton/RadioButton.tsx
@@ -25,7 +25,12 @@ const RadioButton: React.FunctionComponent<Props> = props => {
 
   const content = (
     <>
-      <RadioIcon border={border} error={error} disabled={disabled} />
+      <RadioIcon
+        size={size}
+        border={border}
+        error={error}
+        disabled={disabled}
+      />
       <RadioLabel
         className="radiobtn-content"
         error={error}

--- a/src/Input/RadioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/Input/RadioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<RadioButton> should render as expected 1`] = `
 <label
-  className="RadioButtonStyle__RadioContainer-sc-1xclcfi-1 jwGjPn aries-radiobtn"
+  className="RadioButtonStyle__RadioContainer-sc-1xclcfi-3 fBNjVi aries-radiobtn"
   tabIndex={0}
 >
   <input
@@ -11,7 +11,12 @@ exports[`<RadioButton> should render as expected 1`] = `
     value="full-time"
   />
   <span
-    className="RadioButtonStyle__RadioLabel-sc-1xclcfi-0 jqDYWd radiobtn-content"
+    className="RadioButtonStyle__RadioIcon-sc-1xclcfi-0 dguAlE"
+    size="regular"
+  />
+  <span
+    className="RadioButtonStyle__RadioLabel-sc-1xclcfi-1 xviKd radiobtn-content"
+    size="regular"
     tabIndex={-1}
   >
     Full Time
@@ -21,7 +26,7 @@ exports[`<RadioButton> should render as expected 1`] = `
 
 exports[`<RadioButton> should render as expected 2`] = `
 <label
-  className="RadioButtonStyle__RadioContainer-sc-1xclcfi-1 jePPMf aries-radiobtn"
+  className="RadioButtonStyle__RadioContainer-sc-1xclcfi-3 gdqdYZ aries-radiobtn"
   tabIndex={0}
 >
   <input
@@ -30,7 +35,12 @@ exports[`<RadioButton> should render as expected 2`] = `
     value="full-time"
   />
   <span
-    className="RadioButtonStyle__RadioLabel-sc-1xclcfi-0 icUGCb radiobtn-content"
+    className="RadioButtonStyle__RadioIcon-sc-1xclcfi-0 YxYio"
+    size="regular"
+  />
+  <span
+    className="RadioButtonStyle__RadioLabel-sc-1xclcfi-1 ioQzrz radiobtn-content"
+    size="regular"
     tabIndex={-1}
   >
     Full Time
@@ -41,7 +51,7 @@ exports[`<RadioButton> should render as expected 2`] = `
 exports[`<RadioButton> should render as expected 3`] = `
 Array [
   <label
-    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-1 jwGjPn aries-radiobtn"
+    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-3 fBNjVi aries-radiobtn"
     tabIndex={0}
   >
     <input
@@ -50,14 +60,19 @@ Array [
       value="full-time"
     />
     <span
-      className="RadioButtonStyle__RadioLabel-sc-1xclcfi-0 jqDYWd radiobtn-content"
+      className="RadioButtonStyle__RadioIcon-sc-1xclcfi-0 dguAlE"
+      size="regular"
+    />
+    <span
+      className="RadioButtonStyle__RadioLabel-sc-1xclcfi-1 xviKd radiobtn-content"
+      size="regular"
       tabIndex={-1}
     >
       Full Time
     </span>
   </label>,
   <label
-    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-1 jwGjPn aries-radiobtn"
+    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-3 fBNjVi aries-radiobtn"
     tabIndex={0}
   >
     <input
@@ -66,7 +81,12 @@ Array [
       value="intership"
     />
     <span
-      className="RadioButtonStyle__RadioLabel-sc-1xclcfi-0 jqDYWd radiobtn-content"
+      className="RadioButtonStyle__RadioIcon-sc-1xclcfi-0 dguAlE"
+      size="regular"
+    />
+    <span
+      className="RadioButtonStyle__RadioLabel-sc-1xclcfi-1 xviKd radiobtn-content"
+      size="regular"
       tabIndex={-1}
     >
       Intership
@@ -78,7 +98,7 @@ Array [
 exports[`<RadioButton> should render as expected 4`] = `
 Array [
   <label
-    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-1 jwGjPn aries-radiobtn"
+    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-3 fBNjVi aries-radiobtn"
     tabIndex={0}
   >
     <input
@@ -88,14 +108,19 @@ Array [
       value="full-time"
     />
     <span
-      className="RadioButtonStyle__RadioLabel-sc-1xclcfi-0 jqDYWd radiobtn-content"
+      className="RadioButtonStyle__RadioIcon-sc-1xclcfi-0 dguAlE"
+      size="regular"
+    />
+    <span
+      className="RadioButtonStyle__RadioLabel-sc-1xclcfi-1 xviKd radiobtn-content"
+      size="regular"
       tabIndex={-1}
     >
       Full Time
     </span>
   </label>,
   <label
-    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-1 jwGjPn aries-radiobtn"
+    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-3 fBNjVi aries-radiobtn"
     tabIndex={0}
   >
     <input
@@ -104,7 +129,12 @@ Array [
       value="intership"
     />
     <span
-      className="RadioButtonStyle__RadioLabel-sc-1xclcfi-0 jqDYWd radiobtn-content"
+      className="RadioButtonStyle__RadioIcon-sc-1xclcfi-0 dguAlE"
+      size="regular"
+    />
+    <span
+      className="RadioButtonStyle__RadioLabel-sc-1xclcfi-1 xviKd radiobtn-content"
+      size="regular"
       tabIndex={-1}
     >
       Intership

--- a/src/Input/RadioButton/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/Input/RadioButton/__snapshots__/RadioButton.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<RadioButton> should render as expected 1`] = `
 <label
-  className="RadioButtonStyle__RadioContainer-sc-1xclcfi-3 fBNjVi aries-radiobtn"
+  className="RadioButtonStyle__RadioContainer-sc-1xclcfi-3 eyRelA aries-radiobtn"
   tabIndex={0}
 >
   <input
@@ -11,7 +11,8 @@ exports[`<RadioButton> should render as expected 1`] = `
     value="full-time"
   />
   <span
-    className="RadioButtonStyle__RadioIcon-sc-1xclcfi-0 dguAlE"
+    className="RadioButtonStyle__RadioIcon-sc-1xclcfi-0 hinYyw"
+    data-testid="radio-icon"
     size="regular"
   />
   <span
@@ -26,7 +27,7 @@ exports[`<RadioButton> should render as expected 1`] = `
 
 exports[`<RadioButton> should render as expected 2`] = `
 <label
-  className="RadioButtonStyle__RadioContainer-sc-1xclcfi-3 gdqdYZ aries-radiobtn"
+  className="RadioButtonStyle__RadioContainer-sc-1xclcfi-3 kINzCj aries-radiobtn"
   tabIndex={0}
 >
   <input
@@ -35,7 +36,8 @@ exports[`<RadioButton> should render as expected 2`] = `
     value="full-time"
   />
   <span
-    className="RadioButtonStyle__RadioIcon-sc-1xclcfi-0 YxYio"
+    className="RadioButtonStyle__RadioIcon-sc-1xclcfi-0 fYRZeZ"
+    data-testid="radio-icon"
     size="regular"
   />
   <span
@@ -51,7 +53,7 @@ exports[`<RadioButton> should render as expected 2`] = `
 exports[`<RadioButton> should render as expected 3`] = `
 Array [
   <label
-    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-3 fBNjVi aries-radiobtn"
+    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-3 eyRelA aries-radiobtn"
     tabIndex={0}
   >
     <input
@@ -60,7 +62,8 @@ Array [
       value="full-time"
     />
     <span
-      className="RadioButtonStyle__RadioIcon-sc-1xclcfi-0 dguAlE"
+      className="RadioButtonStyle__RadioIcon-sc-1xclcfi-0 hinYyw"
+      data-testid="radio-icon"
       size="regular"
     />
     <span
@@ -72,7 +75,7 @@ Array [
     </span>
   </label>,
   <label
-    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-3 fBNjVi aries-radiobtn"
+    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-3 eyRelA aries-radiobtn"
     tabIndex={0}
   >
     <input
@@ -81,7 +84,8 @@ Array [
       value="intership"
     />
     <span
-      className="RadioButtonStyle__RadioIcon-sc-1xclcfi-0 dguAlE"
+      className="RadioButtonStyle__RadioIcon-sc-1xclcfi-0 hinYyw"
+      data-testid="radio-icon"
       size="regular"
     />
     <span
@@ -98,7 +102,7 @@ Array [
 exports[`<RadioButton> should render as expected 4`] = `
 Array [
   <label
-    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-3 fBNjVi aries-radiobtn"
+    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-3 eyRelA aries-radiobtn"
     tabIndex={0}
   >
     <input
@@ -108,7 +112,8 @@ Array [
       value="full-time"
     />
     <span
-      className="RadioButtonStyle__RadioIcon-sc-1xclcfi-0 dguAlE"
+      className="RadioButtonStyle__RadioIcon-sc-1xclcfi-0 hinYyw"
+      data-testid="radio-icon"
       size="regular"
     />
     <span
@@ -120,7 +125,7 @@ Array [
     </span>
   </label>,
   <label
-    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-3 fBNjVi aries-radiobtn"
+    className="RadioButtonStyle__RadioContainer-sc-1xclcfi-3 eyRelA aries-radiobtn"
     tabIndex={0}
   >
     <input
@@ -129,7 +134,8 @@ Array [
       value="intership"
     />
     <span
-      className="RadioButtonStyle__RadioIcon-sc-1xclcfi-0 dguAlE"
+      className="RadioButtonStyle__RadioIcon-sc-1xclcfi-0 hinYyw"
+      data-testid="radio-icon"
       size="regular"
     />
     <span

--- a/src/Style/Input/RadioButtonStyle.ts
+++ b/src/Style/Input/RadioButtonStyle.ts
@@ -6,6 +6,7 @@ interface Props {
   error?: boolean;
   theme?: string;
   border?: boolean;
+  disabled?: boolean;
 }
 
 export const RadioLabel = styled.span<Props>`
@@ -31,8 +32,12 @@ export const RadioLabel = styled.span<Props>`
     width: 18px;
     flex-shrink: 0;
 
-    ${({ error, theme }) => {
-      if (error) {
+    ${({ error, theme, disabled }) => {
+      if (disabled) {
+        return css`
+          border-color: #9b9b9b;
+        `;
+      } else if (error) {
         return css`
           border-color: ${PrimaryColor.glintsred};
         `;
@@ -72,8 +77,13 @@ export const RadioLabel = styled.span<Props>`
     transform: scale(0, 0);
     transition: all 0.2s cubic-bezier(0.64, 0.57, 0.67, 1.53);
 
-    ${({ error, theme, border }) => {
-      if (error) {
+    ${({ error, theme, border, disabled }) => {
+      if (disabled) {
+        return css`
+          left: ${border ? '15px' : '5px'};
+          background-color: #9b9b9b;
+        `;
+      } else if (error) {
         return css`
           background-color: ${PrimaryColor.glintsred};
         `;
@@ -99,6 +109,7 @@ export const RadioLabel = styled.span<Props>`
       return css`
         padding: 15px 10px;
         border: 1px solid #aaa;
+        border-color: #aaa;
         border-radius: 2px;
 
         &:hover {
@@ -107,7 +118,22 @@ export const RadioLabel = styled.span<Props>`
         }
       `;
     }
-    return null;
+  }}
+
+  ${({ disabled }) => {
+    if (disabled) {
+      return css`
+        color: #aaa;
+      `;
+    }
+  }}
+
+  ${({ border, disabled }) => {
+    if (border && disabled) {
+      return css`
+        border-color: #e3e3e3;
+      `;
+    }
   }}
 `;
 
@@ -121,8 +147,10 @@ export const RadioContainer = styled.label<Props>`
     display: none;
 
     &:checked + ${RadioLabel} {
-      ${({ border }) => {
-        if (border) {
+      ${({ border, disabled }) => {
+        if (disabled) {
+          return null;
+        } else if (border) {
           return css`
             border-color: ${SecondaryColor.actionblue};
           `;
@@ -131,8 +159,10 @@ export const RadioContainer = styled.label<Props>`
     }
 
     &:checked + ${RadioLabel}:before {
-      ${({ error, theme, border }) => {
-        if (error) {
+      ${({ error, theme, border, disabled }) => {
+        if (disabled) {
+          return null;
+        } else if (error) {
           return css`
             border-color: ${PrimaryColor.glintsred};
           `;
@@ -161,4 +191,12 @@ export const RadioContainer = styled.label<Props>`
   &:focus {
     outline: none;
   }
+
+  ${({ disabled }) => {
+    if (disabled) {
+      return css`
+        pointer-events: none;
+      `;
+    }
+  }}
 `;

--- a/src/Style/Input/RadioButtonStyle.ts
+++ b/src/Style/Input/RadioButtonStyle.ts
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import { PrimaryColor, SecondaryColor } from '../Colors';
+import { PrimaryColor, SecondaryColor, Greyscale } from '../Colors';
 
 interface Props {
   error?: boolean;
@@ -35,7 +35,7 @@ export const RadioLabel = styled.span<Props>`
     ${({ error, theme, disabled }) => {
       if (disabled) {
         return css`
-          border-color: #9b9b9b;
+          border-color: ${Greyscale.lightgrey};
         `;
       } else if (error) {
         return css`
@@ -81,7 +81,7 @@ export const RadioLabel = styled.span<Props>`
       if (disabled) {
         return css`
           left: ${border ? '15px' : '5px'};
-          background-color: #9b9b9b;
+          background-color: ${Greyscale.lightgrey};
         `;
       } else if (error) {
         return css`
@@ -109,7 +109,6 @@ export const RadioLabel = styled.span<Props>`
       return css`
         padding: 15px 10px;
         border: 1px solid #aaa;
-        border-color: #aaa;
         border-radius: 2px;
 
         &:hover {
@@ -131,7 +130,7 @@ export const RadioLabel = styled.span<Props>`
   ${({ border, disabled }) => {
     if (border && disabled) {
       return css`
-        border-color: #e3e3e3;
+        border-color: ${Greyscale.lightgrey};
       `;
     }
   }}

--- a/src/Style/Input/RadioButtonStyle.ts
+++ b/src/Style/Input/RadioButtonStyle.ts
@@ -48,10 +48,6 @@ export const RadioIcon = styled.span<Props>`
   border-width: 2px;
   border-color: ${props => getStateColor(props, false)};
 
-  &:hover {
-    border-color: ${props => getStateColor(props, true)};
-  }
-
   &:after {
     content: '';
     display: inline-block;
@@ -139,4 +135,17 @@ export const RadioContainer = styled.label<Props>`
   &:focus {
     outline: none;
   }
+
+  ${({ disabled, error, border }) => {
+    if (!disabled && !error && !border) {
+      return css`
+        &:hover {
+          ${RadioIcon} {
+            border-color: ${SecondaryColor.darkgreen};
+          }
+        }
+      `;
+    }
+  }}
+
 `;

--- a/src/Style/Input/RadioButtonStyle.ts
+++ b/src/Style/Input/RadioButtonStyle.ts
@@ -2,21 +2,16 @@ import styled, { css } from 'styled-components';
 
 import { PrimaryColor, SecondaryColor, Greyscale } from '../Colors';
 
-const getStateColor = ({
-  disabled,
-  error,
-  border,
-  checked,
-}: {
-  disabled: boolean;
-  error: boolean;
-  border: boolean;
-  checked: boolean;
-}) => {
+const getStateColor = (
+  { disabled, error, border, theme }: Props,
+  checked: boolean
+) => {
   if (disabled) {
     return Greyscale.lightgrey;
   } else if (error) {
     return PrimaryColor.glintsred;
+  } else if (theme === 'white') {
+    return Greyscale.white;
   } else if (!checked) {
     return SecondaryColor.grey;
   } else if (border) {
@@ -51,11 +46,10 @@ export const RadioIcon = styled.span<Props>`
   border-radius: 50%;
   border-style: solid;
   border-width: 2px;
-  border-color: ${({ disabled, error, border }) =>
-    getStateColor({ disabled, error, border, checked: false })};
+  border-color: ${props => getStateColor(props, false)};
 
   &:hover {
-    border-color: ${SecondaryColor.darkgreen};
+    border-color: ${props => getStateColor(props, true)};
   }
 
   &:after {
@@ -67,16 +61,22 @@ export const RadioIcon = styled.span<Props>`
     opacity: 0;
     transform: scale(0, 0);
     transition: all 0.2s cubic-bezier(0.64, 0.57, 0.67, 1.53);
-    background-color: ${({ disabled, error, border }) =>
-      getStateColor({ disabled, error, border, checked: true })};
+    background-color: ${props => getStateColor(props, true)};
   }
 `;
 
 export const RadioLabel = styled.span<Props>`
   font-size: ${({ size }) => (size === 'regular' ? '16px' : '14px')};
   outline: none;
-  color: ${({ disabled }) =>
-    disabled ? Greyscale.lightgrey : SecondaryColor.black};
+  color: ${({ disabled, theme }) => {
+    if (disabled) {
+      return Greyscale.lightgrey;
+    } else if (theme === 'white') {
+      return Greyscale.white;
+    } else {
+      return SecondaryColor.black;
+    }
+  }};
 `;
 
 export const Border = styled.span<Props>`
@@ -101,6 +101,7 @@ export const Border = styled.span<Props>`
 `;
 
 export const RadioContainer = styled.label<Props>`
+  position: relative;
   display: inline-flex;
   align-items: center;
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};;
@@ -112,18 +113,15 @@ export const RadioContainer = styled.label<Props>`
 
     &:checked + ${RadioIcon} {
       ${showSolidCircleStyle}
-      border-color: ${({ disabled, error, border }) =>
-        getStateColor({ disabled, error, border, checked: true })};
+      border-color: ${props => getStateColor(props, true)};
     }
 
     &:checked + ${Border} {
-      border-color: ${({ disabled, error, border }) =>
-        getStateColor({ disabled, error, border, checked: true })};
+      border-color: ${props => getStateColor(props, true)};
 
       ${RadioIcon} {
         ${showSolidCircleStyle}
-        border-color: ${({ disabled, error, border }) =>
-          getStateColor({ disabled, error, border, checked: true })};
+        border-color: ${props => getStateColor(props, true)};
       }
     }
   }

--- a/src/Style/Input/RadioButtonStyle.ts
+++ b/src/Style/Input/RadioButtonStyle.ts
@@ -13,7 +13,7 @@ const getStateColor = (
   } else if (theme === 'white') {
     return Greyscale.white;
   } else if (!checked) {
-    return SecondaryColor.grey;
+    return Greyscale.grey;
   } else if (border) {
     return SecondaryColor.actionblue;
   } else {
@@ -74,7 +74,7 @@ export const RadioLabel = styled.span<Props>`
     } else if (theme === 'white') {
       return Greyscale.white;
     } else {
-      return SecondaryColor.black;
+      return Greyscale.black;
     }
   }};
 `;
@@ -88,15 +88,25 @@ export const Border = styled.span<Props>`
   border-radius: 2px;
   border-color: ${({ disabled }) => (disabled ? Greyscale.lightgrey : '#aaa')};
 
-  ${({ disabled }) => {
-    if (!disabled) {
+  ${({ disabled, error }) => {
+    if (disabled) {
+      return null;
+    } else if (error) {
       return css`
-        &:hover {
-          background-color: rgba(1, 126, 183, 0.1);
-          border-color: ${SecondaryColor.actionblue};
+        background-color: rgba(236, 39, 43, 0.1);
+        border-color: ${PrimaryColor.glintsred};
+
+        ${RadioIcon} {
+          border-color: ${Greyscale.grey};
         }
       `;
     }
+    return css`
+      &:hover {
+        background-color: rgba(1, 126, 183, 0.1);
+        border-color: ${SecondaryColor.actionblue};
+      }
+    `;
   }};
 `;
 
@@ -117,7 +127,7 @@ export const RadioContainer = styled.label<Props>`
     }
 
     &:checked + ${Border} {
-      border-color: ${props => getStateColor(props, true)};
+      background-color: transparent;
 
       ${RadioIcon} {
         ${showSolidCircleStyle}

--- a/src/Style/Input/RadioButtonStyle.ts
+++ b/src/Style/Input/RadioButtonStyle.ts
@@ -2,6 +2,37 @@ import styled, { css } from 'styled-components';
 
 import { PrimaryColor, SecondaryColor, Greyscale } from '../Colors';
 
+const getStateColor = ({
+  disabled,
+  error,
+  border,
+  checked,
+}: {
+  disabled: boolean;
+  error: boolean;
+  border: boolean;
+  checked: boolean;
+}) => {
+  if (disabled) {
+    return Greyscale.lightgrey;
+  } else if (error) {
+    return PrimaryColor.glintsred;
+  } else if (!checked) {
+    return SecondaryColor.grey;
+  } else if (border) {
+    return SecondaryColor.actionblue;
+  } else {
+    return SecondaryColor.darkgreen;
+  }
+};
+
+const showSolidCircleStyle = css`
+  &:after {
+    opacity: 1;
+    transform: scale(1, 1);
+  }
+`;
+
 interface Props {
   error?: boolean;
   theme?: string;
@@ -10,191 +41,93 @@ interface Props {
   size?: 'regular' | 'small';
 }
 
-export const RadioLabel = styled.span<Props>`
+export const RadioIcon = styled.span<Props>`
   display: inline-flex;
   align-items: center;
-  position: relative;
-  font-size: ${({ size }) => (size === 'regular' ? '16px' : '14px')};
-  color: ${({ theme }) =>
-    theme === 'white' ? SecondaryColor.white : SecondaryColor.black};
-  outline: none;
+  justify-content: center;
+  height: ${({ size }) => (size === 'regular' ? '18px' : '15px')};
+  width: ${({ size }) => (size === 'regular' ? '18px' : '15px')};
+  margin-right: 10px;
+  border-radius: 50%;
+  border-style: solid;
+  border-width: 2px;
+  border-color: ${({ disabled, error, border }) =>
+    getStateColor({ disabled, error, border, checked: false })};
 
-  &:before {
-    content: '';
-    display: block;
-    position: relative;
-    top: 0;
-    left: 0;
-    margin-right: 8px;
-    border-radius: 50%;
-    border-style: solid;
-    border-width: 2px;
-    height: ${({ size }) => (size === 'regular' ? '18px' : '15px')};;
-    width: ${({ size }) => (size === 'regular' ? '18px' : '15px')};;
-    flex-shrink: 0;
-
-    ${({ error, theme, disabled }) => {
-      if (disabled) {
-        return css`
-          border-color: ${Greyscale.lightgrey};
-        `;
-      } else if (error) {
-        return css`
-          border-color: ${PrimaryColor.glintsred};
-        `;
-      } else if (theme === 'white') {
-        return css`
-          border-color: ${SecondaryColor.white};
-        `;
-      } else {
-        return css`
-          border-color: ${SecondaryColor.grey};
-        `;
-      }
-    }}
-  }
-
-  &:hover:before {
-    ${({ error, border }) => {
-      if (!error && !border) {
-        return css`
-          border-color: ${SecondaryColor.darkgreen};
-        `;
-      }
-    }}
+  &:hover {
+    border-color: ${SecondaryColor.darkgreen};
   }
 
   &:after {
     content: '';
-    display: block;
+    display: inline-block;
     height: ${({ size }) => (size === 'regular' ? '8px' : '5px')};
     width: ${({ size }) => (size === 'regular' ? '8px' : '5px')};
-    position: absolute;
     border-radius: 50%;
-    left: 5px;
     opacity: 0;
     transform: scale(0, 0);
     transition: all 0.2s cubic-bezier(0.64, 0.57, 0.67, 1.53);
-
-    ${({ error, theme, border, disabled }) => {
-      if (disabled) {
-        return css`
-          left: ${border ? '15px' : '5px'};
-          background-color: ${Greyscale.lightgrey};
-        `;
-      } else if (error) {
-        return css`
-          background-color: ${PrimaryColor.glintsred};
-        `;
-      } else if (border) {
-        return css`
-          left: 15px;
-          background-color: ${SecondaryColor.actionblue};
-        `;
-      } else if (theme === 'white') {
-        return css`
-          background-color: ${SecondaryColor.white};
-        `;
-      } else {
-        return css`
-          background-color: ${SecondaryColor.darkgreen};
-        `;
-      }
-    }}
+    background-color: ${({ disabled, error, border }) =>
+      getStateColor({ disabled, error, border, checked: true })};
   }
+`;
 
-  ${({ border }) => {
-    if (border) {
+export const RadioLabel = styled.span<Props>`
+  font-size: ${({ size }) => (size === 'regular' ? '16px' : '14px')};
+  outline: none;
+  color: ${({ disabled }) => (disabled ? '#aaa' : SecondaryColor.black)};
+`;
+
+export const Border = styled.span<Props>`
+  display: flex;
+  align-items: center;
+  padding: 15px 10px;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 2px;
+  border-color: #aaa;
+
+  ${({ disabled }) => {
+    if (!disabled) {
       return css`
-        padding: 15px 10px;
-        border: 1px solid #aaa;
-        border-radius: 2px;
-
         &:hover {
           background-color: rgba(1, 126, 183, 0.1);
           border-color: ${SecondaryColor.actionblue};
         }
       `;
     }
-  }}
-
-  ${({ disabled }) => {
-    if (disabled) {
-      return css`
-        color: #aaa;
-      `;
-    }
-  }}
-
-  ${({ border, disabled }) => {
-    if (border && disabled) {
-      return css`
-        border-color: ${Greyscale.lightgrey};
-      `;
-    }
-  }}
+  }};
 `;
 
 export const RadioContainer = styled.label<Props>`
   display: inline-flex;
-  cursor: pointer;
+  align-items: center;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};;
   user-select: none;
   text-align: left;
 
   input {
     display: none;
 
-    &:checked + ${RadioLabel} {
-      ${({ border, disabled }) => {
-        if (disabled) {
-          return null;
-        } else if (border) {
-          return css`
-            border-color: ${SecondaryColor.actionblue};
-          `;
-        }
-      }}
+    &:checked + ${RadioIcon} {
+      ${showSolidCircleStyle}
+      border-color: ${({ disabled, error, border }) =>
+        getStateColor({ disabled, error, border, checked: true })};
     }
 
-    &:checked + ${RadioLabel}:before {
-      ${({ error, theme, border, disabled }) => {
-        if (disabled) {
-          return null;
-        } else if (error) {
-          return css`
-            border-color: ${PrimaryColor.glintsred};
-          `;
-        } else if (border) {
-          return css`
-            border-color: ${SecondaryColor.actionblue};
-          `;
-        } else if (theme === 'white') {
-          return css`
-            border-color: ${SecondaryColor.white};
-          `;
-        } else {
-          return css`
-            border-color: ${SecondaryColor.darkgreen};
-          `;
-        }
-      }}
-    }
+    &:checked + ${Border} {
+      border-color: ${({ disabled, error, border }) =>
+        getStateColor({ disabled, error, border, checked: true })};
 
-    &:checked + ${RadioLabel}:after {
-      opacity: 1;
-      transform: scale(1, 1);
+      ${RadioIcon} {
+        ${showSolidCircleStyle}
+        border-color: ${({ disabled, error, border }) =>
+          getStateColor({ disabled, error, border, checked: true })};
+      }
     }
   }
 
   &:focus {
     outline: none;
   }
-
-  ${({ disabled }) => {
-    if (disabled) {
-      return css`
-        pointer-events: none;
-      `;
-    }
-  }}
 `;

--- a/src/Style/Input/RadioButtonStyle.ts
+++ b/src/Style/Input/RadioButtonStyle.ts
@@ -5,6 +5,7 @@ import { PrimaryColor, SecondaryColor } from '../Colors';
 interface Props {
   error?: boolean;
   theme?: string;
+  border?: boolean;
 }
 
 export const RadioLabel = styled.span<Props>`
@@ -24,6 +25,8 @@ export const RadioLabel = styled.span<Props>`
     left: 0;
     margin-right: 8px;
     border-radius: 50%;
+    border-style: solid;
+    border-width: 2px;
     height: 18px;
     width: 18px;
     flex-shrink: 0;
@@ -31,15 +34,15 @@ export const RadioLabel = styled.span<Props>`
     ${({ error, theme }) => {
       if (error) {
         return css`
-          border: solid 2px ${PrimaryColor.glintsred};
+          border-color: ${PrimaryColor.glintsred};
         `;
       } else if (theme === 'white') {
         return css`
-          border: solid 2px ${SecondaryColor.white};
+          border-color: ${SecondaryColor.white};
         `;
       } else {
         return css`
-          border: solid 2px ${SecondaryColor.grey};
+          border-color: ${SecondaryColor.grey};
         `;
       }
     }}
@@ -59,22 +62,43 @@ export const RadioLabel = styled.span<Props>`
     transform: scale(0, 0);
     transition: all 0.2s cubic-bezier(0.64, 0.57, 0.67, 1.53);
 
-    ${({ error, theme }) => {
+    ${({ error, theme, border }) => {
       if (error) {
         return css`
-          background: ${PrimaryColor.glintsred};
+          background-color: ${PrimaryColor.glintsred};
+        `;
+      } else if (border) {
+        return css`
+          left: 15px;
+          background-color: ${SecondaryColor.actionblue};
         `;
       } else if (theme === 'white') {
         return css`
-          background: ${SecondaryColor.white};
+          background-color: ${SecondaryColor.white};
         `;
       } else {
         return css`
-          background: ${SecondaryColor.darkgreen};
+          background-color: ${SecondaryColor.darkgreen};
         `;
       }
     }}
   }
+
+  ${({ border }) => {
+    if (border) {
+      return css`
+        padding: 15px 10px;
+        border: 1px solid #aaa;
+        border-radius: 2px;
+
+        &:hover {
+          background-color: rgba(1, 126, 183, 0.1);
+          border-color: ${SecondaryColor.actionblue};
+        }
+      `;
+    }
+    return null;
+  }}
 `;
 
 export const RadioContainer = styled.label<Props>`
@@ -84,13 +108,27 @@ export const RadioContainer = styled.label<Props>`
   text-align: left;
 
   input {
-    opacity: 0;
+    display: none;
 
-    &:checked + span:before {
-      ${({ error, theme }) => {
+    &:checked + ${RadioLabel} {
+      ${({ border }) => {
+        if (border) {
+          return css`
+            border-color: ${SecondaryColor.actionblue};
+          `;
+        }
+      }}
+    }
+
+    &:checked + ${RadioLabel}:before {
+      ${({ error, theme, border }) => {
         if (error) {
           return css`
-            border-color: solid 2px ${PrimaryColor.glintsred};
+            border-color: ${PrimaryColor.glintsred};
+          `;
+        } else if (border) {
+          return css`
+            border-color: ${SecondaryColor.actionblue};
           `;
         } else if (theme === 'white') {
           return css`
@@ -104,7 +142,7 @@ export const RadioContainer = styled.label<Props>`
       }}
     }
 
-    &:checked + span:after {
+    &:checked + ${RadioLabel}:after {
       opacity: 1;
       transform: scale(1, 1);
     }
@@ -112,9 +150,5 @@ export const RadioContainer = styled.label<Props>`
 
   &:focus {
     outline: none;
-  }
-
-  &:focus > ${RadioLabel} {
-    outline: 5px auto -webkit-focus-ring-color;
   }
 `;

--- a/src/Style/Input/RadioButtonStyle.ts
+++ b/src/Style/Input/RadioButtonStyle.ts
@@ -104,7 +104,7 @@ export const RadioContainer = styled.label<Props>`
   position: relative;
   display: inline-flex;
   align-items: center;
-  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
   user-select: none;
   text-align: left;
 

--- a/src/Style/Input/RadioButtonStyle.ts
+++ b/src/Style/Input/RadioButtonStyle.ts
@@ -48,6 +48,16 @@ export const RadioLabel = styled.span<Props>`
     }}
   }
 
+  &:hover:before {
+    ${({ error, border }) => {
+      if (!error && !border) {
+        return css`
+          border-color: ${SecondaryColor.darkgreen};
+        `;
+      }
+    }}
+  }
+
   &:after {
     content: '';
     display: block;

--- a/src/Style/Input/RadioButtonStyle.ts
+++ b/src/Style/Input/RadioButtonStyle.ts
@@ -7,13 +7,14 @@ interface Props {
   theme?: string;
   border?: boolean;
   disabled?: boolean;
+  size?: 'regular' | 'small';
 }
 
 export const RadioLabel = styled.span<Props>`
   display: inline-flex;
   align-items: center;
   position: relative;
-  font-size: 1em;
+  font-size: ${({ size }) => (size === 'regular' ? '16px' : '14px')};
   color: ${({ theme }) =>
     theme === 'white' ? SecondaryColor.white : SecondaryColor.black};
   outline: none;
@@ -28,8 +29,8 @@ export const RadioLabel = styled.span<Props>`
     border-radius: 50%;
     border-style: solid;
     border-width: 2px;
-    height: 18px;
-    width: 18px;
+    height: ${({ size }) => (size === 'regular' ? '18px' : '15px')};;
+    width: ${({ size }) => (size === 'regular' ? '18px' : '15px')};;
     flex-shrink: 0;
 
     ${({ error, theme, disabled }) => {
@@ -66,13 +67,11 @@ export const RadioLabel = styled.span<Props>`
   &:after {
     content: '';
     display: block;
-    height: 8px;
-    width: 8px;
+    height: ${({ size }) => (size === 'regular' ? '8px' : '5px')};
+    width: ${({ size }) => (size === 'regular' ? '8px' : '5px')};
     position: absolute;
     border-radius: 50%;
     left: 5px;
-    top: 50%;
-    margin-top: -4px;
     opacity: 0;
     transform: scale(0, 0);
     transition: all 0.2s cubic-bezier(0.64, 0.57, 0.67, 1.53);

--- a/src/Style/Input/RadioButtonStyle.ts
+++ b/src/Style/Input/RadioButtonStyle.ts
@@ -124,6 +124,7 @@ export const RadioContainer = styled.label<Props>`
 
     &:checked + ${Border} {
       background-color: transparent;
+      border-color: ${props => getStateColor(props, true)};
 
       ${RadioIcon} {
         ${showSolidCircleStyle}

--- a/src/Style/Input/RadioButtonStyle.ts
+++ b/src/Style/Input/RadioButtonStyle.ts
@@ -61,8 +61,8 @@ export const RadioIcon = styled.span<Props>`
   &:after {
     content: '';
     display: inline-block;
-    height: ${({ size }) => (size === 'regular' ? '8px' : '5px')};
-    width: ${({ size }) => (size === 'regular' ? '8px' : '5px')};
+    height: ${({ size }) => (size === 'regular' ? '8px' : '7px')};
+    width: ${({ size }) => (size === 'regular' ? '8px' : '7px')};
     border-radius: 50%;
     opacity: 0;
     transform: scale(0, 0);
@@ -75,7 +75,8 @@ export const RadioIcon = styled.span<Props>`
 export const RadioLabel = styled.span<Props>`
   font-size: ${({ size }) => (size === 'regular' ? '16px' : '14px')};
   outline: none;
-  color: ${({ disabled }) => (disabled ? '#aaa' : SecondaryColor.black)};
+  color: ${({ disabled }) =>
+    disabled ? Greyscale.lightgrey : SecondaryColor.black};
 `;
 
 export const Border = styled.span<Props>`
@@ -85,7 +86,7 @@ export const Border = styled.span<Props>`
   border-style: solid;
   border-width: 1px;
   border-radius: 2px;
-  border-color: #aaa;
+  border-color: ${({ disabled }) => (disabled ? Greyscale.lightgrey : '#aaa')};
 
   ${({ disabled }) => {
     if (!disabled) {

--- a/stories/Input/RadioButtonStory.tsx
+++ b/stories/Input/RadioButtonStory.tsx
@@ -10,6 +10,7 @@ const Row = styled.div`
   display: inline-grid;
   grid-template-columns: auto auto auto auto auto;
   grid-column-gap: 10px;
+  align-items: end;
 `;
 
 const jsxToString = require('jsx-to-string');

--- a/stories/Input/RadioButtonStory.tsx
+++ b/stories/Input/RadioButtonStory.tsx
@@ -8,7 +8,7 @@ import Divider from '../../src/General/Divider';
 
 const Row = styled.div`
   display: inline-grid;
-  grid-template-columns: auto auto auto auto;
+  grid-template-columns: auto auto auto auto auto;
   grid-column-gap: 10px;
 `;
 
@@ -85,8 +85,9 @@ const props = {
 
 const Story = (
   <Row>
-    <RadioButton label="Full Time" name="job-type" value="full-time" />
-    <RadioButton label="Intership" name="job-type" value="intership" error />
+    <RadioButton label="Regular" name="default" value="regular" />
+    <RadioButton label="Small" name="default" value="small" size="small" />
+    <RadioButton label="Error" name="default" value="error" error />
     <RadioButton label="Disabled" name="disabled" value="disabled" disabled />
     <RadioButton
       label="Disabled selection"
@@ -128,14 +129,29 @@ const RadioButtonWithBorderStory = () => {
         require: 'no',
         description: 'Sets Radio Button to disable state.',
       },
+      {
+        name: 'size',
+        type: 'string',
+        defaultValue: 'regular',
+        possibleValue: 'regular | small',
+        require: 'no',
+        description: 'Sets the size of Radio Button.',
+      },
     ],
   };
 
   return (
     <StorybookComponent title="Radio Button with Border" propsObject={props}>
       <Row>
-        <RadioButton label="Full Time" name="border" value="full-time" border />
-        <RadioButton label="Intership" name="border" value="intership" border />
+        <RadioButton label="Regular" name="border" value="regular" border />
+        <RadioButton
+          label="Small"
+          name="border"
+          value="small"
+          size="small"
+          border
+        />
+        <RadioButton label="Error" name="border" value="error" error border />
         <RadioButton
           label="Disabled"
           name="disabled-border"

--- a/stories/Input/RadioButtonStory.tsx
+++ b/stories/Input/RadioButtonStory.tsx
@@ -1,8 +1,16 @@
 import * as React from 'react';
+import styled from 'styled-components';
 
 import StorybookComponent from '../StorybookComponent';
 
 import RadioButton from '../../src/Input/RadioButton';
+import Divider from '../../src/General/Divider';
+
+const Row = styled.div`
+  display: inline-grid;
+  grid-template-columns: auto auto;
+  grid-column-gap: 10px;
+`;
 
 const jsxToString = require('jsx-to-string');
 
@@ -68,10 +76,10 @@ const props = {
 };
 
 const Story = (
-  <div>
+  <Row>
     <RadioButton label="Full Time" name="job-type" value="full-time" />
     <RadioButton label="Intership" name="job-type" value="intership" error />
-  </div>
+  </Row>
 );
 
 const RadioButtonStory = () => (
@@ -85,4 +93,36 @@ const RadioButtonStory = () => (
   </StorybookComponent>
 );
 
-export default RadioButtonStory;
+const RadioButtonWithBorderStory = () => {
+  const props = {
+    RadioButton: [
+      {
+        name: 'border',
+        type: 'boolean',
+        defaultValue: <code>false</code>,
+        possibleValue: <code>true | false</code>,
+        require: 'no',
+        description: 'Sets a border around the Radio Button.',
+      },
+    ],
+  };
+
+  return (
+    <StorybookComponent title="Radio Button with Border" propsObject={props}>
+      <Row>
+        <RadioButton label="Full Time" name="border" value="full-time" border />
+        <RadioButton label="Intership" name="border" value="intership" border />
+      </Row>
+    </StorybookComponent>
+  );
+};
+
+const RadioButtonStories = () => (
+  <>
+    <RadioButtonStory />
+    <Divider theme="grey" />
+    <RadioButtonWithBorderStory />
+  </>
+);
+
+export default RadioButtonStories;

--- a/stories/Input/RadioButtonStory.tsx
+++ b/stories/Input/RadioButtonStory.tsx
@@ -8,7 +8,7 @@ import Divider from '../../src/General/Divider';
 
 const Row = styled.div`
   display: inline-grid;
-  grid-template-columns: auto auto;
+  grid-template-columns: auto auto auto auto;
   grid-column-gap: 10px;
 `;
 
@@ -72,6 +72,14 @@ const props = {
       require: 'no',
       description: 'Sets theme for Radio Button.',
     },
+    {
+      name: 'disabled',
+      type: 'boolean',
+      defaultValue: <code>false</code>,
+      possibleValue: <code>true | false</code>,
+      require: 'no',
+      description: 'Sets Radio Button to disable state.',
+    },
   ],
 };
 
@@ -79,6 +87,14 @@ const Story = (
   <Row>
     <RadioButton label="Full Time" name="job-type" value="full-time" />
     <RadioButton label="Intership" name="job-type" value="intership" error />
+    <RadioButton label="Disabled" name="disabled" value="disabled" disabled />
+    <RadioButton
+      label="Disabled selection"
+      name="disabled"
+      value="disabled-selection"
+      disabled
+      checked
+    />
   </Row>
 );
 
@@ -104,6 +120,14 @@ const RadioButtonWithBorderStory = () => {
         require: 'no',
         description: 'Sets a border around the Radio Button.',
       },
+      {
+        name: 'disabled',
+        type: 'boolean',
+        defaultValue: <code>false</code>,
+        possibleValue: <code>true | false</code>,
+        require: 'no',
+        description: 'Sets Radio Button to disable state.',
+      },
     ],
   };
 
@@ -112,6 +136,21 @@ const RadioButtonWithBorderStory = () => {
       <Row>
         <RadioButton label="Full Time" name="border" value="full-time" border />
         <RadioButton label="Intership" name="border" value="intership" border />
+        <RadioButton
+          label="Disabled"
+          name="disabled-border"
+          value="disabled"
+          disabled
+          border
+        />
+        <RadioButton
+          label="Disabled selection"
+          name="disabled-border"
+          value="disabled-selection"
+          disabled
+          border
+          checked
+        />
       </Row>
     </StorybookComponent>
   );

--- a/stories/Input/RadioButtonStory.tsx
+++ b/stories/Input/RadioButtonStory.tsx
@@ -15,74 +15,80 @@ const Row = styled.div`
 
 const jsxToString = require('jsx-to-string');
 
-const props = {
-  RadioButton: [
-    {
-      name: 'label',
-      type: 'string',
-      defaultValue: '',
-      possibleValue: 'any',
-      require: 'yes',
-      description: 'Sets the label of Radio Button.',
-    },
-    {
-      name: 'name',
-      type: 'string',
-      defaultValue: '',
-      possibleValue: 'any',
-      require: 'yes',
-      description: '',
-    },
-    {
-      name: 'value',
-      type: 'string',
-      defaultValue: '',
-      possibleValue: 'any',
-      require: 'yes',
-      description: '',
-    },
-    {
-      name: 'checked',
-      type: 'boolean',
-      defaultValue: <code>false</code>,
-      possibleValue: <code>true | false</code>,
-      require: 'no',
-      description: '',
-    },
-    {
-      name: 'error',
-      type: 'boolean',
-      defaultValue: <code>false</code>,
-      possibleValue: <code>true | false</code>,
-      require: 'no',
-      description: 'Displays the error styles',
-    },
-    {
-      name: 'labelProps',
-      type: 'object',
-      defaultValue: '',
-      possibleValue: '',
-      require: 'no',
-      description: 'Sets the props on the label element.',
-    },
-    {
-      name: 'theme',
-      type: 'boolean',
-      defaultValue: '',
-      possibleValue: <code>white</code>,
-      require: 'no',
-      description: 'Sets theme for Radio Button.',
-    },
-    {
-      name: 'disabled',
-      type: 'boolean',
-      defaultValue: <code>false</code>,
-      possibleValue: <code>true | false</code>,
-      require: 'no',
-      description: 'Sets Radio Button to disable state.',
-    },
-  ],
-};
+const commonProps = [
+  {
+    name: 'label',
+    type: 'string',
+    defaultValue: '',
+    possibleValue: 'any',
+    require: 'yes',
+    description: 'Sets the label of Radio Button.',
+  },
+  {
+    name: 'name',
+    type: 'string',
+    defaultValue: '',
+    possibleValue: 'any',
+    require: 'yes',
+    description: '',
+  },
+  {
+    name: 'value',
+    type: 'string',
+    defaultValue: '',
+    possibleValue: 'any',
+    require: 'yes',
+    description: '',
+  },
+  {
+    name: 'checked',
+    type: 'boolean',
+    defaultValue: <code>false</code>,
+    possibleValue: <code>true | false</code>,
+    require: 'no',
+    description: '',
+  },
+  {
+    name: 'labelProps',
+    type: 'object',
+    defaultValue: '',
+    possibleValue: '',
+    require: 'no',
+    description: 'Sets the props on the label element.',
+  },
+  {
+    name: 'disabled',
+    type: 'boolean',
+    defaultValue: <code>false</code>,
+    possibleValue: <code>true | false</code>,
+    require: 'no',
+    description: 'Sets Radio Button to disable state.',
+  },
+  {
+    name: 'size',
+    type: 'string',
+    defaultValue: 'regular',
+    possibleValue: 'regular | small',
+    require: 'no',
+    description: 'Sets the size of Radio Button.',
+  },
+  {
+    name: 'error',
+    type: 'boolean',
+    defaultValue: <code>false</code>,
+    possibleValue: <code>true | false</code>,
+    require: 'no',
+    description: 'Displays the error styles',
+  },
+  {
+    name: 'theme',
+    type: 'boolean',
+    defaultValue: '',
+    possibleValue: <code>white</code>,
+    require: 'no',
+    description: 'Sets theme for Radio Button.',
+  },
+];
 
 const Story = (
   <Row>
@@ -100,16 +106,22 @@ const Story = (
   </Row>
 );
 
-const RadioButtonStory = () => (
-  <StorybookComponent
-    title="Radio Button"
-    code="import { RadioButton } from 'glints-aries'"
-    propsObject={props}
-    usage={jsxToString(Story)}
-  >
-    {Story}
-  </StorybookComponent>
-);
+const RadioButtonStory = () => {
+  const props = {
+    RadioButton: commonProps,
+  };
+
+  return (
+    <StorybookComponent
+      title="Radio Button"
+      code="import { RadioButton } from 'glints-aries'"
+      propsObject={props}
+      usage={jsxToString(Story)}
+    >
+      {Story}
+    </StorybookComponent>
+  );
+};
 
 const RadioButtonWithBorderStory = () => {
   const props = {
@@ -122,22 +134,7 @@ const RadioButtonWithBorderStory = () => {
         require: 'no',
         description: 'Sets a border around the Radio Button.',
       },
-      {
-        name: 'disabled',
-        type: 'boolean',
-        defaultValue: <code>false</code>,
-        possibleValue: <code>true | false</code>,
-        require: 'no',
-        description: 'Sets Radio Button to disable state.',
-      },
-      {
-        name: 'size',
-        type: 'string',
-        defaultValue: 'regular',
-        possibleValue: 'regular | small',
-        require: 'no',
-        description: 'Sets the size of Radio Button.',
-      },
+      ...commonProps,
     ],
   };
 


### PR DESCRIPTION
# What changed
- update the hover, disabled, error state of radio button
- add `border` prop to set a border around the radio button
- add `size` prop
- add testing for the new style and disabled state
- create a `RadioIcon` to be easy to center icon and manage the color