### PR TITLE
Slider: Convert to functional component

### DIFF
--- a/src/Application/Gallery/Gallery.tsx
+++ b/src/Application/Gallery/Gallery.tsx
@@ -16,7 +16,7 @@ import {
 const defaultImagesDisplayed = 8;
 
 class Gallery extends React.Component<Props, State> {
-  sliderRef: React.RefObject<Slider>;
+  sliderRef: React.RefObject<HTMLDivElement>;
 
   constructor(props: Props) {
     super(props);
@@ -61,18 +61,13 @@ class Gallery extends React.Component<Props, State> {
       });
     }
     if (this.state.visible) {
-      this.sliderRef.current.sliderContainerRef.current.focus();
+      this.sliderRef.current.focus();
     }
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
-    if (
-      !prevState.visible &&
-      this.state.visible &&
-      this.sliderRef.current &&
-      this.sliderRef.current.sliderContainerRef.current
-    ) {
-      this.sliderRef.current.sliderContainerRef.current.focus();
+    if (!prevState.visible && this.state.visible && this.sliderRef.current) {
+      this.sliderRef.current.focus();
     }
   }
 
@@ -106,7 +101,7 @@ class Gallery extends React.Component<Props, State> {
             arrowWhite
             removeDots
             afterChange={this.getCurrentIndex}
-            ref={this.sliderRef}
+            containerRef={this.sliderRef}
           >
             {React.Children.map(
               children,

--- a/src/Application/Gallery/Gallery.tsx
+++ b/src/Application/Gallery/Gallery.tsx
@@ -49,7 +49,7 @@ class Gallery extends React.Component<Props, State> {
 
   getCurrentIndex = (index: number) => {
     this.setState({
-      currentIndex: index - 1,
+      currentIndex: index,
     });
   };
 
@@ -97,7 +97,7 @@ class Gallery extends React.Component<Props, State> {
           removeAnimation
         >
           <Slider
-            initialItem={currentIndex + 1}
+            index={currentIndex}
             arrowWhite
             removeDots
             afterChange={this.getCurrentIndex}

--- a/src/Display/Slider/LeftArrow.tsx
+++ b/src/Display/Slider/LeftArrow.tsx
@@ -7,7 +7,7 @@ const LeftArrow = (props: Props) => {
 
   let arrowColor = 'black';
 
-  if (index === 1) arrowColor = '#c7c7c7';
+  if (index === 0) arrowColor = '#c7c7c7';
 
   return (
     <LeftArrowContainer

--- a/src/Display/Slider/Slider.test.tsx
+++ b/src/Display/Slider/Slider.test.tsx
@@ -1,6 +1,6 @@
 import 'jest-styled-components';
 import '@testing-library/jest-dom/extend-expect';
-import { render, wait, fireEvent } from '@testing-library/react';
+import { render, wait, fireEvent, act } from '@testing-library/react';
 import * as React from 'react';
 
 import Slider, { Props } from './Slider';
@@ -13,6 +13,13 @@ const SliderComponent = (props: SliderComponentProp) => (
     <Slider.Item>c</Slider.Item>
   </Slider>
 );
+
+const mockContainer = (width: number) => {
+  const boundingRect = { width };
+  const element = document.createElement('div');
+  element.getBoundingClientRect = () => boundingRect as DOMRect;
+  return { current: element };
+};
 
 describe('<Slider/> prop className', () => {
   const matchSnapshot = (className: string) => {
@@ -29,18 +36,19 @@ describe('<Slider/> prop className', () => {
 describe('<Slider/> prop initialItem', () => {
   const matchSnapshot = (initialItem: number) => {
     it(`should match snapshot when initialItem ${initialItem} is passed`, async () => {
-      const sliderRef: any = {
-        current: null,
-      };
-      const { rerender, asFragment } = render(
-        <Slider ref={sliderRef} initialItem={initialItem}>
+      const useRefSpy = jest
+        .spyOn(React, 'useRef')
+        .mockReturnValue(mockContainer(400));
+
+      const { asFragment } = render(
+        <Slider initialItem={initialItem}>
           <Slider.Item>a</Slider.Item>
           <Slider.Item>b</Slider.Item>
           <Slider.Item>c</Slider.Item>
         </Slider>
       );
 
-      const index = initialItem > 0 ? initialItem - 1 : 0;
+      const index = initialItem;
       const theThreeNavigationDots = document.querySelectorAll('li');
 
       // wait setState in componentDidMount to set active dot
@@ -50,28 +58,35 @@ describe('<Slider/> prop initialItem', () => {
         ).toBeTruthy();
       });
 
-      // mock getSliderContainerDOMNode to calculate translateX
-      sliderRef.current.getSliderContainerDOMNode = () => ({
-        getBoundingClientRect: () => ({
-          width: 500,
-        }),
-      });
+      expect(asFragment()).toMatchSnapshot();
 
-      // trigger componentWillReceiveProp to recalculate translateX
-      rerender(
-        <Slider ref={sliderRef} initialItem={initialItem}>
+      useRefSpy.mockRestore();
+    });
+  };
+
+  [0, 1, 2].forEach(initialItem => matchSnapshot(initialItem));
+
+  it(`should throw when initialItem is out of bounds`, async () => {
+    // Silence any errors in the console during this test
+    // Otherwise the Slider will throw print his error here, even though the
+    // test passes.
+    const originalError = console.error;
+    console.error = jest.fn();
+
+    const tryToRender = (initialItem: number) =>
+      render(
+        <Slider initialItem={initialItem}>
           <Slider.Item>a</Slider.Item>
           <Slider.Item>b</Slider.Item>
           <Slider.Item>c</Slider.Item>
         </Slider>
       );
 
-      // validate translateX from snapshot
-      expect(asFragment()).toMatchSnapshot();
-    });
-  };
+    expect(() => tryToRender(-1)).toThrow();
+    expect(() => tryToRender(3)).toThrow();
 
-  [0, 1, 2, 3].forEach(initialItem => matchSnapshot(initialItem));
+    console.error = originalError;
+  });
 });
 
 describe('<Slider/> prop fullContent', () => {
@@ -126,7 +141,7 @@ describe('<Slider/> prop autoplay', () => {
     expect(asFragment()).toMatchSnapshot();
 
     // validate autoplay
-    jest.advanceTimersByTime(6000);
+    act(() => jest.advanceTimersByTime(6000));
     expect(theThreeNavigationDots[1].classList.contains('active')).toBeTruthy();
     expect(asFragment()).toMatchSnapshot();
   });
@@ -134,7 +149,7 @@ describe('<Slider/> prop autoplay', () => {
   it(`should go to the first slide after 6000ms when autoplay is truthy and the current slide is the last slide`, () => {
     jest.useFakeTimers();
     const { asFragment } = render(
-      <SliderComponent autoplay={true} initialItem={3} />
+      <SliderComponent autoplay={true} initialItem={2} />
     );
     const theThreeNavigationDots = document.querySelectorAll('li');
     // validate initial active slide
@@ -142,7 +157,7 @@ describe('<Slider/> prop autoplay', () => {
     expect(asFragment()).toMatchSnapshot();
 
     // validate autoplay
-    jest.advanceTimersByTime(6000);
+    act(() => jest.advanceTimersByTime(6000));
     expect(theThreeNavigationDots[0].classList.contains('active')).toBeTruthy();
     expect(asFragment()).toMatchSnapshot();
   });
@@ -156,7 +171,7 @@ describe('<Slider/> prop autoplay', () => {
     expect(asFragment()).toMatchSnapshot();
 
     // validate autoplay
-    jest.advanceTimersByTime(6000);
+    act(() => jest.advanceTimersByTime(6000));
     expect(theThreeNavigationDots[0].classList.contains('active')).toBeTruthy();
     expect(asFragment()).toMatchSnapshot();
   });
@@ -177,19 +192,16 @@ describe('<Slider/> prop afterChange', () => {
     expect(afterChange).not.toBeCalled();
     fireEvent.click(rightArrow);
     expect(afterChange).toHaveBeenCalledTimes(1);
-    expect(afterChange).toHaveBeenLastCalledWith(2);
+    expect(afterChange).toHaveBeenLastCalledWith(1);
     fireEvent.click(firstDot);
     expect(afterChange).toHaveBeenCalledTimes(2);
-    expect(afterChange).toHaveBeenLastCalledWith(1);
-    fireEvent.click(firstDot);
-    expect(afterChange).toHaveBeenCalledTimes(3);
-    expect(afterChange).toHaveBeenLastCalledWith(1);
+    expect(afterChange).toHaveBeenLastCalledWith(0);
   });
 
   test(`when active slide is the middle slide`, () => {
     const afterChange = jest.fn();
     const { queryByTestId } = render(
-      <SliderComponent afterChange={afterChange} initialItem={2} />
+      <SliderComponent afterChange={afterChange} initialItem={1} />
     );
 
     const leftArrow = queryByTestId('slider_left-arrow');
@@ -198,22 +210,19 @@ describe('<Slider/> prop afterChange', () => {
 
     fireEvent.click(leftArrow);
     expect(afterChange).toHaveBeenCalledTimes(1);
-    expect(afterChange).toHaveBeenLastCalledWith(1);
+    expect(afterChange).toHaveBeenLastCalledWith(0);
     fireEvent.click(rightArrow);
     expect(afterChange).toHaveBeenCalledTimes(2);
-    expect(afterChange).toHaveBeenLastCalledWith(2);
+    expect(afterChange).toHaveBeenLastCalledWith(1);
     fireEvent.click(firstDot);
     expect(afterChange).toHaveBeenCalledTimes(3);
-    expect(afterChange).toHaveBeenLastCalledWith(1);
-    fireEvent.click(firstDot);
-    expect(afterChange).toHaveBeenCalledTimes(4);
-    expect(afterChange).toHaveBeenLastCalledWith(1);
+    expect(afterChange).toHaveBeenLastCalledWith(0);
   });
 
   test(`when active slide is the last slide`, () => {
     const afterChange = jest.fn();
     const { queryByTestId } = render(
-      <SliderComponent afterChange={afterChange} initialItem={3} />
+      <SliderComponent afterChange={afterChange} initialItem={2} />
     );
 
     const leftArrow = queryByTestId('slider_left-arrow');
@@ -224,13 +233,11 @@ describe('<Slider/> prop afterChange', () => {
     expect(afterChange).not.toBeCalled();
     fireEvent.click(leftArrow);
     expect(afterChange).toHaveBeenCalledTimes(1);
-    expect(afterChange).toHaveBeenLastCalledWith(2);
+    expect(afterChange).toHaveBeenLastCalledWith(1);
     fireEvent.click(firstDot);
     expect(afterChange).toHaveBeenCalledTimes(2);
-    expect(afterChange).toHaveBeenLastCalledWith(1);
+    expect(afterChange).toHaveBeenLastCalledWith(0);
     fireEvent.click(firstDot);
-    expect(afterChange).toHaveBeenCalledTimes(3);
-    expect(afterChange).toHaveBeenLastCalledWith(1);
   });
 });
 
@@ -249,46 +256,56 @@ describe('<Slider/> keydown event', () => {
 });
 
 describe('<Slider/> unmount', () => {
-  it(`should removeEventListener and clearInterval`, () => {
+  it(`should removeEventListener`, () => {
     const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
-    const clearIntervalSpy = jest.spyOn(window, 'clearInterval');
-    const sliderRef: React.LegacyRef<Slider> = { current: null };
     const { unmount } = render(
-      <Slider ref={sliderRef}>
+      <Slider>
         <Slider.Item>a</Slider.Item>
         <Slider.Item>b</Slider.Item>
         <Slider.Item>c</Slider.Item>
       </Slider>
     );
-    const setSize = sliderRef.current.setSize;
-    const interval = sliderRef.current.interval;
     unmount();
-    expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', setSize);
-    expect(clearIntervalSpy).toHaveBeenLastCalledWith(interval);
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'resize',
+      expect.any(Function)
+    );
+  });
+
+  it(`should clear the autoplay Interval`, () => {
+    const clearIntervalSpy = jest.spyOn(window, 'clearInterval');
+    const { unmount } = render(
+      <Slider autoplay={true}>
+        <Slider.Item>a</Slider.Item>
+        <Slider.Item>b</Slider.Item>
+        <Slider.Item>c</Slider.Item>
+      </Slider>
+    );
+    unmount();
+    expect(clearIntervalSpy).toHaveBeenCalled();
   });
 });
 
-describe('<Slider/> setSize', () => {
-  test(`setSize should be called when resize event is triggered`, () => {
-    const sliderRef: any = {
-      current: null,
-    };
+describe('<Slider/> resizing', () => {
+  it(`should update the translateX value on window resize`, async () => {
+    const useRefSpy = jest
+      .spyOn(React, 'useRef')
+      .mockReturnValue(mockContainer(500));
+
     const { asFragment } = render(
-      <Slider ref={sliderRef} initialItem={2}>
+      <Slider initialItem={1}>
         <Slider.Item>a</Slider.Item>
         <Slider.Item>b</Slider.Item>
         <Slider.Item>c</Slider.Item>
       </Slider>
     );
+    expect(asFragment()).toMatchSnapshot();
 
-    sliderRef.current.getSliderContainerDOMNode = () => ({
-      getBoundingClientRect: () => ({
-        width: 1000,
-      }),
-    });
-
+    useRefSpy.mockReturnValue(mockContainer(400));
     fireEvent(window, new Event('resize'));
     expect(asFragment()).toMatchSnapshot();
+
+    useRefSpy.mockRestore();
   });
 });
 

--- a/src/Display/Slider/Slider.tsx
+++ b/src/Display/Slider/Slider.tsx
@@ -45,32 +45,37 @@ const Slider = ({
 
   const [index, setIndex] = React.useState<number>(initialItem || 0);
 
+  const setSlide = React.useCallback(
+    (index: number, shouldLoop = false) => {
+      setIndex(currentIndex => {
+        if (index < 0) {
+          index = 0;
+        }
+        if (index >= childrenCount) {
+          index = shouldLoop ? 0 : childrenCount - 1;
+        }
+        if (afterChange !== undefined && currentIndex !== index) {
+          afterChange(index);
+        }
+        return index;
+      });
+    },
+    [childrenCount, afterChange]
+  );
+
   const previousSlide = () => {
-    if (index > 0) {
-      setIndex(index - 1);
-    }
+    setSlide(index - 1);
   };
 
   const nextSlide = React.useCallback(
     (loop = false) => {
-      setIndex(index =>
-        index >= childrenCount - 1 ? (loop ? 0 : index) : index + 1
-      );
+      setSlide(index + 1, loop);
     },
-    [childrenCount]
+    [index, setSlide]
   );
 
-  React.useEffect(
-    function callAfterChange() {
-      if (afterChange !== undefined) {
-        afterChange(index);
-      }
-    },
-    [afterChange, index]
-  );
-
-  const handleDotClick = (idx: number) => {
-    setIndex(idx);
+  const handleDotClick = (index: number) => {
+    setSlide(index);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/src/Display/Slider/Slider.tsx
+++ b/src/Display/Slider/Slider.tsx
@@ -28,9 +28,11 @@ const Slider = ({
   fullContent,
   arrowWhite,
   removeDots,
+  containerRef,
 }: Props) => {
   const interval = React.useRef<ReturnType<typeof setTimeout>>();
-  const sliderContainerRef = React.useRef<HTMLDivElement>();
+  const privateContainerRef = React.useRef<HTMLDivElement>();
+  const sliderContainerRef = containerRef || privateContainerRef;
 
   const childrenCount = React.Children.toArray(children).filter(
     child => !isNil(child)
@@ -178,6 +180,7 @@ export interface Props {
   removeDots?: boolean;
   afterChange?: Function;
   autoplay?: boolean;
+  containerRef?: React.RefObject<HTMLDivElement>;
 }
 
 export default Slider;

--- a/src/Display/Slider/Slider.tsx
+++ b/src/Display/Slider/Slider.tsx
@@ -24,6 +24,7 @@ const Slider = ({
   children,
   autoplay,
   initialItem,
+  index: controlledIndex,
   className,
   fullContent,
   arrowWhite,
@@ -45,11 +46,13 @@ const Slider = ({
     );
   }
 
-  const [index, setIndex] = React.useState<number>(initialItem || 0);
+  const [internalIndex, setInternalIndex] = React.useState<number>(
+    initialItem || 0
+  );
 
   const setSlide = React.useCallback(
     (index: number, shouldLoop = false) => {
-      setIndex(currentIndex => {
+      setInternalIndex(currentIndex => {
         if (index < 0) {
           index = 0;
         }
@@ -66,14 +69,14 @@ const Slider = ({
   );
 
   const previousSlide = () => {
-    setSlide(index - 1);
+    setSlide(internalIndex - 1);
   };
 
   const nextSlide = React.useCallback(
     (loop = false) => {
-      setSlide(index + 1, loop);
+      setSlide(internalIndex + 1, loop);
     },
-    [index, setSlide]
+    [internalIndex, setSlide]
   );
 
   const handleDotClick = (index: number) => {
@@ -111,6 +114,8 @@ const Slider = ({
     },
     [forceUpdate]
   );
+
+  const index = controlledIndex | internalIndex;
 
   const sliderContainerElement = ReactDOM.findDOMNode(
     sliderContainerRef.current
@@ -175,6 +180,7 @@ export interface Props {
   children: React.ReactNode;
   className?: string;
   initialItem?: number;
+  index?: number;
   fullContent?: boolean;
   arrowWhite?: boolean;
   removeDots?: boolean;

--- a/src/Display/Slider/Slider.tsx
+++ b/src/Display/Slider/Slider.tsx
@@ -32,16 +32,21 @@ const Slider = ({
   const interval = React.useRef<ReturnType<typeof setTimeout>>();
   const sliderContainerRef = React.useRef<HTMLDivElement>();
 
-  // NOTE: The slider is one-indexed. E.g. for three pages, the indices of the
-  // are 1, 2 and 3.
-  const [index, setIndex] = React.useState<number>(initialItem || 1);
-
   const childrenCount = React.Children.toArray(children).filter(
     child => !isNil(child)
   ).length;
 
+  if (initialItem && (initialItem < 0 || initialItem >= childrenCount)) {
+    throw new Error(
+      `initialItem ${initialItem} is out of bounds (min 0, max ${childrenCount -
+        1})`
+    );
+  }
+
+  const [index, setIndex] = React.useState<number>(initialItem || 0);
+
   const previousSlide = () => {
-    if (index !== 1) {
+    if (index > 0) {
       setIndex(index - 1);
     }
   };
@@ -49,7 +54,7 @@ const Slider = ({
   const nextSlide = React.useCallback(
     (loop = false) => {
       setIndex(index =>
-        index === childrenCount ? (loop ? 1 : index) : index + 1
+        index >= childrenCount - 1 ? (loop ? 0 : index) : index + 1
       );
     },
     [childrenCount]
@@ -65,7 +70,7 @@ const Slider = ({
   );
 
   const handleDotClick = (idx: number) => {
-    setIndex(idx + 1);
+    setIndex(idx);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -106,7 +111,7 @@ const Slider = ({
   const windowWidth = sliderContainerElement
     ? sliderContainerElement.getBoundingClientRect().width
     : 0;
-  const translateValue = -(windowWidth * (index - 1));
+  const translateValue = -(windowWidth * index);
 
   return (
     <SliderContainer
@@ -133,7 +138,7 @@ const Slider = ({
       <RightArrow
         nextSlide={() => nextSlide(false)}
         index={index}
-        limit={childrenCount}
+        limit={childrenCount - 1}
         arrowWhite={arrowWhite}
       />
       {!removeDots && (
@@ -145,7 +150,7 @@ const Slider = ({
             return (
               // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
               <li
-                className={idx + 1 === index ? 'active' : null}
+                className={idx === index ? 'active' : null}
                 onClick={() => handleDotClick(idx)}
                 key={idx}
               ></li>

--- a/src/Display/Slider/Slider.tsx
+++ b/src/Display/Slider/Slider.tsx
@@ -46,9 +46,21 @@ const Slider = ({
     );
   }
 
+  if (
+    controlledIndex &&
+    (controlledIndex < 0 || controlledIndex >= childrenCount)
+  ) {
+    throw new Error(
+      `controlledIndex ${controlledIndex} is out of bounds (min 0, max ${childrenCount -
+        1})`
+    );
+  }
+
   const [internalIndex, setInternalIndex] = React.useState<number>(
     initialItem || 0
   );
+
+  const index = isNil(controlledIndex) ? internalIndex : controlledIndex;
 
   const setSlide = React.useCallback(
     (index: number, shouldLoop = false) => {
@@ -69,14 +81,14 @@ const Slider = ({
   );
 
   const previousSlide = () => {
-    setSlide(internalIndex - 1);
+    setSlide(index - 1);
   };
 
   const nextSlide = React.useCallback(
     (loop = false) => {
-      setSlide(internalIndex + 1, loop);
+      setSlide(index + 1, loop);
     },
-    [internalIndex, setSlide]
+    [index, setSlide]
   );
 
   const handleDotClick = (index: number) => {
@@ -114,8 +126,6 @@ const Slider = ({
     },
     [forceUpdate]
   );
-
-  const index = controlledIndex | internalIndex;
 
   const sliderContainerElement = ReactDOM.findDOMNode(
     sliderContainerRef.current

--- a/src/Display/Slider/Slider.tsx
+++ b/src/Display/Slider/Slider.tsx
@@ -10,6 +10,15 @@ import LeftArrow from './LeftArrow';
 import RightArrow from './RightArrow';
 import SliderItem from './SliderItem';
 
+/**
+ * Custom react hook that utilizes an internal state to trigger re-renders when
+ * the exported state update function is called.
+ */
+const useForceUpdate = () => {
+  const [, setIndex] = React.useState(0);
+  return () => setIndex(index => index + 1);
+};
+
 const Slider = ({
   afterChange,
   children,
@@ -77,6 +86,18 @@ const Slider = ({
       };
     },
     [autoplay, nextSlide]
+  );
+
+  const forceUpdate = useForceUpdate();
+
+  React.useEffect(
+    function registerResizeHandler() {
+      window.addEventListener('resize', forceUpdate);
+      return () => {
+        window.removeEventListener('resize', forceUpdate);
+      };
+    },
+    [forceUpdate]
   );
 
   const sliderContainerElement = ReactDOM.findDOMNode(

--- a/src/Display/Slider/SliderStyle.ts
+++ b/src/Display/Slider/SliderStyle.ts
@@ -27,7 +27,7 @@ export const SliderItemWrapper = styled.div`
 export const LeftArrowContainer = styled.div<LeftArrowContainerProps>`
   ${arrow};
   left: 0;
-  cursor: ${({ index }) => (index === 1 ? 'not-allowed' : 'pointer')};
+  cursor: ${({ index }) => (index === 0 ? 'not-allowed' : 'pointer')};
 `;
 
 interface LeftArrowContainerProps {

--- a/src/Display/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/src/Display/Slider/__snapshots__/Slider.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`<Slider/> has null child should match snapshot 1`] = `
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: not-allowed;
+  cursor: pointer;
 }
 
 .c6 {
@@ -213,7 +213,7 @@ exports[`<Slider/> prop arrowWhite should match snapshot when arrowWhite false i
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: not-allowed;
+  cursor: pointer;
 }
 
 .c6 {
@@ -395,7 +395,7 @@ exports[`<Slider/> prop arrowWhite should match snapshot when arrowWhite true is
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: not-allowed;
+  cursor: pointer;
 }
 
 .c6 {
@@ -577,7 +577,7 @@ exports[`<Slider/> prop autoplay should go to next slide after 6000ms when autop
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: not-allowed;
+  cursor: pointer;
 }
 
 .c6 {
@@ -759,7 +759,7 @@ exports[`<Slider/> prop autoplay should go to next slide after 6000ms when autop
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .c6 {
@@ -1123,7 +1123,7 @@ exports[`<Slider/> prop autoplay should go to the first slide after 6000ms when 
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: not-allowed;
+  cursor: pointer;
 }
 
 .c6 {
@@ -1305,7 +1305,7 @@ exports[`<Slider/> prop autoplay should not go to next slide after 6000ms when a
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: not-allowed;
+  cursor: pointer;
 }
 
 .c6 {
@@ -1487,7 +1487,7 @@ exports[`<Slider/> prop autoplay should not go to next slide after 6000ms when a
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: not-allowed;
+  cursor: pointer;
 }
 
 .c6 {
@@ -1669,7 +1669,7 @@ exports[`<Slider/> prop className should match snapshot when class name test is 
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: not-allowed;
+  cursor: pointer;
 }
 
 .c6 {
@@ -1851,7 +1851,7 @@ exports[`<Slider/> prop className should match snapshot when class name undefine
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: not-allowed;
+  cursor: pointer;
 }
 
 .c6 {
@@ -2033,7 +2033,7 @@ exports[`<Slider/> prop fullContent should match snapshot when fullContent false
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: not-allowed;
+  cursor: pointer;
 }
 
 .c6 {
@@ -2215,7 +2215,7 @@ exports[`<Slider/> prop fullContent should match snapshot when fullContent true 
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: not-allowed;
+  cursor: pointer;
 }
 
 .c6 {
@@ -2473,7 +2473,7 @@ exports[`<Slider/> prop initialItem should match snapshot when initialItem 0 is 
   >
     <div
       class="c1 slider-wrapper"
-      style="transform: translateX(500px); transition: transform ease-out 0.45s;"
+      style="transform: translateX(0px); transition: transform ease-out 0.45s;"
     >
       <div
         class="c2 c3 slider-item"
@@ -2498,7 +2498,7 @@ exports[`<Slider/> prop initialItem should match snapshot when initialItem 0 is 
       <svg
         class="c5"
         data-testid="icon-svg"
-        fill="black"
+        fill="#c7c7c7"
         height="1em"
         viewBox="0 0 100 100"
         width="1em"
@@ -2526,7 +2526,9 @@ exports[`<Slider/> prop initialItem should match snapshot when initialItem 0 is 
       </svg>
     </div>
     <ul>
-      <li />
+      <li
+        class="active"
+      />
       <li />
       <li />
     </ul>
@@ -2653,7 +2655,7 @@ exports[`<Slider/> prop initialItem should match snapshot when initialItem 1 is 
   >
     <div
       class="c1 slider-wrapper"
-      style="transform: translateX(0px); transition: transform ease-out 0.45s;"
+      style="transform: translateX(-400px); transition: transform ease-out 0.45s;"
     >
       <div
         class="c2 c3 slider-item"
@@ -2678,7 +2680,7 @@ exports[`<Slider/> prop initialItem should match snapshot when initialItem 1 is 
       <svg
         class="c5"
         data-testid="icon-svg"
-        fill="#c7c7c7"
+        fill="black"
         height="1em"
         viewBox="0 0 100 100"
         width="1em"
@@ -2706,10 +2708,10 @@ exports[`<Slider/> prop initialItem should match snapshot when initialItem 1 is 
       </svg>
     </div>
     <ul>
+      <li />
       <li
         class="active"
       />
-      <li />
       <li />
     </ul>
   </div>
@@ -2717,188 +2719,6 @@ exports[`<Slider/> prop initialItem should match snapshot when initialItem 1 is 
 `;
 
 exports[`<Slider/> prop initialItem should match snapshot when initialItem 2 is passed 1`] = `
-<DocumentFragment>
-  .c1 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c3 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex: 0 0 auto;
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  width: 100%;
-  white-space: normal;
-}
-
-.c4 {
-  position: absolute;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  top: 50%;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  cursor: pointer;
-  font-size: 2em;
-  left: 0;
-  cursor: pointer;
-}
-
-.c6 {
-  position: absolute;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  top: 50%;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-  cursor: pointer;
-  font-size: 2em;
-  right: 0;
-  cursor: pointer;
-}
-
-.c0 {
-  position: relative;
-  white-space: nowrap;
-  overflow: hidden;
-  outline: none;
-}
-
-.c0 .c2 {
-  padding: 2em 4em;
-}
-
-.c0 ul {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  padding: 0;
-  margin: 10px 0;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c0 ul li {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  width: 12px;
-  height: 12px;
-  background: #C6C6C6;
-  border-radius: 50%;
-  box-shadow: 0 1px 1px rgba(0,0,0,0.15);
-  margin: 0 4px;
-  cursor: pointer;
-}
-
-.c0 ul li.active {
-  width: 2.5em;
-  border-radius: 1em;
-  background: #FFF240;
-}
-
-.c5 {
-  vertical-align: middle;
-}
-
-<div
-    class="c0 aries-slider"
-    tabindex="0"
-  >
-    <div
-      class="c1 slider-wrapper"
-      style="transform: translateX(-500px); transition: transform ease-out 0.45s;"
-    >
-      <div
-        class="c2 c3 slider-item"
-      >
-        a
-      </div>
-      <div
-        class="c2 c3 slider-item"
-      >
-        b
-      </div>
-      <div
-        class="c2 c3 slider-item"
-      >
-        c
-      </div>
-    </div>
-    <div
-      class="c4"
-      data-testid="slider_left-arrow"
-    >
-      <svg
-        class="c5"
-        data-testid="icon-svg"
-        fill="black"
-        height="1em"
-        viewBox="0 0 100 100"
-        width="1em"
-      >
-        <path
-          d="M81 88.4L42.6 50 81 11.8 69.2 0l-50 50 50 50z"
-        />
-      </svg>
-    </div>
-    <div
-      class="c6"
-      data-testid="slider_right-arrow"
-    >
-      <svg
-        class="c5"
-        data-testid="icon-svg"
-        fill="black"
-        height="1em"
-        viewBox="0 0 100 100"
-        width="1em"
-      >
-        <path
-          d="M19 88.4L57.4 50 19 11.8 30.8 0l50 50-50 50z"
-        />
-      </svg>
-    </div>
-    <ul>
-      <li />
-      <li
-        class="active"
-      />
-      <li />
-    </ul>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`<Slider/> prop initialItem should match snapshot when initialItem 3 is passed 1`] = `
 <DocumentFragment>
   .c1 {
   position: relative;
@@ -3017,7 +2837,7 @@ exports[`<Slider/> prop initialItem should match snapshot when initialItem 3 is 
   >
     <div
       class="c1 slider-wrapper"
-      style="transform: translateX(-1000px); transition: transform ease-out 0.45s;"
+      style="transform: translateX(-800px); transition: transform ease-out 0.45s;"
     >
       <div
         class="c2 c3 slider-item"
@@ -3123,7 +2943,7 @@ exports[`<Slider/> prop removeDots should match snapshot when removeDots false i
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: not-allowed;
+  cursor: pointer;
 }
 
 .c6 {
@@ -3305,7 +3125,7 @@ exports[`<Slider/> prop removeDots should match snapshot when removeDots true is
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: not-allowed;
+  cursor: pointer;
 }
 
 .c6 {
@@ -3437,7 +3257,7 @@ exports[`<Slider/> prop removeDots should match snapshot when removeDots true is
 </DocumentFragment>
 `;
 
-exports[`<Slider/> setSize setSize should be called when resize event is triggered 1`] = `
+exports[`<Slider/> resizing should update the translateX value on window resize 1`] = `
 <DocumentFragment>
   .c1 {
   position: relative;
@@ -3480,7 +3300,7 @@ exports[`<Slider/> setSize setSize should be called when resize event is trigger
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .c6 {
@@ -3556,7 +3376,189 @@ exports[`<Slider/> setSize setSize should be called when resize event is trigger
   >
     <div
       class="c1 slider-wrapper"
-      style="transform: translateX(-1000px); transition: transform ease-out 0.45s;"
+      style="transform: translateX(-500px); transition: transform ease-out 0.45s;"
+    >
+      <div
+        class="c2 c3 slider-item"
+      >
+        a
+      </div>
+      <div
+        class="c2 c3 slider-item"
+      >
+        b
+      </div>
+      <div
+        class="c2 c3 slider-item"
+      >
+        c
+      </div>
+    </div>
+    <div
+      class="c4"
+      data-testid="slider_left-arrow"
+    >
+      <svg
+        class="c5"
+        data-testid="icon-svg"
+        fill="black"
+        height="1em"
+        viewBox="0 0 100 100"
+        width="1em"
+      >
+        <path
+          d="M81 88.4L42.6 50 81 11.8 69.2 0l-50 50 50 50z"
+        />
+      </svg>
+    </div>
+    <div
+      class="c6"
+      data-testid="slider_right-arrow"
+    >
+      <svg
+        class="c5"
+        data-testid="icon-svg"
+        fill="black"
+        height="1em"
+        viewBox="0 0 100 100"
+        width="1em"
+      >
+        <path
+          d="M19 88.4L57.4 50 19 11.8 30.8 0l50 50-50 50z"
+        />
+      </svg>
+    </div>
+    <ul>
+      <li />
+      <li
+        class="active"
+      />
+      <li />
+    </ul>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Slider/> resizing should update the translateX value on window resize 2`] = `
+<DocumentFragment>
+  .c1 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  white-space: normal;
+}
+
+.c4 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  cursor: pointer;
+  font-size: 2em;
+  left: 0;
+  cursor: not-allowed;
+}
+
+.c6 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  cursor: pointer;
+  font-size: 2em;
+  right: 0;
+  cursor: pointer;
+}
+
+.c0 {
+  position: relative;
+  white-space: nowrap;
+  overflow: hidden;
+  outline: none;
+}
+
+.c0 .c2 {
+  padding: 2em 4em;
+}
+
+.c0 ul {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  padding: 0;
+  margin: 10px 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c0 ul li {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: 12px;
+  height: 12px;
+  background: #C6C6C6;
+  border-radius: 50%;
+  box-shadow: 0 1px 1px rgba(0,0,0,0.15);
+  margin: 0 4px;
+  cursor: pointer;
+}
+
+.c0 ul li.active {
+  width: 2.5em;
+  border-radius: 1em;
+  background: #FFF240;
+}
+
+.c5 {
+  vertical-align: middle;
+}
+
+<div
+    class="c0 aries-slider"
+    tabindex="0"
+  >
+    <div
+      class="c1 slider-wrapper"
+      style="transform: translateX(-400px); transition: transform ease-out 0.45s;"
     >
       <div
         class="c2 c3 slider-item"

--- a/src/Display/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/src/Display/Slider/__snapshots__/Slider.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`<Slider/> has null child should match snapshot 1`] = `
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .c6 {
@@ -213,7 +213,7 @@ exports[`<Slider/> prop arrowWhite should match snapshot when arrowWhite false i
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .c6 {
@@ -395,7 +395,7 @@ exports[`<Slider/> prop arrowWhite should match snapshot when arrowWhite true is
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .c6 {
@@ -577,7 +577,7 @@ exports[`<Slider/> prop autoplay should go to next slide after 6000ms when autop
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .c6 {
@@ -759,7 +759,7 @@ exports[`<Slider/> prop autoplay should go to next slide after 6000ms when autop
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: not-allowed;
+  cursor: pointer;
 }
 
 .c6 {
@@ -1123,7 +1123,7 @@ exports[`<Slider/> prop autoplay should go to the first slide after 6000ms when 
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .c6 {
@@ -1305,7 +1305,7 @@ exports[`<Slider/> prop autoplay should not go to next slide after 6000ms when a
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .c6 {
@@ -1487,7 +1487,7 @@ exports[`<Slider/> prop autoplay should not go to next slide after 6000ms when a
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .c6 {
@@ -1669,7 +1669,7 @@ exports[`<Slider/> prop className should match snapshot when class name test is 
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .c6 {
@@ -1851,7 +1851,7 @@ exports[`<Slider/> prop className should match snapshot when class name undefine
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .c6 {
@@ -2033,7 +2033,7 @@ exports[`<Slider/> prop fullContent should match snapshot when fullContent false
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .c6 {
@@ -2215,7 +2215,7 @@ exports[`<Slider/> prop fullContent should match snapshot when fullContent true 
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .c6 {
@@ -2354,7 +2354,189 @@ exports[`<Slider/> prop fullContent should match snapshot when fullContent true 
 </DocumentFragment>
 `;
 
-exports[`<Slider/> prop initialItem should match snapshot when initialItem 0 is passed 1`] = `
+exports[`<Slider/> prop index should match snapshot when index 0 is passed 1`] = `
+<DocumentFragment>
+  .c1 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  white-space: normal;
+}
+
+.c4 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  cursor: pointer;
+  font-size: 2em;
+  left: 0;
+  cursor: not-allowed;
+}
+
+.c6 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  cursor: pointer;
+  font-size: 2em;
+  right: 0;
+  cursor: pointer;
+}
+
+.c0 {
+  position: relative;
+  white-space: nowrap;
+  overflow: hidden;
+  outline: none;
+}
+
+.c0 .c2 {
+  padding: 2em 4em;
+}
+
+.c0 ul {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  padding: 0;
+  margin: 10px 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c0 ul li {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: 12px;
+  height: 12px;
+  background: #C6C6C6;
+  border-radius: 50%;
+  box-shadow: 0 1px 1px rgba(0,0,0,0.15);
+  margin: 0 4px;
+  cursor: pointer;
+}
+
+.c0 ul li.active {
+  width: 2.5em;
+  border-radius: 1em;
+  background: #FFF240;
+}
+
+.c5 {
+  vertical-align: middle;
+}
+
+<div
+    class="c0 aries-slider"
+    tabindex="0"
+  >
+    <div
+      class="c1 slider-wrapper"
+      style="transform: translateX(0px); transition: transform ease-out 0.45s;"
+    >
+      <div
+        class="c2 c3 slider-item"
+      >
+        a
+      </div>
+      <div
+        class="c2 c3 slider-item"
+      >
+        b
+      </div>
+      <div
+        class="c2 c3 slider-item"
+      >
+        c
+      </div>
+    </div>
+    <div
+      class="c4"
+      data-testid="slider_left-arrow"
+    >
+      <svg
+        class="c5"
+        data-testid="icon-svg"
+        fill="#c7c7c7"
+        height="1em"
+        viewBox="0 0 100 100"
+        width="1em"
+      >
+        <path
+          d="M81 88.4L42.6 50 81 11.8 69.2 0l-50 50 50 50z"
+        />
+      </svg>
+    </div>
+    <div
+      class="c6"
+      data-testid="slider_right-arrow"
+    >
+      <svg
+        class="c5"
+        data-testid="icon-svg"
+        fill="black"
+        height="1em"
+        viewBox="0 0 100 100"
+        width="1em"
+      >
+        <path
+          d="M19 88.4L57.4 50 19 11.8 30.8 0l50 50-50 50z"
+        />
+      </svg>
+    </div>
+    <ul>
+      <li
+        class="active"
+      />
+      <li />
+      <li />
+    </ul>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Slider/> prop index should match snapshot when index 1 is passed 1`] = `
 <DocumentFragment>
   .c1 {
   position: relative;
@@ -2398,6 +2580,370 @@ exports[`<Slider/> prop initialItem should match snapshot when initialItem 0 is 
   font-size: 2em;
   left: 0;
   cursor: pointer;
+}
+
+.c6 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  cursor: pointer;
+  font-size: 2em;
+  right: 0;
+  cursor: pointer;
+}
+
+.c0 {
+  position: relative;
+  white-space: nowrap;
+  overflow: hidden;
+  outline: none;
+}
+
+.c0 .c2 {
+  padding: 2em 4em;
+}
+
+.c0 ul {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  padding: 0;
+  margin: 10px 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c0 ul li {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: 12px;
+  height: 12px;
+  background: #C6C6C6;
+  border-radius: 50%;
+  box-shadow: 0 1px 1px rgba(0,0,0,0.15);
+  margin: 0 4px;
+  cursor: pointer;
+}
+
+.c0 ul li.active {
+  width: 2.5em;
+  border-radius: 1em;
+  background: #FFF240;
+}
+
+.c5 {
+  vertical-align: middle;
+}
+
+<div
+    class="c0 aries-slider"
+    tabindex="0"
+  >
+    <div
+      class="c1 slider-wrapper"
+      style="transform: translateX(-400px); transition: transform ease-out 0.45s;"
+    >
+      <div
+        class="c2 c3 slider-item"
+      >
+        a
+      </div>
+      <div
+        class="c2 c3 slider-item"
+      >
+        b
+      </div>
+      <div
+        class="c2 c3 slider-item"
+      >
+        c
+      </div>
+    </div>
+    <div
+      class="c4"
+      data-testid="slider_left-arrow"
+    >
+      <svg
+        class="c5"
+        data-testid="icon-svg"
+        fill="black"
+        height="1em"
+        viewBox="0 0 100 100"
+        width="1em"
+      >
+        <path
+          d="M81 88.4L42.6 50 81 11.8 69.2 0l-50 50 50 50z"
+        />
+      </svg>
+    </div>
+    <div
+      class="c6"
+      data-testid="slider_right-arrow"
+    >
+      <svg
+        class="c5"
+        data-testid="icon-svg"
+        fill="black"
+        height="1em"
+        viewBox="0 0 100 100"
+        width="1em"
+      >
+        <path
+          d="M19 88.4L57.4 50 19 11.8 30.8 0l50 50-50 50z"
+        />
+      </svg>
+    </div>
+    <ul>
+      <li />
+      <li
+        class="active"
+      />
+      <li />
+    </ul>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Slider/> prop index should match snapshot when index 2 is passed 1`] = `
+<DocumentFragment>
+  .c1 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  white-space: normal;
+}
+
+.c4 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  cursor: pointer;
+  font-size: 2em;
+  left: 0;
+  cursor: pointer;
+}
+
+.c6 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  cursor: pointer;
+  font-size: 2em;
+  right: 0;
+  cursor: not-allowed;
+}
+
+.c0 {
+  position: relative;
+  white-space: nowrap;
+  overflow: hidden;
+  outline: none;
+}
+
+.c0 .c2 {
+  padding: 2em 4em;
+}
+
+.c0 ul {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  padding: 0;
+  margin: 10px 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c0 ul li {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  width: 12px;
+  height: 12px;
+  background: #C6C6C6;
+  border-radius: 50%;
+  box-shadow: 0 1px 1px rgba(0,0,0,0.15);
+  margin: 0 4px;
+  cursor: pointer;
+}
+
+.c0 ul li.active {
+  width: 2.5em;
+  border-radius: 1em;
+  background: #FFF240;
+}
+
+.c5 {
+  vertical-align: middle;
+}
+
+<div
+    class="c0 aries-slider"
+    tabindex="0"
+  >
+    <div
+      class="c1 slider-wrapper"
+      style="transform: translateX(-800px); transition: transform ease-out 0.45s;"
+    >
+      <div
+        class="c2 c3 slider-item"
+      >
+        a
+      </div>
+      <div
+        class="c2 c3 slider-item"
+      >
+        b
+      </div>
+      <div
+        class="c2 c3 slider-item"
+      >
+        c
+      </div>
+    </div>
+    <div
+      class="c4"
+      data-testid="slider_left-arrow"
+    >
+      <svg
+        class="c5"
+        data-testid="icon-svg"
+        fill="black"
+        height="1em"
+        viewBox="0 0 100 100"
+        width="1em"
+      >
+        <path
+          d="M81 88.4L42.6 50 81 11.8 69.2 0l-50 50 50 50z"
+        />
+      </svg>
+    </div>
+    <div
+      class="c6"
+      data-testid="slider_right-arrow"
+    >
+      <svg
+        class="c5"
+        data-testid="icon-svg"
+        fill="#c7c7c7"
+        height="1em"
+        viewBox="0 0 100 100"
+        width="1em"
+      >
+        <path
+          d="M19 88.4L57.4 50 19 11.8 30.8 0l50 50-50 50z"
+        />
+      </svg>
+    </div>
+    <ul>
+      <li />
+      <li />
+      <li
+        class="active"
+      />
+    </ul>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Slider/> prop initialItem should match snapshot when initialItem 0 is passed 1`] = `
+<DocumentFragment>
+  .c1 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 100%;
+  white-space: normal;
+}
+
+.c4 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  top: 50%;
+  -webkit-transform: translateY(-50%);
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
+  cursor: pointer;
+  font-size: 2em;
+  left: 0;
+  cursor: not-allowed;
 }
 
 .c6 {
@@ -2579,7 +3125,7 @@ exports[`<Slider/> prop initialItem should match snapshot when initialItem 1 is 
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: not-allowed;
+  cursor: pointer;
 }
 
 .c6 {
@@ -2943,7 +3489,7 @@ exports[`<Slider/> prop removeDots should match snapshot when removeDots false i
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .c6 {
@@ -3125,7 +3671,7 @@ exports[`<Slider/> prop removeDots should match snapshot when removeDots true is
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: pointer;
+  cursor: not-allowed;
 }
 
 .c6 {
@@ -3300,7 +3846,7 @@ exports[`<Slider/> resizing should update the translateX value on window resize 
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: not-allowed;
+  cursor: pointer;
 }
 
 .c6 {
@@ -3482,7 +4028,7 @@ exports[`<Slider/> resizing should update the translateX value on window resize 
   cursor: pointer;
   font-size: 2em;
   left: 0;
-  cursor: not-allowed;
+  cursor: pointer;
 }
 
 .c6 {

--- a/stories/Display/SliderStory.tsx
+++ b/stories/Display/SliderStory.tsx
@@ -9,13 +9,22 @@ import ProfilePicture from '../../src/General/ProfilePicture';
 const props = {
   Slider: [
     {
+      name: 'index',
+      type: 'number',
+      defaultValue: '',
+      possibleValue: '0 to n-1 (n=number of pages',
+      require: 'no',
+      description:
+        'If set, controls the current page. If not set, Slider will control the current page internally',
+    },
+    {
       name: 'initialItem',
       type: 'number',
-      defaultValue: '1',
+      defaultValue: '',
       possibleValue: 'index of item',
       require: 'no',
       description:
-        'Sets initial item to show. Index starts from 0 until so on.',
+        'If uncontrolled, determined which image will be shown initially',
     },
     {
       name: 'fullContent',
@@ -55,7 +64,8 @@ const props = {
       defaultValue: '',
       possibleValue: 'function',
       require: 'no',
-      description: 'Gets current index of item.',
+      description:
+        'Gets called with the current Index after the slider page was changed',
     },
   ],
 };

--- a/stories/Display/SliderStory.tsx
+++ b/stories/Display/SliderStory.tsx
@@ -15,7 +15,7 @@ const props = {
       possibleValue: 'index of item',
       require: 'no',
       description:
-        'Sets initial item to show. Index starts from 1 until so on.',
+        'Sets initial item to show. Index starts from 0 until so on.',
     },
     {
       name: 'fullContent',


### PR DESCRIPTION
Due to the poor state handling and redundancies in this component, the conversion ended up being almost a complete rewrite.

Most notably I got rid of the `translateValue` state, which really is just a value that can be easily be calculated from `index`. That enabled me to remove the `screenSize` state too, which is in essence just a mostly static value that gets used in when calculating `translateValue`. Also I made the autoplay interval use the same logic as `nextSlide` which just needed an additional param to specify whether the requested page change should loop back to the first page or not when on the last page. Also makes the page indexing start from zero.

During the conversion, I noticed that the conversion broke the Gallery, which uses the Slider internally. Turns our Gallery was using `initialItem` to take full control of the Slider (not just to set the initial item). During the conversion I assumed that `initialItem` was really just to set the initial item, so the Gallery couldn't control the state anymore. That's why I've added the `index` prop to Slider, which can be used to take full control, while the `initialItem` can continue to be used for setting the initial item for the internal uncontrolled state.

DST will require one tiny migration for this: https://gitlab.glints.com/glints/glints-dst/blob/feca2b1384e806399c0cecb0045cdd7ee20f915c/app/components/Testimonial/TestimonialSlider/TestimonialSlider.tsx#L71 uses the `initialItem`. After upgrading Aries, the prop can just be removed to make the component fully uncontrolled.

This PR adapts the Gallery, so it fixes #379.