### PR TITLE
Select: defaultOpen & close behavior

### DIFF
--- a/src/Input/Select/Select.test.tsx
+++ b/src/Input/Select/Select.test.tsx
@@ -639,6 +639,75 @@ describe('<Select/> disableTyping', () => {
   });
 });
 
+describe('<Select/> defaultOpen', () => {
+  it('should be open', async () => {
+    const Component = () => (
+      <React.Fragment>
+        <Select label="defaultOpen" defaultOpen={true}>
+          <Select.Option value="defaultOpen">defaultOpen</Select.Option>
+        </Select>
+      </React.Fragment>
+    );
+
+    const { queryByTestId } = render(<Component />);
+    const selectList = queryByTestId('listbox');
+
+    expect(selectList.hasAttribute('open')).toEqual(true);
+  });
+
+  it('should be focused', async () => {
+    const Component = () => (
+      <React.Fragment>
+        <Select label="defaultOpen" defaultOpen={true}>
+          <Select.Option value="defaultOpen">defaultOpen</Select.Option>
+        </Select>
+      </React.Fragment>
+    );
+
+    const { queryByRole } = render(<Component />);
+    const selectInput = queryByRole('combobox');
+
+    expect(selectInput).toHaveFocus();
+  });
+
+  it('should be closed by clicking outside', async () => {
+    const Component = () => (
+      <React.Fragment>
+        <Select label="defaultOpen" defaultOpen={true}>
+          <Select.Option value="defaultOpen">defaultOpen</Select.Option>
+        </Select>
+        <div>outside</div>
+      </React.Fragment>
+    );
+
+    const { queryByTestId, queryByText } = render(<Component />);
+    const selectList = queryByTestId('listbox');
+    const outside = queryByText('outside');
+
+    expect(selectList.hasAttribute('open')).toEqual(true);
+    fireEvent.click(outside);
+    expect(selectList.hasAttribute('open')).toEqual(false);
+  });
+
+  it('should be closed by clicking option', async () => {
+    const Component = () => (
+      <React.Fragment>
+        <Select label="defaultOpen" defaultOpen={true}>
+          <Select.Option value="defaultOpen">defaultOpen</Select.Option>
+        </Select>
+      </React.Fragment>
+    );
+
+    const { queryByTestId } = render(<Component />);
+    const selectList = queryByTestId('listbox');
+    const option = queryByTestId('option');
+
+    expect(selectList.hasAttribute('open')).toEqual(true);
+    userEvent.click(option);
+    expect(selectList.hasAttribute('open')).toEqual(false);
+  });
+});
+
 describe('<Select/> esc key', () => {
   it('esc keydown event should close the option list', async () => {
     const Component = () => (

--- a/src/Input/Select/Select.test.tsx
+++ b/src/Input/Select/Select.test.tsx
@@ -512,7 +512,7 @@ describe('<Select />', () => {
     );
 
     const { queryByTestId } = render(<Component />);
-    const dropIcon = queryByTestId('select-drop-icon');
+    const dropIcon = document.querySelector('.select-icon');
     const selectList = queryByTestId('listbox');
 
     userEvent.click(dropIcon);
@@ -532,7 +532,7 @@ describe('<Select />', () => {
     );
 
     const { queryByTestId, queryByRole } = render(<Component />);
-    const dropIcon = queryByTestId('select-drop-icon');
+    const dropIcon = document.querySelector('.select-icon');
     const selectInput = queryByRole('combobox');
 
     userEvent.click(dropIcon);
@@ -614,7 +614,7 @@ describe('<Select/> disableTyping', () => {
 
     const { queryByTestId } = render(<Component />);
     const selectList = queryByTestId('listbox');
-    const dropIcon = queryByTestId('select-drop-icon');
+    const dropIcon = document.querySelector('.select-icon');
 
     userEvent.click(dropIcon);
     expect(selectList.hasAttribute('open')).toEqual(true);

--- a/src/Input/Select/Select.test.tsx
+++ b/src/Input/Select/Select.test.tsx
@@ -389,11 +389,9 @@ describe('<Select/> on click outside', () => {
     const removeEventListenerSpy = jest.spyOn(document, 'removeEventListener');
 
     const Component = () => (
-      <React.Fragment>
-        <Select label="ClickOutside">
-          <Select.Option value="ClickOutside">ClickOutside</Select.Option>
-        </Select>
-      </React.Fragment>
+      <Select label="ClickOutside">
+        <Select.Option value="ClickOutside">ClickOutside</Select.Option>
+      </Select>
     );
 
     const { unmount } = render(<Component />);
@@ -411,11 +409,9 @@ describe('<Select/> onBlur onFocus', () => {
     const onBlurSpy = jest.fn();
     const onFocusSpy = jest.fn();
     const Component = () => (
-      <React.Fragment>
-        <Select label="ClickOutside" onBlur={onBlurSpy} onFocus={onFocusSpy}>
-          <Select.Option value="ClickOutside">ClickOutside</Select.Option>
-        </Select>
-      </React.Fragment>
+      <Select label="ClickOutside" onBlur={onBlurSpy} onFocus={onFocusSpy}>
+        <Select.Option value="ClickOutside">ClickOutside</Select.Option>
+      </Select>
     );
 
     const { queryByRole, asFragment } = render(<Component />);
@@ -436,13 +432,11 @@ describe('<Select/> onBlur onFocus', () => {
 describe('<Select/> handleValueChange', () => {
   it('input value should be the same as passed prop value', async () => {
     const Component = ({ value }: { value: string }) => (
-      <React.Fragment>
-        <Select label="handleValueChange" value={value}>
-          <Select.Option value="handleValueChange">
-            handleValueChange
-          </Select.Option>
-        </Select>
-      </React.Fragment>
+      <Select label="handleValueChange" value={value}>
+        <Select.Option value="handleValueChange">
+          handleValueChange
+        </Select.Option>
+      </Select>
     );
 
     const mockValue = 'mock';
@@ -460,11 +454,9 @@ describe('<Select/> prop onInputChange', () => {
   it('should call onInputChange on input change', async () => {
     const onInputChangeSpy = jest.fn();
     const Component = () => (
-      <React.Fragment>
-        <Select label="onInputChange" onInputChange={onInputChangeSpy}>
-          <Select.Option value="onInputChange">onInputChange</Select.Option>
-        </Select>
-      </React.Fragment>
+      <Select label="onInputChange" onInputChange={onInputChangeSpy}>
+        <Select.Option value="onInputChange">onInputChange</Select.Option>
+      </Select>
     );
 
     const mockValue = 'mock value';
@@ -555,11 +547,9 @@ describe('<Select />', () => {
 describe('<Select/> disableTyping', () => {
   it('esc key should still have effect', async () => {
     const Component = () => (
-      <React.Fragment>
-        <Select label="disableTyping" disableTyping={true}>
-          <Select.Option value="disableTyping">disableTyping</Select.Option>
-        </Select>
-      </React.Fragment>
+      <Select label="disableTyping" disableTyping={true}>
+        <Select.Option value="disableTyping">disableTyping</Select.Option>
+      </Select>
     );
 
     const { queryByRole, queryByTestId } = render(<Component />);
@@ -574,11 +564,9 @@ describe('<Select/> disableTyping', () => {
 
   it('input value should change when disableTyping is not specified', async () => {
     const Component = () => (
-      <React.Fragment>
-        <Select label="disableTyping">
-          <Select.Option value="disableTyping">disableTyping</Select.Option>
-        </Select>
-      </React.Fragment>
+      <Select label="disableTyping">
+        <Select.Option value="disableTyping">disableTyping</Select.Option>
+      </Select>
     );
 
     const { queryByRole } = render(<Component />);
@@ -589,11 +577,9 @@ describe('<Select/> disableTyping', () => {
 
   it('input value should not change when disableTyping is truthy', async () => {
     const Component = () => (
-      <React.Fragment>
-        <Select label="disableTyping" disableTyping={true}>
-          <Select.Option value="disableTyping">disableTyping</Select.Option>
-        </Select>
-      </React.Fragment>
+      <Select label="disableTyping" disableTyping={true}>
+        <Select.Option value="disableTyping">disableTyping</Select.Option>
+      </Select>
     );
 
     const { queryByRole } = render(<Component />);
@@ -604,11 +590,9 @@ describe('<Select/> disableTyping', () => {
 
   it('should be open/ close when input is clicked', async () => {
     const Component = () => (
-      <React.Fragment>
-        <Select label="disableTyping" disableTyping={true}>
-          <Select.Option value="disableTyping">disableTyping</Select.Option>
-        </Select>
-      </React.Fragment>
+      <Select label="disableTyping" disableTyping={true}>
+        <Select.Option value="disableTyping">disableTyping</Select.Option>
+      </Select>
     );
 
     const { queryByRole, queryByTestId } = render(<Component />);
@@ -642,11 +626,9 @@ describe('<Select/> disableTyping', () => {
 describe('<Select/> defaultOpen', () => {
   it('should be open', async () => {
     const Component = () => (
-      <React.Fragment>
-        <Select label="defaultOpen" defaultOpen={true}>
-          <Select.Option value="defaultOpen">defaultOpen</Select.Option>
-        </Select>
-      </React.Fragment>
+      <Select label="defaultOpen" defaultOpen={true}>
+        <Select.Option value="defaultOpen">defaultOpen</Select.Option>
+      </Select>
     );
 
     const { queryByTestId } = render(<Component />);
@@ -657,11 +639,9 @@ describe('<Select/> defaultOpen', () => {
 
   it('should be focused', async () => {
     const Component = () => (
-      <React.Fragment>
-        <Select label="defaultOpen" defaultOpen={true}>
-          <Select.Option value="defaultOpen">defaultOpen</Select.Option>
-        </Select>
-      </React.Fragment>
+      <Select label="defaultOpen" defaultOpen={true}>
+        <Select.Option value="defaultOpen">defaultOpen</Select.Option>
+      </Select>
     );
 
     const { queryByRole } = render(<Component />);
@@ -691,11 +671,9 @@ describe('<Select/> defaultOpen', () => {
 
   it('should be closed by clicking option', async () => {
     const Component = () => (
-      <React.Fragment>
-        <Select label="defaultOpen" defaultOpen={true}>
-          <Select.Option value="defaultOpen">defaultOpen</Select.Option>
-        </Select>
-      </React.Fragment>
+      <Select label="defaultOpen" defaultOpen={true}>
+        <Select.Option value="defaultOpen">defaultOpen</Select.Option>
+      </Select>
     );
 
     const { queryByTestId } = render(<Component />);
@@ -711,11 +689,9 @@ describe('<Select/> defaultOpen', () => {
 describe('<Select/> esc key', () => {
   it('esc keydown event should close the option list', async () => {
     const Component = () => (
-      <React.Fragment>
-        <Select label="esc">
-          <Select.Option value="esc">esc</Select.Option>
-        </Select>
-      </React.Fragment>
+      <Select label="esc">
+        <Select.Option value="esc">esc</Select.Option>
+      </Select>
     );
 
     const { queryByRole, queryByTestId } = render(<Component />);
@@ -732,13 +708,11 @@ describe('<Select/> esc key', () => {
 describe('<Select/> handleMouseEnterOption', () => {
   it('it should match snapshot, the option element should have active class name', async () => {
     const Component = () => (
-      <React.Fragment>
-        <Select label="handleMouseEnterOption">
-          <Select.Option value="handleMouseEnterOption">
-            handleMouseEnterOption
-          </Select.Option>
-        </Select>
-      </React.Fragment>
+      <Select label="handleMouseEnterOption">
+        <Select.Option value="handleMouseEnterOption">
+          handleMouseEnterOption
+        </Select.Option>
+      </Select>
     );
 
     const { queryByRole, queryByTestId, asFragment } = render(<Component />);

--- a/src/Input/Select/Select.test.tsx
+++ b/src/Input/Select/Select.test.tsx
@@ -472,7 +472,7 @@ describe('<Select/> prop onInputChange', () => {
   });
 });
 
-describe('<Select />', () => {
+describe('<Select /> click to close option dropdown', () => {
   it('should not be closed when input is clicked again', async () => {
     const Component = () => (
       <Select label="default">
@@ -531,7 +531,7 @@ describe('<Select />', () => {
       </Select>
     );
 
-    const { queryByTestId, queryByRole } = render(<Component />);
+    const { queryByRole } = render(<Component />);
     const dropIcon = document.querySelector('.select-icon');
     const selectInput = queryByRole('combobox');
 

--- a/src/Input/Select/Select.test.tsx
+++ b/src/Input/Select/Select.test.tsx
@@ -480,6 +480,78 @@ describe('<Select/> prop onInputChange', () => {
   });
 });
 
+describe('<Select />', () => {
+  it('should not be closed when input is clicked again', async () => {
+    const Component = () => (
+      <Select label="default">
+        <Select.Option value="default">default</Select.Option>
+      </Select>
+    );
+
+    const { queryByRole, queryByTestId } = render(<Component />);
+    const selectInput = queryByRole('combobox');
+    const selectList = queryByTestId('listbox');
+
+    userEvent.click(selectInput);
+    expect(selectList.hasAttribute('open')).toEqual(true);
+    userEvent.click(selectInput);
+    expect(selectList.hasAttribute('open')).toEqual(true);
+  });
+
+  it('should be focused when input is clicked', () => {
+    const Component = () => (
+      <Select label="default">
+        <Select.Option value="default">default</Select.Option>
+      </Select>
+    );
+
+    const { queryByRole } = render(<Component />);
+    const selectInput = queryByRole('combobox');
+
+    userEvent.click(selectInput);
+    expect(selectInput).toHaveFocus();
+  });
+
+  it('should open/ close when drop icon is clicked', async () => {
+    const Component = () => (
+      <Select label="default">
+        <Select.Option value="default">default</Select.Option>
+      </Select>
+    );
+
+    const { queryByTestId } = render(<Component />);
+    const dropIcon = queryByTestId('select-drop-icon');
+    const selectList = queryByTestId('listbox');
+
+    userEvent.click(dropIcon);
+    expect(selectList.hasAttribute('open')).toEqual(true);
+    userEvent.click(dropIcon);
+    expect(selectList.hasAttribute('open')).toEqual(false);
+  });
+
+  it('should be focused/ blurred when drop icon is clicked', () => {
+    const onBlurSpy = jest.fn();
+    const onFocusSpy = jest.fn();
+
+    const Component = () => (
+      <Select label="default" onFocus={onFocusSpy} onBlur={onBlurSpy}>
+        <Select.Option value="default">default</Select.Option>
+      </Select>
+    );
+
+    const { queryByTestId, queryByRole } = render(<Component />);
+    const dropIcon = queryByTestId('select-drop-icon');
+    const selectInput = queryByRole('combobox');
+
+    userEvent.click(dropIcon);
+    expect(selectInput).toHaveFocus();
+    expect(onFocusSpy).toHaveBeenCalledTimes(1);
+    userEvent.click(dropIcon);
+    expect(selectInput).not.toHaveFocus();
+    expect(onBlurSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('<Select/> disableTyping', () => {
   it('esc key should still have effect', async () => {
     const Component = () => (
@@ -494,7 +566,7 @@ describe('<Select/> disableTyping', () => {
     const selectInput = queryByRole('combobox');
     const selectList = queryByTestId('listbox');
 
-    fireEvent.focus(selectInput);
+    fireEvent.click(selectInput);
     expect(selectList.hasAttribute('open')).toEqual(true);
     fireEvent.keyDown(selectInput, { key: 'Esc', keyCode: 27 });
     expect(selectList.hasAttribute('open')).toEqual(false);
@@ -528,6 +600,42 @@ describe('<Select/> disableTyping', () => {
     const selectInput = queryByRole('combobox');
     userEvent.type(selectInput, 'abc');
     expect((selectInput as any).value).toEqual('');
+  });
+
+  it('should be open/ close when input is clicked', async () => {
+    const Component = () => (
+      <React.Fragment>
+        <Select label="disableTyping" disableTyping={true}>
+          <Select.Option value="disableTyping">disableTyping</Select.Option>
+        </Select>
+      </React.Fragment>
+    );
+
+    const { queryByRole, queryByTestId } = render(<Component />);
+    const selectInput = queryByRole('combobox');
+    const selectList = queryByTestId('listbox');
+
+    userEvent.click(selectInput);
+    expect(selectList.hasAttribute('open')).toEqual(true);
+    userEvent.click(selectInput);
+    expect(selectList.hasAttribute('open')).toEqual(false);
+  });
+
+  it('should be open/ close when drop icon is clicked', () => {
+    const Component = () => (
+      <Select label="disableTyping" disableTyping={true}>
+        <Select.Option value="disableTyping">disableTyping</Select.Option>
+      </Select>
+    );
+
+    const { queryByTestId } = render(<Component />);
+    const selectList = queryByTestId('listbox');
+    const dropIcon = queryByTestId('select-drop-icon');
+
+    userEvent.click(dropIcon);
+    expect(selectList.hasAttribute('open')).toEqual(true);
+    userEvent.click(dropIcon);
+    expect(selectList.hasAttribute('open')).toEqual(false);
   });
 });
 

--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -352,7 +352,6 @@ const Select: ISelect = (props: Props) => {
           <div
             className="select-icon"
             aria-label="show options"
-            data-testid="select-drop-icon"
             onClick={handleDropIconClick}
           >
             <ArrowDownIcon color="#777777" />

--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -66,6 +66,7 @@ const Select: ISelect = (props: Props) => {
   ] = React.useState<boolean>(false);
 
   const selectContainerRef: React.RefObject<HTMLDivElement> = React.useRef();
+  const selectInputRef: React.RefObject<HTMLInputElement> = React.useRef();
 
   // set options based on children and inputValue
   const availableOptions = React.useMemo(() => {
@@ -156,6 +157,18 @@ const Select: ISelect = (props: Props) => {
     },
     [onFocus]
   );
+
+  const handleClick = () => {
+    setIsFocus(!isFocus);
+  };
+
+  const handleDropIconClick = () => {
+    setIsFocus(!isFocus);
+
+    if (!disableTyping && !isFocus) {
+      selectInputRef.current.focus();
+    }
+  };
 
   // Should be called when the user types into the input
   const handleInputChange = React.useCallback(
@@ -302,6 +315,7 @@ const Select: ISelect = (props: Props) => {
         small={small}
       >
         <SelectInput
+          ref={selectInputRef}
           type="text"
           placeholder={removeFloatingLabel && label}
           role="combobox"
@@ -309,10 +323,11 @@ const Select: ISelect = (props: Props) => {
           aria-autocomplete="list"
           status={deprecatedStatus}
           disabled={disabled}
-          onFocus={handleFocus}
-          onBlur={handleFocusOut}
+          onFocus={!disableTyping ? handleFocus : null}
+          onBlur={!disableTyping ? handleFocusOut : null}
           onChange={handleInputChange}
           onKeyDown={handleKeyDown}
+          onClick={disableTyping ? handleClick : null}
           floating={floating}
           value={inputValue}
           small={small}
@@ -332,7 +347,12 @@ const Select: ISelect = (props: Props) => {
           </SelectLabel>
         )}
         {!removeDropIcon && (
-          <div className="select-icon" aria-label="show options">
+          <div
+            className="select-icon"
+            aria-label="show options"
+            data-testid="select-drop-icon"
+            onClick={handleDropIconClick}
+          >
             <ArrowDownIcon color="#777777" />
           </div>
         )}

--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -34,6 +34,7 @@ const Select: ISelect = (props: Props) => {
     renderError,
     value,
     defaultValue,
+    defaultOpen = false,
     children,
     isLoading,
     ...defaultProps
@@ -54,7 +55,7 @@ const Select: ISelect = (props: Props) => {
   );
 
   const [floating, setFloating] = React.useState<boolean>(false);
-  const [isFocus, setIsFocus] = React.useState<boolean>(false);
+  const [isFocus, setIsFocus] = React.useState<boolean>(defaultOpen);
   const [isInputChange, setIsInputChange] = React.useState<boolean>(false);
   const [inputValue, setInputValue] = React.useState<string>(
     value || defaultValue || ''
@@ -333,6 +334,7 @@ const Select: ISelect = (props: Props) => {
           small={small}
           disableTyping={disableTyping}
           readOnly={disableTyping}
+          autoFocus={defaultOpen}
           {...defaultProps}
         />
         {!removeFloatingLabel && (
@@ -383,6 +385,7 @@ interface Props extends React.ComponentPropsWithoutRef<typeof SelectInput> {
   error?: React.ReactNode | string | boolean;
   renderError?: (error: React.ReactNode | string | boolean) => React.ReactNode;
   defaultValue?: string;
+  defaultOpen?: boolean;
 
   onFocus?(e: React.FocusEvent<HTMLInputElement>): void;
   onBlur?(e: React.FocusEvent<HTMLInputElement>): void;

--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -323,8 +323,8 @@ const Select: ISelect = (props: Props) => {
           aria-autocomplete="list"
           status={deprecatedStatus}
           disabled={disabled}
-          onFocus={!disableTyping ? handleFocus : null}
-          onBlur={!disableTyping ? handleFocusOut : null}
+          onFocus={disableTyping ? null : handleFocus}
+          onBlur={disableTyping ? null : handleFocusOut}
           onChange={handleInputChange}
           onKeyDown={handleKeyDown}
           onClick={disableTyping ? handleClick : null}

--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -164,11 +164,10 @@ const Select: ISelect = (props: Props) => {
   };
 
   const handleDropIconClick = () => {
-    setIsFocus(!isFocus);
-
     if (!disableTyping && !isFocus) {
       selectInputRef.current.focus();
     }
+    setIsFocus(!isFocus);
   };
 
   // Should be called when the user types into the input

--- a/src/Input/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/Input/Select/__snapshots__/Select.test.tsx.snap
@@ -36,6 +36,7 @@ exports[`<Select/> handleMouseEnterOption it should match snapshot, the option e
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  cursor: pointer;
 }
 
 .c1 .select-icon svg {
@@ -247,7 +248,6 @@ exports[`<Select/> handleMouseEnterOption it should match snapshot, the option e
       <div
         aria-label="show options"
         class="select-icon"
-        data-testid="select-drop-icon"
       >
         <svg
           class="c5"
@@ -319,6 +319,7 @@ exports[`<Select/> onBlur onFocus should call onBlur and onFocus 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  cursor: pointer;
 }
 
 .c1 .select-icon svg {
@@ -513,7 +514,6 @@ exports[`<Select/> onBlur onFocus should call onBlur and onFocus 1`] = `
       <div
         aria-label="show options"
         class="select-icon"
-        data-testid="select-drop-icon"
       >
         <svg
           class="c5"
@@ -585,6 +585,7 @@ exports[`<Select/> onBlur onFocus should call onBlur and onFocus 2`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  cursor: pointer;
 }
 
 .c1 .select-icon svg {
@@ -779,7 +780,6 @@ exports[`<Select/> onBlur onFocus should call onBlur and onFocus 2`] = `
       <div
         aria-label="show options"
         class="select-icon"
-        data-testid="select-drop-icon"
       >
         <svg
           class="c5"
@@ -850,6 +850,7 @@ exports[`<Select> should render with 3 options 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  cursor: pointer;
 }
 
 .c1 .select-icon svg {
@@ -1028,7 +1029,6 @@ exports[`<Select> should render with 3 options 1`] = `
     <div
       aria-label="show options"
       className="select-icon"
-      data-testid="select-drop-icon"
       onClick={[Function]}
     >
       <svg

--- a/src/Input/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/Input/Select/__snapshots__/Select.test.tsx.snap
@@ -1007,6 +1007,7 @@ exports[`<Select> should render with 3 options 1`] = `
     <input
       aria-autocomplete="list"
       aria-expanded={false}
+      autoFocus={false}
       className="c2"
       onBlur={[Function]}
       onChange={[Function]}

--- a/src/Input/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/Input/Select/__snapshots__/Select.test.tsx.snap
@@ -36,7 +36,6 @@ exports[`<Select/> handleMouseEnterOption it should match snapshot, the option e
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  pointer-events: none;
 }
 
 .c1 .select-icon svg {
@@ -248,6 +247,7 @@ exports[`<Select/> handleMouseEnterOption it should match snapshot, the option e
       <div
         aria-label="show options"
         class="select-icon"
+        data-testid="select-drop-icon"
       >
         <svg
           class="c5"
@@ -319,7 +319,6 @@ exports[`<Select/> onBlur onFocus should call onBlur and onFocus 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  pointer-events: none;
 }
 
 .c1 .select-icon svg {
@@ -514,6 +513,7 @@ exports[`<Select/> onBlur onFocus should call onBlur and onFocus 1`] = `
       <div
         aria-label="show options"
         class="select-icon"
+        data-testid="select-drop-icon"
       >
         <svg
           class="c5"
@@ -585,7 +585,6 @@ exports[`<Select/> onBlur onFocus should call onBlur and onFocus 2`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  pointer-events: none;
 }
 
 .c1 .select-icon svg {
@@ -780,6 +779,7 @@ exports[`<Select/> onBlur onFocus should call onBlur and onFocus 2`] = `
       <div
         aria-label="show options"
         class="select-icon"
+        data-testid="select-drop-icon"
       >
         <svg
           class="c5"
@@ -850,7 +850,6 @@ exports[`<Select> should render with 3 options 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  pointer-events: none;
 }
 
 .c1 .select-icon svg {
@@ -1011,6 +1010,7 @@ exports[`<Select> should render with 3 options 1`] = `
       className="c2"
       onBlur={[Function]}
       onChange={[Function]}
+      onClick={null}
       onFocus={[Function]}
       onKeyDown={[Function]}
       role="combobox"
@@ -1027,6 +1027,8 @@ exports[`<Select> should render with 3 options 1`] = `
     <div
       aria-label="show options"
       className="select-icon"
+      data-testid="select-drop-icon"
+      onClick={[Function]}
     >
       <svg
         className="c5"

--- a/src/Style/Input/SelectStyle.ts
+++ b/src/Style/Input/SelectStyle.ts
@@ -16,6 +16,7 @@ export const SelectWrapper = styled.div<SelectWrapperProps>`
     right: 15px;
     display: flex;
     align-items: center;
+    cursor: pointer;
     svg {
       transform: ${({ isFocus }) => (isFocus ? 'rotate(180deg)' : 'rotate(0)')};
       transition: ${({ isFocus }) =>

--- a/src/Style/Input/SelectStyle.ts
+++ b/src/Style/Input/SelectStyle.ts
@@ -16,7 +16,6 @@ export const SelectWrapper = styled.div<SelectWrapperProps>`
     right: 15px;
     display: flex;
     align-items: center;
-    pointer-events: none;
     svg {
       transform: ${({ isFocus }) => (isFocus ? 'rotate(180deg)' : 'rotate(0)')};
       transition: ${({ isFocus }) =>

--- a/stories/Input/SelectStory.tsx
+++ b/stories/Input/SelectStory.tsx
@@ -131,6 +131,14 @@ const props = {
       require: 'no',
       description: 'Removes drop icon.',
     },
+    {
+      name: 'defaultOpen',
+      type: 'boolean',
+      defaultValue: <code>false</code>,
+      possibleValue: <code>true | false</code>,
+      require: 'no',
+      description: 'Sets initial open state of Select.',
+    },
   ],
   'Select.Option': [
     {


### PR DESCRIPTION
## What Changed

1. commit https://github.com/glints-dev/glints-aries/commit/146bbd2089bf6d1531b2f4189eb3c110efe6996f resolves issue https://github.com/glints-dev/glints-aries/issues/369

   The user should be able to close the select box by:
   - Clicking on the select input again (for non-typing select)
   - Clicking on the arrow (for typing select)
   - Clicking on one of the option on the dropdown
   - Clicking anything outside the select box

2. commit https://github.com/glints-dev/glints-aries/commit/3e698a63a3a473c55c706f34987785e4efce25d1 resolves issue https://github.com/glints-dev/glints-aries/issues/357

   Add `defaultOpen` prop to allow we set the initial open state.
   The name refers to https://ant.design/components/select/