### PR TITLE
Adds a new variant to the underlined tabs, with tests

### DIFF
--- a/src/Display/Tabs/TabPane.tsx
+++ b/src/Display/Tabs/TabPane.tsx
@@ -15,7 +15,7 @@ const TabPane: React.FunctionComponent<Props> = props => {
 export interface Props
   extends React.ComponentPropsWithoutRef<typeof TabsContent> {
   children: React.ReactNode;
-  tab?: string;
+  tab?: string | React.ReactNode;
   label?: string | number;
   tabClassName?: string;
 }

--- a/src/Display/Tabs/Tabs.test.tsx
+++ b/src/Display/Tabs/Tabs.test.tsx
@@ -6,7 +6,10 @@ import '@testing-library/jest-dom/extend-expect';
 import { fireEvent, render } from '@testing-library/react';
 
 import Tabs from './Tabs';
-import { EHorizontalTabVariant, ETabColourVariant } from '../../Utils/StyleConfig';
+import {
+  EHorizontalTabVariant,
+  ETabColourVariant,
+} from '../../Utils/StyleConfig';
 
 describe('<Tabs/> render', () => {
   test('should match snapshot', () => {

--- a/src/Display/Tabs/Tabs.test.tsx
+++ b/src/Display/Tabs/Tabs.test.tsx
@@ -6,7 +6,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { fireEvent, render } from '@testing-library/react';
 
 import Tabs from './Tabs';
-import { EHorizontalTabVariant } from '../../Utils/StyleConfig';
+import { EHorizontalTabVariant, ETabColourVariant } from '../../Utils/StyleConfig';
 
 describe('<Tabs/> render', () => {
   test('should match snapshot', () => {
@@ -61,6 +61,26 @@ describe('<Tabs/> snapshots with variant props', () => {
 
   Object.values(EHorizontalTabVariant).forEach(variant =>
     matchTabSnapshotsWithVariant(variant)
+  );
+});
+
+describe('<Tabs/> snapshots with colour prop and variant as underlined', () => {
+  const matchTabSnapshotsWithVariant = (colour: ETabColourVariant) => {
+    test(`colour ${colour}`, () => {
+      const { asFragment } = render(
+        <Tabs variant={EHorizontalTabVariant.UNDERLINED} colour={colour}>
+          <Tabs.Pane tab="Job">Software Engineer</Tabs.Pane>
+          <Tabs.Pane tab="Company">Glints</Tabs.Pane>
+          <Tabs.Pane tab="Location">Jakarta</Tabs.Pane>
+          <Tabs.Pane tab="Salary">Rp 10,000,000</Tabs.Pane>
+        </Tabs>
+      );
+      expect(asFragment()).toMatchSnapshot();
+    });
+  };
+
+  Object.values(ETabColourVariant).forEach(colour =>
+    matchTabSnapshotsWithVariant(colour)
   );
 });
 

--- a/src/Display/Tabs/Tabs.test.tsx
+++ b/src/Display/Tabs/Tabs.test.tsx
@@ -8,7 +8,7 @@ import { fireEvent, render } from '@testing-library/react';
 import Tabs from './Tabs';
 import {
   EHorizontalTabVariant,
-  ETabColourVariant,
+  ETabThemeVariant,
 } from '../../Utils/StyleConfig';
 
 describe('<Tabs/> render', () => {
@@ -68,10 +68,10 @@ describe('<Tabs/> snapshots with variant props', () => {
 });
 
 describe('<Tabs/> snapshots with colour prop and variant as underlined', () => {
-  const matchTabSnapshotsWithVariant = (colour: ETabColourVariant) => {
-    test(`colour ${colour}`, () => {
+  const matchTabSnapshotsWithVariant = (theme: ETabThemeVariant) => {
+    test(`colour ${theme}`, () => {
       const { asFragment } = render(
-        <Tabs variant={EHorizontalTabVariant.UNDERLINED} colour={colour}>
+        <Tabs variant={EHorizontalTabVariant.UNDERLINED} theme={theme}>
           <Tabs.Pane tab="Job">Software Engineer</Tabs.Pane>
           <Tabs.Pane tab="Company">Glints</Tabs.Pane>
           <Tabs.Pane tab="Location">Jakarta</Tabs.Pane>
@@ -82,8 +82,8 @@ describe('<Tabs/> snapshots with colour prop and variant as underlined', () => {
     });
   };
 
-  Object.values(ETabColourVariant).forEach(colour =>
-    matchTabSnapshotsWithVariant(colour)
+  Object.values(ETabThemeVariant).forEach(theme =>
+    matchTabSnapshotsWithVariant(theme)
   );
 });
 

--- a/src/Display/Tabs/Tabs.tsx
+++ b/src/Display/Tabs/Tabs.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 import {
   EHorizontalTabVariant,
-  ETabColourVariant,
+  ETabThemeVariant,
 } from '../../Utils/StyleConfig';
 import TabPane, { Props as TabPaneProps } from './TabPane';
 
@@ -17,7 +17,7 @@ const Tabs: Tabs = ({
   variant = 'underlined',
   className,
   alignment = 'horizontal',
-  colour = ETabColourVariant.BLACK,
+  theme = ETabThemeVariant.BLACK,
 }) => {
   const [currentIndex, setCurrentIndex] = React.useState(0);
   const activeTabOrIndex: string | number = activeTab || currentIndex;
@@ -40,7 +40,7 @@ const Tabs: Tabs = ({
     >
       <TabsHeader
         className={classNames(`${alignment}-tabs-header`, 'tabs-header')}
-        colour={colour}
+        theme={theme}
         alignment={alignment}
       >
         <ul
@@ -117,7 +117,7 @@ interface Props {
   activeTab?: string | number;
   onTabClick?(tab: React.ReactText | React.ReactNode): void;
   className?: string;
-  colour?: ETabColourVariant;
+  theme?: ETabThemeVariant;
 }
 
 export default Tabs;

--- a/src/Display/Tabs/Tabs.tsx
+++ b/src/Display/Tabs/Tabs.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import classNames from 'classnames';
 
-import { EHorizontalTabVariant } from '../../Utils/StyleConfig';
+import { EHorizontalTabVariant, ETabColourVariant } from '../../Utils/StyleConfig';
 import TabPane, { Props as TabPaneProps } from './TabPane';
 
 import { TabsContainer, TabsHeader, TabsBody } from './TabsStyle';
@@ -14,6 +14,7 @@ const Tabs: Tabs = ({
   variant = 'underlined',
   className,
   alignment = 'horizontal',
+  colour = ETabColourVariant.BLACK,
 }) => {
   const [currentIndex, setCurrentIndex] = React.useState(0);
   const activeTabOrIndex: string | number = activeTab || currentIndex;
@@ -36,6 +37,8 @@ const Tabs: Tabs = ({
     >
       <TabsHeader
         className={classNames(`${alignment}-tabs-header`, 'tabs-header')}
+        colour={colour}
+        alignment={alignment}
       >
         <ul
           className={classNames(
@@ -59,7 +62,7 @@ const Tabs: Tabs = ({
                     `${variant}`,
                     `${tabClassName}`
                   )}
-                  key={data.props.tab}
+                  key={index}
                   role="tab"
                   aria-selected={activeTabOrIndex === tabLabel && true}
                   aria-controls={`tab-item-${tabLabel}`}
@@ -109,8 +112,9 @@ interface Props {
   variant?: EHorizontalTabVariant;
   alignment?: string;
   activeTab?: string | number;
-  onTabClick?(tab: React.ReactText): void;
+  onTabClick?(tab: React.ReactText | React.ReactNode): void;
   className?: string;
+  colour?: ETabColourVariant;
 }
 
 export default Tabs;

--- a/src/Display/Tabs/Tabs.tsx
+++ b/src/Display/Tabs/Tabs.tsx
@@ -2,7 +2,10 @@ import * as React from 'react';
 
 import classNames from 'classnames';
 
-import { EHorizontalTabVariant, ETabColourVariant } from '../../Utils/StyleConfig';
+import {
+  EHorizontalTabVariant,
+  ETabColourVariant,
+} from '../../Utils/StyleConfig';
 import TabPane, { Props as TabPaneProps } from './TabPane';
 
 import { TabsContainer, TabsHeader, TabsBody } from './TabsStyle';

--- a/src/Display/Tabs/TabsStyle.ts
+++ b/src/Display/Tabs/TabsStyle.ts
@@ -1,7 +1,16 @@
 import styled from 'styled-components';
 
-import { SecondaryColor } from '../../Utils/Colors';
-import { ScreenSize } from '../../Utils/StyleConfig';
+import {
+  ScreenSize,
+  ETabColourVariant,
+  ETabAlignment,
+} from '../../Utils/StyleConfig';
+import { SecondaryColor, Greyscale } from '../../Utils/Colors';
+
+interface TabHeader {
+  colour: ETabColourVariant;
+  alignment: string;
+}
 
 export const TabsContainer = styled.div`
   position: relative;
@@ -14,7 +23,7 @@ export const TabsContainer = styled.div`
   }
 `;
 
-export const TabsHeader = styled.div`
+export const TabsHeader = styled.div<TabHeader>`
   position: relative;
 
   &.vertical-tabs-header {
@@ -63,7 +72,8 @@ export const TabsHeader = styled.div`
     }
 
     .horizontal-tab.underlined {
-      margin: 0 10px;
+      margin: ${({ colour }) =>
+        colour === ETabColourVariant.GREY ? '0 15px' : '0 10px'};
     }
 
     .vertical-tab {
@@ -95,11 +105,21 @@ export const TabsHeader = styled.div`
 
       &.underlined.active.horizontal-tab,
       &.active.vertical-tab {
-        border-bottom: 2px solid ${SecondaryColor.black};
+        border-bottom: ${({ colour }) =>
+          colour === ETabColourVariant.GREY
+            ? `4px solid ${SecondaryColor.actionblue}`
+            : `2px solid ${Greyscale.black}`};
 
         button {
           font-weight: bold;
           text-transform: uppercase;
+          color: ${({ colour }) =>
+            colour === ETabColourVariant.GREY
+              ? `${SecondaryColor.actionblue}`
+              : `${Greyscale.black}`};
+        }
+        button:hover {
+          border: 0;
         }
       }
 
@@ -113,9 +133,11 @@ export const TabsHeader = styled.div`
       }
 
       &.active.vertical-tab {
-        border-bottom: 2px solid ${SecondaryColor.black};
         @media (min-width: ${ScreenSize.tablet}px) {
-          border-right: 2px solid ${SecondaryColor.black};
+          border-right: ${({ colour }) =>
+            colour === ETabColourVariant.GREY
+              ? `4px solid ${SecondaryColor.actionblue}`
+              : `2px solid ${Greyscale.black}`};
           border-bottom: none;
         }
 
@@ -124,6 +146,12 @@ export const TabsHeader = styled.div`
           text-transform: uppercase;
         }
       }
+    }
+
+    svg {
+      margin-right: 10px;
+      height: 15px;
+      width: 15px;
     }
 
     &:focus {
@@ -142,6 +170,41 @@ export const TabsHeader = styled.div`
       cursor: pointer;
       outline: none;
       text-transform: uppercase;
+      ${({ colour }) => {
+        if (colour === ETabColourVariant.GREY) {
+          return `
+            letter-spacing: 1px;
+            font-weight: 500;
+            color: ${Greyscale.grey};
+          `;
+        }
+      }};
+    }
+
+    button:hover {
+      ${({ colour, alignment }) => {
+        if (
+          colour === ETabColourVariant.GREY &&
+          alignment === ETabAlignment.VERTICAL
+        ) {
+          return `
+            color: ${SecondaryColor.actionblue};
+            border-bottom: 4px solid rgba(1, 126, 183, 0.5);
+            @media (min-width: ${ScreenSize.tablet}px) {
+              border-bottom: 0;
+              border-right: 4px solid rgba(1, 126, 183, 0.5);
+            }
+          `;
+        } else if (
+          colour === ETabColourVariant.GREY &&
+          alignment === ETabAlignment.HORIZONTAL
+        ) {
+          return `
+            color: ${SecondaryColor.actionblue};
+            border-bottom: 4px solid rgba(1, 126, 183, 0.5);
+          `;
+        }
+      }};
     }
   }
 

--- a/src/Display/Tabs/TabsStyle.ts
+++ b/src/Display/Tabs/TabsStyle.ts
@@ -2,15 +2,19 @@ import styled from 'styled-components';
 
 import {
   ScreenSize,
-  ETabColourVariant,
+  ETabThemeVariant,
   ETabAlignment,
 } from '../../Utils/StyleConfig';
 import { SecondaryColor, Greyscale } from '../../Utils/Colors';
 
 interface TabHeader {
-  colour: ETabColourVariant;
+  theme: ETabThemeVariant;
   alignment: string;
 }
+
+const isNewTab = (theme: ETabThemeVariant) => {
+  return theme !== ETabThemeVariant.BLACK;
+};
 
 export const TabsContainer = styled.div`
   position: relative;
@@ -72,14 +76,14 @@ export const TabsHeader = styled.div<TabHeader>`
     }
 
     .horizontal-tab.underlined {
-      margin: ${({ colour }) =>
-        colour === ETabColourVariant.GREY ? '0 15px' : '0 10px'};
+      margin: ${({ theme }) => (isNewTab(theme) ? '0 15px' : '0 10px')};
     }
 
     .vertical-tab {
       margin: 0 10px;
       @media (min-width: ${ScreenSize.tablet}px) {
         margin: 0;
+        padding-left: 15px;
       }
     }
 
@@ -105,16 +109,16 @@ export const TabsHeader = styled.div<TabHeader>`
 
       &.underlined.active.horizontal-tab,
       &.active.vertical-tab {
-        border-bottom: ${({ colour }) =>
-          colour === ETabColourVariant.GREY
+        border-bottom: ${({ theme }) =>
+          isNewTab(theme)
             ? `4px solid ${SecondaryColor.actionblue}`
             : `2px solid ${Greyscale.black}`};
 
         button {
           font-weight: bold;
           text-transform: uppercase;
-          color: ${({ colour }) =>
-            colour === ETabColourVariant.GREY
+          color: ${({ theme }) =>
+            isNewTab(theme)
               ? `${SecondaryColor.actionblue}`
               : `${Greyscale.black}`};
         }
@@ -134,8 +138,8 @@ export const TabsHeader = styled.div<TabHeader>`
 
       &.active.vertical-tab {
         @media (min-width: ${ScreenSize.tablet}px) {
-          border-right: ${({ colour }) =>
-            colour === ETabColourVariant.GREY
+          border-right: ${({ theme }) =>
+            isNewTab(theme)
               ? `4px solid ${SecondaryColor.actionblue}`
               : `2px solid ${Greyscale.black}`};
           border-bottom: none;
@@ -170,8 +174,8 @@ export const TabsHeader = styled.div<TabHeader>`
       cursor: pointer;
       outline: none;
       text-transform: uppercase;
-      ${({ colour }) => {
-        if (colour === ETabColourVariant.GREY) {
+      ${({ theme }) => {
+        if (isNewTab(theme)) {
           return `
             letter-spacing: 1px;
             font-weight: 500;
@@ -182,26 +186,21 @@ export const TabsHeader = styled.div<TabHeader>`
     }
 
     button:hover {
-      ${({ colour, alignment }) => {
-        if (
-          colour === ETabColourVariant.GREY &&
-          alignment === ETabAlignment.VERTICAL
-        ) {
+      ${({ theme }) => {
+        if (isNewTab(theme)) {
           return `
-            color: ${SecondaryColor.actionblue};
-            border-bottom: 4px solid rgba(1, 126, 183, 0.5);
+          color: ${SecondaryColor.actionblue};
+          border-bottom: 4px solid rgba(1, 126, 183, 0.5);
+          `;
+        }
+      }};
+      ${({ alignment, theme }) => {
+        if (alignment === ETabAlignment.VERTICAL && isNewTab(theme)) {
+          return `
             @media (min-width: ${ScreenSize.tablet}px) {
               border-bottom: 0;
               border-right: 4px solid rgba(1, 126, 183, 0.5);
             }
-          `;
-        } else if (
-          colour === ETabColourVariant.GREY &&
-          alignment === ETabAlignment.HORIZONTAL
-        ) {
-          return `
-            color: ${SecondaryColor.actionblue};
-            border-bottom: 4px solid rgba(1, 126, 183, 0.5);
           `;
         }
       }};

--- a/src/Display/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/Display/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -82,6 +82,12 @@ exports[`<Tabs/> render should match snapshot 1`] = `
 .c1 ul li.active.vertical-tab button {
   font-weight: bold;
   text-transform: uppercase;
+  color: #000000;
+}
+
+.c1 ul li.underlined.active.horizontal-tab button:hover,
+.c1 ul li.active.vertical-tab button:hover {
+  border: 0;
 }
 
 .c1 ul li.colored.active.horizontal-tab {
@@ -93,13 +99,15 @@ exports[`<Tabs/> render should match snapshot 1`] = `
   text-transform: uppercase;
 }
 
-.c1 ul li.active.vertical-tab {
-  border-bottom: 2px solid #000000;
-}
-
 .c1 ul li.active.vertical-tab button {
   font-weight: bold;
   text-transform: uppercase;
+}
+
+.c1 ul svg {
+  margin-right: 10px;
+  height: 15px;
+  width: 15px;
 }
 
 .c1 ul:focus {
@@ -360,6 +368,12 @@ exports[`<Tabs/> snapshots with alignment props alignment horizontal 1`] = `
 .c1 ul li.active.vertical-tab button {
   font-weight: bold;
   text-transform: uppercase;
+  color: #000000;
+}
+
+.c1 ul li.underlined.active.horizontal-tab button:hover,
+.c1 ul li.active.vertical-tab button:hover {
+  border: 0;
 }
 
 .c1 ul li.colored.active.horizontal-tab {
@@ -371,13 +385,15 @@ exports[`<Tabs/> snapshots with alignment props alignment horizontal 1`] = `
   text-transform: uppercase;
 }
 
-.c1 ul li.active.vertical-tab {
-  border-bottom: 2px solid #000000;
-}
-
 .c1 ul li.active.vertical-tab button {
   font-weight: bold;
   text-transform: uppercase;
+}
+
+.c1 ul svg {
+  margin-right: 10px;
+  height: 15px;
+  width: 15px;
 }
 
 .c1 ul:focus {
@@ -635,6 +651,12 @@ exports[`<Tabs/> snapshots with alignment props alignment vertical 1`] = `
 .c1 ul li.active.vertical-tab button {
   font-weight: bold;
   text-transform: uppercase;
+  color: #000000;
+}
+
+.c1 ul li.underlined.active.horizontal-tab button:hover,
+.c1 ul li.active.vertical-tab button:hover {
+  border: 0;
 }
 
 .c1 ul li.colored.active.horizontal-tab {
@@ -646,13 +668,15 @@ exports[`<Tabs/> snapshots with alignment props alignment vertical 1`] = `
   text-transform: uppercase;
 }
 
-.c1 ul li.active.vertical-tab {
-  border-bottom: 2px solid #000000;
-}
-
 .c1 ul li.active.vertical-tab button {
   font-weight: bold;
   text-transform: uppercase;
+}
+
+.c1 ul svg {
+  margin-right: 10px;
+  height: 15px;
+  width: 15px;
 }
 
 .c1 ul:focus {
@@ -827,6 +851,583 @@ exports[`<Tabs/> snapshots with alignment props alignment vertical 1`] = `
 </DocumentFragment>
 `;
 
+exports[`<Tabs/> snapshots with colour prop and variant as underlined colour black 1`] = `
+<DocumentFragment>
+  .c0 {
+  position: relative;
+}
+
+.c1 {
+  position: relative;
+}
+
+.c1 .horizontal-tabs-list.colored {
+  border-top: 1px solid #EEEEEE;
+}
+
+.c1 ul {
+  border-bottom: 1px solid #EEEEEE;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  white-space: nowrap;
+  overflow: auto;
+  font-size: 1em;
+  padding: 0;
+  margin: 0;
+}
+
+.c1 ul::-webkit-scrollbar {
+  display: none;
+}
+
+.c1 ul .horizontal-tab.colored {
+  min-width: 230px;
+  font-size: 16px;
+  text-align: center;
+  margin: 0;
+}
+
+.c1 ul .horizontal-tab.colored:hover {
+  background-color: #F3F3F3;
+  color: #017EB7;
+  margin: 0;
+}
+
+.c1 ul .horizontal-tab.underlined {
+  margin: 0 10px;
+}
+
+.c1 ul .vertical-tab {
+  margin: 0 10px;
+}
+
+.c1 ul li {
+  text-transform: uppercase;
+  list-style-type: none;
+}
+
+.c1 ul li:first-child.horizontal-tab {
+  margin-left: 0;
+}
+
+.c1 ul li:last-child.horizontal-tab {
+  margin-right: 0;
+}
+
+.c1 ul li:first-child.vertical-tab {
+  margin-top: 0;
+}
+
+.c1 ul li:last-child.vertical-tab {
+  margin-bottom: 0;
+}
+
+.c1 ul li.underlined.active.horizontal-tab,
+.c1 ul li.active.vertical-tab {
+  border-bottom: 2px solid #000000;
+}
+
+.c1 ul li.underlined.active.horizontal-tab button,
+.c1 ul li.active.vertical-tab button {
+  font-weight: bold;
+  text-transform: uppercase;
+  color: #000000;
+}
+
+.c1 ul li.underlined.active.horizontal-tab button:hover,
+.c1 ul li.active.vertical-tab button:hover {
+  border: 0;
+}
+
+.c1 ul li.colored.active.horizontal-tab {
+  background-color: #F3F3F3;
+}
+
+.c1 ul li.colored.active.horizontal-tab button {
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.c1 ul li.active.vertical-tab button {
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.c1 ul svg {
+  margin-right: 10px;
+  height: 15px;
+  width: 15px;
+}
+
+.c1 ul:focus {
+  outline: none;
+}
+
+.c1 ul .vertical-tab button {
+  text-align: left;
+}
+
+.c1 ul button {
+  width: 100%;
+  padding: 20px 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  outline: none;
+  text-transform: uppercase;
+}
+
+.c4 {
+  position: relative;
+  outline: none;
+}
+
+.c2 {
+  position: relative;
+  padding-top: 1.2em;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus > .c3 {
+  outline: 5px auto -webkit-focus-ring-color;
+}
+
+@media (min-width:768px) {
+  .c0.vertical-aries-tabs {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    max-width: 100%;
+  }
+}
+
+@media (min-width:768px) {
+  .c1.vertical-tabs-header {
+    width: 20%;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 .vertical-tabs-list {
+    border-right: 1px solid #EEEEEE;
+    border-bottom: none;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 ul .vertical-tab {
+    margin: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 ul li.active.vertical-tab {
+    border-right: 2px solid #000000;
+    border-bottom: none;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 li {
+    margin: 0 15px;
+  }
+}
+
+@media (min-width:768px) {
+  .c4.tabs-item-vertical {
+    margin-left: 60px;
+  }
+}
+
+<div
+    class="c0 horizontal-aries-tabs aries-tabs"
+  >
+    <div
+      class="c1 horizontal-tabs-header tabs-header"
+    >
+      <ul
+        class="horizontal-tabs-list tabs-list underlined"
+        role="tablist"
+      >
+        <li
+          aria-controls="tab-item-0"
+          aria-selected="true"
+          class="tab-0 active horizontal-tab underlined"
+          role="tab"
+          tabindex="-1"
+        >
+          <button
+            role="tab-button"
+            type="button"
+          >
+            Job
+          </button>
+        </li>
+        <li
+          aria-controls="tab-item-1"
+          aria-selected="false"
+          class="tab-1 horizontal-tab underlined"
+          role="tab"
+          tabindex="-1"
+        >
+          <button
+            role="tab-button"
+            type="button"
+          >
+            Company
+          </button>
+        </li>
+        <li
+          aria-controls="tab-item-2"
+          aria-selected="false"
+          class="tab-2 horizontal-tab underlined"
+          role="tab"
+          tabindex="-1"
+        >
+          <button
+            role="tab-button"
+            type="button"
+          >
+            Location
+          </button>
+        </li>
+        <li
+          aria-controls="tab-item-3"
+          aria-selected="false"
+          class="tab-3 horizontal-tab underlined"
+          role="tab"
+          tabindex="-1"
+        >
+          <button
+            role="tab-button"
+            type="button"
+          >
+            Salary
+          </button>
+        </li>
+      </ul>
+    </div>
+    <div
+      class="c2 tabs-body"
+      tabindex="0"
+    >
+      <div
+        aria-labelledby="tab-0"
+        class="c3 c4 tabs-item tab-item-0 tabs-item-horizontal tabs-item"
+        role="tabpanel"
+        tabindex="-1"
+      >
+        Software Engineer
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Tabs/> snapshots with colour prop and variant as underlined colour grey 1`] = `
+<DocumentFragment>
+  .c0 {
+  position: relative;
+}
+
+.c1 {
+  position: relative;
+}
+
+.c1 .horizontal-tabs-list.colored {
+  border-top: 1px solid #EEEEEE;
+}
+
+.c1 ul {
+  border-bottom: 1px solid #EEEEEE;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  white-space: nowrap;
+  overflow: auto;
+  font-size: 1em;
+  padding: 0;
+  margin: 0;
+}
+
+.c1 ul::-webkit-scrollbar {
+  display: none;
+}
+
+.c1 ul .horizontal-tab.colored {
+  min-width: 230px;
+  font-size: 16px;
+  text-align: center;
+  margin: 0;
+}
+
+.c1 ul .horizontal-tab.colored:hover {
+  background-color: #F3F3F3;
+  color: #017EB7;
+  margin: 0;
+}
+
+.c1 ul .horizontal-tab.underlined {
+  margin: 0 15px;
+}
+
+.c1 ul .vertical-tab {
+  margin: 0 10px;
+}
+
+.c1 ul li {
+  text-transform: uppercase;
+  list-style-type: none;
+}
+
+.c1 ul li:first-child.horizontal-tab {
+  margin-left: 0;
+}
+
+.c1 ul li:last-child.horizontal-tab {
+  margin-right: 0;
+}
+
+.c1 ul li:first-child.vertical-tab {
+  margin-top: 0;
+}
+
+.c1 ul li:last-child.vertical-tab {
+  margin-bottom: 0;
+}
+
+.c1 ul li.underlined.active.horizontal-tab,
+.c1 ul li.active.vertical-tab {
+  border-bottom: 4px solid #017EB7;
+}
+
+.c1 ul li.underlined.active.horizontal-tab button,
+.c1 ul li.active.vertical-tab button {
+  font-weight: bold;
+  text-transform: uppercase;
+  color: #017EB7;
+}
+
+.c1 ul li.underlined.active.horizontal-tab button:hover,
+.c1 ul li.active.vertical-tab button:hover {
+  border: 0;
+}
+
+.c1 ul li.colored.active.horizontal-tab {
+  background-color: #F3F3F3;
+}
+
+.c1 ul li.colored.active.horizontal-tab button {
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.c1 ul li.active.vertical-tab button {
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.c1 ul svg {
+  margin-right: 10px;
+  height: 15px;
+  width: 15px;
+}
+
+.c1 ul:focus {
+  outline: none;
+}
+
+.c1 ul .vertical-tab button {
+  text-align: left;
+}
+
+.c1 ul button {
+  width: 100%;
+  padding: 20px 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  outline: none;
+  text-transform: uppercase;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
+  font-weight: 500;
+  color: #777777;
+}
+
+.c1 ul button:hover {
+  color: #017EB7;
+  border-bottom: 4px solid rgba(1,126,183,0.5);
+}
+
+.c4 {
+  position: relative;
+  outline: none;
+}
+
+.c2 {
+  position: relative;
+  padding-top: 1.2em;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus > .c3 {
+  outline: 5px auto -webkit-focus-ring-color;
+}
+
+@media (min-width:768px) {
+  .c0.vertical-aries-tabs {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    max-width: 100%;
+  }
+}
+
+@media (min-width:768px) {
+  .c1.vertical-tabs-header {
+    width: 20%;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 .vertical-tabs-list {
+    border-right: 1px solid #EEEEEE;
+    border-bottom: none;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 ul .vertical-tab {
+    margin: 0;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 ul li.active.vertical-tab {
+    border-right: 4px solid #017EB7;
+    border-bottom: none;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 li {
+    margin: 0 15px;
+  }
+}
+
+@media (min-width:768px) {
+  .c4.tabs-item-vertical {
+    margin-left: 60px;
+  }
+}
+
+<div
+    class="c0 horizontal-aries-tabs aries-tabs"
+  >
+    <div
+      class="c1 horizontal-tabs-header tabs-header"
+    >
+      <ul
+        class="horizontal-tabs-list tabs-list underlined"
+        role="tablist"
+      >
+        <li
+          aria-controls="tab-item-0"
+          aria-selected="true"
+          class="tab-0 active horizontal-tab underlined"
+          role="tab"
+          tabindex="-1"
+        >
+          <button
+            role="tab-button"
+            type="button"
+          >
+            Job
+          </button>
+        </li>
+        <li
+          aria-controls="tab-item-1"
+          aria-selected="false"
+          class="tab-1 horizontal-tab underlined"
+          role="tab"
+          tabindex="-1"
+        >
+          <button
+            role="tab-button"
+            type="button"
+          >
+            Company
+          </button>
+        </li>
+        <li
+          aria-controls="tab-item-2"
+          aria-selected="false"
+          class="tab-2 horizontal-tab underlined"
+          role="tab"
+          tabindex="-1"
+        >
+          <button
+            role="tab-button"
+            type="button"
+          >
+            Location
+          </button>
+        </li>
+        <li
+          aria-controls="tab-item-3"
+          aria-selected="false"
+          class="tab-3 horizontal-tab underlined"
+          role="tab"
+          tabindex="-1"
+        >
+          <button
+            role="tab-button"
+            type="button"
+          >
+            Salary
+          </button>
+        </li>
+      </ul>
+    </div>
+    <div
+      class="c2 tabs-body"
+      tabindex="0"
+    >
+      <div
+        aria-labelledby="tab-0"
+        class="c3 c4 tabs-item tab-item-0 tabs-item-horizontal tabs-item"
+        role="tabpanel"
+        tabindex="-1"
+      >
+        Software Engineer
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`<Tabs/> snapshots with variant props alignment colored 1`] = `
 <DocumentFragment>
   .c0 {
@@ -910,6 +1511,12 @@ exports[`<Tabs/> snapshots with variant props alignment colored 1`] = `
 .c1 ul li.active.vertical-tab button {
   font-weight: bold;
   text-transform: uppercase;
+  color: #000000;
+}
+
+.c1 ul li.underlined.active.horizontal-tab button:hover,
+.c1 ul li.active.vertical-tab button:hover {
+  border: 0;
 }
 
 .c1 ul li.colored.active.horizontal-tab {
@@ -921,13 +1528,15 @@ exports[`<Tabs/> snapshots with variant props alignment colored 1`] = `
   text-transform: uppercase;
 }
 
-.c1 ul li.active.vertical-tab {
-  border-bottom: 2px solid #000000;
-}
-
 .c1 ul li.active.vertical-tab button {
   font-weight: bold;
   text-transform: uppercase;
+}
+
+.c1 ul svg {
+  margin-right: 10px;
+  height: 15px;
+  width: 15px;
 }
 
 .c1 ul:focus {
@@ -1185,6 +1794,12 @@ exports[`<Tabs/> snapshots with variant props alignment underlined 1`] = `
 .c1 ul li.active.vertical-tab button {
   font-weight: bold;
   text-transform: uppercase;
+  color: #000000;
+}
+
+.c1 ul li.underlined.active.horizontal-tab button:hover,
+.c1 ul li.active.vertical-tab button:hover {
+  border: 0;
 }
 
 .c1 ul li.colored.active.horizontal-tab {
@@ -1196,13 +1811,15 @@ exports[`<Tabs/> snapshots with variant props alignment underlined 1`] = `
   text-transform: uppercase;
 }
 
-.c1 ul li.active.vertical-tab {
-  border-bottom: 2px solid #000000;
-}
-
 .c1 ul li.active.vertical-tab button {
   font-weight: bold;
   text-transform: uppercase;
+}
+
+.c1 ul svg {
+  margin-right: 10px;
+  height: 15px;
+  width: 15px;
 }
 
 .c1 ul:focus {

--- a/src/Display/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/Display/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -175,6 +175,7 @@ exports[`<Tabs/> render should match snapshot 1`] = `
 @media (min-width:768px) {
   .c1 ul .vertical-tab {
     margin: 0;
+    padding-left: 15px;
   }
 }
 
@@ -461,6 +462,7 @@ exports[`<Tabs/> snapshots with alignment props alignment horizontal 1`] = `
 @media (min-width:768px) {
   .c1 ul .vertical-tab {
     margin: 0;
+    padding-left: 15px;
   }
 }
 
@@ -744,6 +746,7 @@ exports[`<Tabs/> snapshots with alignment props alignment vertical 1`] = `
 @media (min-width:768px) {
   .c1 ul .vertical-tab {
     margin: 0;
+    padding-left: 15px;
   }
 }
 
@@ -1027,6 +1030,7 @@ exports[`<Tabs/> snapshots with colour prop and variant as underlined colour bla
 @media (min-width:768px) {
   .c1 ul .vertical-tab {
     margin: 0;
+    padding-left: 15px;
   }
 }
 
@@ -1134,7 +1138,7 @@ exports[`<Tabs/> snapshots with colour prop and variant as underlined colour bla
 </DocumentFragment>
 `;
 
-exports[`<Tabs/> snapshots with colour prop and variant as underlined colour grey 1`] = `
+exports[`<Tabs/> snapshots with colour prop and variant as underlined colour blue 1`] = `
 <DocumentFragment>
   .c0 {
   position: relative;
@@ -1321,6 +1325,7 @@ exports[`<Tabs/> snapshots with colour prop and variant as underlined colour gre
 @media (min-width:768px) {
   .c1 ul .vertical-tab {
     margin: 0;
+    padding-left: 15px;
   }
 }
 
@@ -1604,6 +1609,7 @@ exports[`<Tabs/> snapshots with variant props alignment colored 1`] = `
 @media (min-width:768px) {
   .c1 ul .vertical-tab {
     margin: 0;
+    padding-left: 15px;
   }
 }
 
@@ -1887,6 +1893,7 @@ exports[`<Tabs/> snapshots with variant props alignment underlined 1`] = `
 @media (min-width:768px) {
   .c1 ul .vertical-tab {
     margin: 0;
+    padding-left: 15px;
   }
 }
 

--- a/src/Utils/StyleConfig.ts
+++ b/src/Utils/StyleConfig.ts
@@ -8,6 +8,11 @@ export enum EHorizontalTabVariant {
   COLORED = 'colored',
 }
 
+export enum ETabColourVariant {
+  GREY = 'grey',
+  BLACK = 'black',
+}
+
 export enum ETooltipPosition {
   TOP = 'top',
   BOTTOM = 'bottom',

--- a/src/Utils/StyleConfig.ts
+++ b/src/Utils/StyleConfig.ts
@@ -8,8 +8,8 @@ export enum EHorizontalTabVariant {
   COLORED = 'colored',
 }
 
-export enum ETabColourVariant {
-  GREY = 'grey',
+export enum ETabThemeVariant {
+  BLUE = 'blue',
   BLACK = 'black',
 }
 

--- a/stories/Display/TabsStory.tsx
+++ b/stories/Display/TabsStory.tsx
@@ -9,7 +9,9 @@ import StorybookComponent from '../StorybookComponent';
 import {
   ETabAlignment,
   EHorizontalTabVariant,
+  ETabColourVariant,
 } from '../../src/Utils/StyleConfig';
+import FileAlternateIcon from '../../src/General/Icon/components/FileAlternateIcon';
 
 const props = {
   Tabs: [
@@ -30,6 +32,15 @@ const props = {
       require: 'no',
       description:
         'Sets alignment of Tab. The vertical tabs are changed to horizontal ones for screen size below 768',
+    },
+    {
+      name: 'colour',
+      type: 'string',
+      defaultValue: 'black',
+      possibleValue: 'blue, grey',
+      require: 'no',
+      description:
+        'Sets the colour for the tabs in underlined variant.',
     },
     {
       name: 'activeTab',
@@ -132,6 +143,128 @@ const TabsStory = () => (
         <Tabs.Pane tab="Company">Glints</Tabs.Pane>
         <Tabs.Pane tab="Location">Jakarta</Tabs.Pane>
         <Tabs.Pane tab="Salary">Rp 10,000,000</Tabs.Pane>
+      </Tabs>
+    </StorybookComponent>
+
+    <Divider theme="grey" />
+
+    <StorybookComponent
+      title="Tabs"
+      code="import { Tabs } from 'glints-aries'"
+      usage={`<Tabs variant="underlined" colour="grey">
+        <Tabs.Pane tab="Job">
+        Software Engineer <Badge label="1" />
+        </Tabs.Pane>
+        <Tabs.Pane tab="Company">Glints</Tabs.Pane>
+        <Tabs.Pane tab="Location">Jakarta</Tabs.Pane>
+        <Tabs.Pane tab="Salary">Rp 10,000,000</Tabs.Pane>
+      </Tabs>`}
+    >
+      <Heading style={{ fontSize: '20px', marginBottom: '1em' }}>
+        Horizontal Tabs (Grey Colour, Underlined Variant)
+      </Heading>
+      <Tabs
+        variant={EHorizontalTabVariant.UNDERLINED}
+        colour={ETabColourVariant.GREY}
+      >
+        <Tabs.Pane tab="Job">
+          Software Engineer <Badge label="1" />
+        </Tabs.Pane>
+        <Tabs.Pane tab="Company">Glints</Tabs.Pane>
+        <Tabs.Pane tab="Location">Jakarta</Tabs.Pane>
+        <Tabs.Pane tab="Salary">Rp 10,000,000</Tabs.Pane>
+      </Tabs>
+    </StorybookComponent>
+
+    <Divider theme="grey" />
+
+    <StorybookComponent
+      title="Tabs"
+      code="import { Tabs } from 'glints-aries'"
+      usage={`<Tabs variant="underlined" colour="grey">
+        <Tabs.Pane tab={<div><FileAlternateIcon />Jobs</div>}>
+        Software Engineer <Badge label="1" />
+        </Tabs.Pane>
+        <Tabs.Pane tab={<div><FileAlternateIcon />Company</div>}>Glints</Tabs.Pane>
+        <Tabs.Pane tab={<div><FileAlternateIcon />Location</div>}>Jakarta</Tabs.Pane>
+        <Tabs.Pane tab={<div><FileAlternateIcon />Salary</div>}>Rp 10,000,000</Tabs.Pane>
+      </Tabs>`}
+    >
+      <Heading style={{ fontSize: '20px', marginBottom: '1em' }}>
+        Horizontal Icon Tabs (Grey Colour, Underlined Variant)
+      </Heading>
+      <Tabs
+        variant={EHorizontalTabVariant.UNDERLINED}
+        colour={ETabColourVariant.GREY}
+      >
+        <Tabs.Pane tab={<div><FileAlternateIcon />Jobs</div>}>
+          Software Engineer <Badge label="1" />
+        </Tabs.Pane>
+        <Tabs.Pane tab={<div><FileAlternateIcon />Company</div>}>Glints</Tabs.Pane>
+        <Tabs.Pane tab={<div><FileAlternateIcon />Location</div>}>Jakarta</Tabs.Pane>
+        <Tabs.Pane tab={<div><FileAlternateIcon />Salary</div>}>Rp 10,000,000</Tabs.Pane>
+      </Tabs>
+    </StorybookComponent>
+
+    <Divider theme="grey" />
+
+    <StorybookComponent
+      title="Tabs"
+      code="import { Tabs } from 'glints-aries'"
+      usage={`<Tabs variant="underlined" alignment="vertical" colour="grey">
+        <Tabs.Pane tab="Job">
+        Software Engineer <Badge label="1" />
+        </Tabs.Pane>
+        <Tabs.Pane tab="Company">Glints</Tabs.Pane>
+        <Tabs.Pane tab="Location">Jakarta</Tabs.Pane>
+        <Tabs.Pane tab="Salary">Rp 10,000,000</Tabs.Pane>
+      </Tabs>`}
+    >
+      <Heading style={{ fontSize: '20px', marginBottom: '1em' }}>
+        Vertical Tabs (Grey Colour, Underlined Variant)
+      </Heading>
+      <Tabs
+        variant={EHorizontalTabVariant.UNDERLINED}
+        alignment={ETabAlignment.VERTICAL}
+        colour={ETabColourVariant.GREY}
+      >
+        <Tabs.Pane tab="Job">
+          Software Engineer <Badge label="1" />
+        </Tabs.Pane>
+        <Tabs.Pane tab="Company">Glints</Tabs.Pane>
+        <Tabs.Pane tab="Location">Jakarta</Tabs.Pane>
+        <Tabs.Pane tab="Salary">Rp 10,000,000</Tabs.Pane>
+      </Tabs>
+    </StorybookComponent>
+
+    <Divider theme="grey" />
+
+    <StorybookComponent
+      title="Tabs"
+      code="import { Tabs } from 'glints-aries'"
+      usage={`<Tabs variant="underlined" alignment="vertical" colour="grey">
+        <Tabs.Pane tab={<div><FileAlternateIcon />Jobs</div>}>
+        Software Engineer <Badge label="1" />
+        </Tabs.Pane>
+        <Tabs.Pane tab={<div><FileAlternateIcon />Company</div>}>Glints</Tabs.Pane>
+        <Tabs.Pane tab={<div><FileAlternateIcon />Location</div>}>Jakarta</Tabs.Pane>
+        <Tabs.Pane tab={<div><FileAlternateIcon />Salary</div>}>Rp 10,000,000</Tabs.Pane>
+      </Tabs>`}
+    >
+      <Heading style={{ fontSize: '20px', marginBottom: '1em' }}>
+        Vertical Icon Tabs (Grey Colour, Underlined Variant)
+      </Heading>
+      <Tabs
+        variant={EHorizontalTabVariant.UNDERLINED}
+        alignment={ETabAlignment.VERTICAL}
+        colour={ETabColourVariant.GREY}
+      >
+        <Tabs.Pane tab={<div><FileAlternateIcon />Jobs</div>}>
+          Software Engineer <Badge label="1" />
+        </Tabs.Pane>
+        <Tabs.Pane tab={<div><FileAlternateIcon />Company</div>}>Glints</Tabs.Pane>
+        <Tabs.Pane tab={<div><FileAlternateIcon />Location</div>}>Jakarta</Tabs.Pane>
+        <Tabs.Pane tab={<div><FileAlternateIcon />Salary</div>}>Rp 10,000,000</Tabs.Pane>
       </Tabs>
     </StorybookComponent>
   </React.Fragment>

--- a/stories/Display/TabsStory.tsx
+++ b/stories/Display/TabsStory.tsx
@@ -39,8 +39,7 @@ const props = {
       defaultValue: 'black',
       possibleValue: 'blue, grey',
       require: 'no',
-      description:
-        'Sets the colour for the tabs in underlined variant.',
+      description: 'Sets the colour for the tabs in underlined variant.',
     },
     {
       name: 'activeTab',
@@ -197,12 +196,46 @@ const TabsStory = () => (
         variant={EHorizontalTabVariant.UNDERLINED}
         colour={ETabColourVariant.GREY}
       >
-        <Tabs.Pane tab={<div><FileAlternateIcon />Jobs</div>}>
+        <Tabs.Pane
+          tab={
+            <div>
+              <FileAlternateIcon />
+              Jobs
+            </div>
+          }
+        >
           Software Engineer <Badge label="1" />
         </Tabs.Pane>
-        <Tabs.Pane tab={<div><FileAlternateIcon />Company</div>}>Glints</Tabs.Pane>
-        <Tabs.Pane tab={<div><FileAlternateIcon />Location</div>}>Jakarta</Tabs.Pane>
-        <Tabs.Pane tab={<div><FileAlternateIcon />Salary</div>}>Rp 10,000,000</Tabs.Pane>
+        <Tabs.Pane
+          tab={
+            <div>
+              <FileAlternateIcon />
+              Company
+            </div>
+          }
+        >
+          Glints
+        </Tabs.Pane>
+        <Tabs.Pane
+          tab={
+            <div>
+              <FileAlternateIcon />
+              Location
+            </div>
+          }
+        >
+          Jakarta
+        </Tabs.Pane>
+        <Tabs.Pane
+          tab={
+            <div>
+              <FileAlternateIcon />
+              Salary
+            </div>
+          }
+        >
+          Rp 10,000,000
+        </Tabs.Pane>
       </Tabs>
     </StorybookComponent>
 
@@ -259,12 +292,46 @@ const TabsStory = () => (
         alignment={ETabAlignment.VERTICAL}
         colour={ETabColourVariant.GREY}
       >
-        <Tabs.Pane tab={<div><FileAlternateIcon />Jobs</div>}>
+        <Tabs.Pane
+          tab={
+            <div>
+              <FileAlternateIcon />
+              Jobs
+            </div>
+          }
+        >
           Software Engineer <Badge label="1" />
         </Tabs.Pane>
-        <Tabs.Pane tab={<div><FileAlternateIcon />Company</div>}>Glints</Tabs.Pane>
-        <Tabs.Pane tab={<div><FileAlternateIcon />Location</div>}>Jakarta</Tabs.Pane>
-        <Tabs.Pane tab={<div><FileAlternateIcon />Salary</div>}>Rp 10,000,000</Tabs.Pane>
+        <Tabs.Pane
+          tab={
+            <div>
+              <FileAlternateIcon />
+              Company
+            </div>
+          }
+        >
+          Glints
+        </Tabs.Pane>
+        <Tabs.Pane
+          tab={
+            <div>
+              <FileAlternateIcon />
+              Location
+            </div>
+          }
+        >
+          Jakarta
+        </Tabs.Pane>
+        <Tabs.Pane
+          tab={
+            <div>
+              <FileAlternateIcon />
+              Salary
+            </div>
+          }
+        >
+          Rp 10,000,000
+        </Tabs.Pane>
       </Tabs>
     </StorybookComponent>
   </React.Fragment>

--- a/stories/Display/TabsStory.tsx
+++ b/stories/Display/TabsStory.tsx
@@ -150,7 +150,7 @@ const TabsStory = () => (
     <StorybookComponent
       title="Tabs"
       code="import { Tabs } from 'glints-aries'"
-      usage={`<Tabs variant="underlined" theme="grey">
+      usage={`<Tabs variant="underlined" theme="blue">
         <Tabs.Pane tab="Job">
         Software Engineer <Badge label="1" />
         </Tabs.Pane>
@@ -180,7 +180,7 @@ const TabsStory = () => (
     <StorybookComponent
       title="Tabs"
       code="import { Tabs } from 'glints-aries'"
-      usage={`<Tabs variant="underlined" theme="grey">
+      usage={`<Tabs variant="underlined" theme="blue">
         <Tabs.Pane tab={<div><FileAlternateIcon />Jobs</div>}>
         Software Engineer <Badge label="1" />
         </Tabs.Pane>
@@ -244,7 +244,7 @@ const TabsStory = () => (
     <StorybookComponent
       title="Tabs"
       code="import { Tabs } from 'glints-aries'"
-      usage={`<Tabs variant="underlined" alignment="vertical" theme="grey">
+      usage={`<Tabs variant="underlined" alignment="vertical" theme="blue">
         <Tabs.Pane tab="Job">
         Software Engineer <Badge label="1" />
         </Tabs.Pane>
@@ -275,7 +275,7 @@ const TabsStory = () => (
     <StorybookComponent
       title="Tabs"
       code="import { Tabs } from 'glints-aries'"
-      usage={`<Tabs variant="underlined" alignment="vertical" theme="grey">
+      usage={`<Tabs variant="underlined" alignment="vertical" theme="blue">
         <Tabs.Pane tab={<div><FileAlternateIcon />Jobs</div>}>
         Software Engineer <Badge label="1" />
         </Tabs.Pane>

--- a/stories/Display/TabsStory.tsx
+++ b/stories/Display/TabsStory.tsx
@@ -9,7 +9,7 @@ import StorybookComponent from '../StorybookComponent';
 import {
   ETabAlignment,
   EHorizontalTabVariant,
-  ETabColourVariant,
+  ETabThemeVariant,
 } from '../../src/Utils/StyleConfig';
 import FileAlternateIcon from '../../src/General/Icon/components/FileAlternateIcon';
 
@@ -34,12 +34,12 @@ const props = {
         'Sets alignment of Tab. The vertical tabs are changed to horizontal ones for screen size below 768',
     },
     {
-      name: 'colour',
+      name: 'theme',
       type: 'string',
       defaultValue: 'black',
-      possibleValue: 'blue, grey',
+      possibleValue: 'blue, black',
       require: 'no',
-      description: 'Sets the colour for the tabs in underlined variant.',
+      description: 'Sets the theme for the tabs in underlined variant.',
     },
     {
       name: 'activeTab',
@@ -150,7 +150,7 @@ const TabsStory = () => (
     <StorybookComponent
       title="Tabs"
       code="import { Tabs } from 'glints-aries'"
-      usage={`<Tabs variant="underlined" colour="grey">
+      usage={`<Tabs variant="underlined" theme="grey">
         <Tabs.Pane tab="Job">
         Software Engineer <Badge label="1" />
         </Tabs.Pane>
@@ -160,11 +160,11 @@ const TabsStory = () => (
       </Tabs>`}
     >
       <Heading style={{ fontSize: '20px', marginBottom: '1em' }}>
-        Horizontal Tabs (Grey Colour, Underlined Variant)
+        Horizontal Tabs (Blue theme, Underlined Variant)
       </Heading>
       <Tabs
         variant={EHorizontalTabVariant.UNDERLINED}
-        colour={ETabColourVariant.GREY}
+        theme={ETabThemeVariant.BLUE}
       >
         <Tabs.Pane tab="Job">
           Software Engineer <Badge label="1" />
@@ -180,7 +180,7 @@ const TabsStory = () => (
     <StorybookComponent
       title="Tabs"
       code="import { Tabs } from 'glints-aries'"
-      usage={`<Tabs variant="underlined" colour="grey">
+      usage={`<Tabs variant="underlined" theme="grey">
         <Tabs.Pane tab={<div><FileAlternateIcon />Jobs</div>}>
         Software Engineer <Badge label="1" />
         </Tabs.Pane>
@@ -190,11 +190,11 @@ const TabsStory = () => (
       </Tabs>`}
     >
       <Heading style={{ fontSize: '20px', marginBottom: '1em' }}>
-        Horizontal Icon Tabs (Grey Colour, Underlined Variant)
+        Horizontal Icon Tabs (Blue theme, Underlined Variant)
       </Heading>
       <Tabs
         variant={EHorizontalTabVariant.UNDERLINED}
-        colour={ETabColourVariant.GREY}
+        theme={ETabThemeVariant.BLUE}
       >
         <Tabs.Pane
           tab={
@@ -244,7 +244,7 @@ const TabsStory = () => (
     <StorybookComponent
       title="Tabs"
       code="import { Tabs } from 'glints-aries'"
-      usage={`<Tabs variant="underlined" alignment="vertical" colour="grey">
+      usage={`<Tabs variant="underlined" alignment="vertical" theme="grey">
         <Tabs.Pane tab="Job">
         Software Engineer <Badge label="1" />
         </Tabs.Pane>
@@ -254,12 +254,12 @@ const TabsStory = () => (
       </Tabs>`}
     >
       <Heading style={{ fontSize: '20px', marginBottom: '1em' }}>
-        Vertical Tabs (Grey Colour, Underlined Variant)
+        Vertical Tabs (Blue theme, Underlined Variant)
       </Heading>
       <Tabs
         variant={EHorizontalTabVariant.UNDERLINED}
         alignment={ETabAlignment.VERTICAL}
-        colour={ETabColourVariant.GREY}
+        theme={ETabThemeVariant.BLUE}
       >
         <Tabs.Pane tab="Job">
           Software Engineer <Badge label="1" />
@@ -275,7 +275,7 @@ const TabsStory = () => (
     <StorybookComponent
       title="Tabs"
       code="import { Tabs } from 'glints-aries'"
-      usage={`<Tabs variant="underlined" alignment="vertical" colour="grey">
+      usage={`<Tabs variant="underlined" alignment="vertical" theme="grey">
         <Tabs.Pane tab={<div><FileAlternateIcon />Jobs</div>}>
         Software Engineer <Badge label="1" />
         </Tabs.Pane>
@@ -285,12 +285,12 @@ const TabsStory = () => (
       </Tabs>`}
     >
       <Heading style={{ fontSize: '20px', marginBottom: '1em' }}>
-        Vertical Icon Tabs (Grey Colour, Underlined Variant)
+        Vertical Icon Tabs (Blue theme, Underlined Variant)
       </Heading>
       <Tabs
         variant={EHorizontalTabVariant.UNDERLINED}
         alignment={ETabAlignment.VERTICAL}
-        colour={ETabColourVariant.GREY}
+        theme={ETabThemeVariant.BLUE}
       >
         <Tabs.Pane
           tab={


### PR DESCRIPTION
Fixes: #208 

https://docs.google.com/document/d/1pHImZ2YXcG0WxMU5ll1y9zBygyErR2EjR8xu3Y2lgDw/edit


I have added a new colour variant (black and grey) only for the `underlined` tabs, because the other tabs are being used in the Q&A, and maybe some other parts. So for now it's ok to keep them. https://glints.slack.com/archives/CS09D0LJX/p1590990467027600
Will remove it after they are refactorred.

Also made the tab to take input as string and node.