### PR TITLE
Select: Abort option select handler if there is no active option

### DIFF
--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -206,6 +206,7 @@ const Select: ISelect = (props: Props) => {
   const handleClickOnOption = React.useCallback(
     (e?: React.ChangeEvent<HTMLInputElement>) => {
       const activeElement = e ? e.target : getActiveElement();
+      if (!activeElement) return; // This is the case for the 'no results' option
       const inputValue = activeElement.textContent;
       setInputValue(inputValue);
       setIsFocus(false);


### PR DESCRIPTION
This was causing a TypeError when attempting to read the `textContent` from
`undefined` in the next line. When enter is pressed on the 'no results' option, `handleClickOnOption` is called without `e`, so `getActiveElement` will search for an element with the `.active` class. But the 'no results' option is never active, so `getActiveElement` returns `undefined` in that case.

Please read the bug report at #350 for context.