### PR TITLE
Typography: Fix UI mismatches in the current typography component

### DIFF
--- a/src/General/Typography/Paragraph.test.tsx
+++ b/src/General/Typography/Paragraph.test.tsx
@@ -54,13 +54,13 @@ it('display the ellipsis', () => {
   `);
 });
 
-describe('displays the correct line height, when lineHeight value is set to true', () => {
+describe('displays the correct line height, when shouldSetLineHeight value is set to true', () => {
   const variants = Object.values(PARAGRAPH_VARIANTS) as paragraphType[];
 
   const matchSnapshotWithTag = (variant: paragraphType) => {
-    test(`tag with lineHeight as true ${variant}`, () => {
+    test(`tag with shouldSetLineHeight as true ${variant}`, () => {
       const { asFragment } = render(
-        <Paragraph variant={variant} lineHeight={true}>
+        <Paragraph variant={variant} shouldSetLineHeight={true}>
           {paragraphText}
         </Paragraph>
       );

--- a/src/General/Typography/Paragraph.test.tsx
+++ b/src/General/Typography/Paragraph.test.tsx
@@ -58,7 +58,7 @@ describe('displays the correct line height, when lineHeight value is set to true
   const variants = Object.values(PARAGRAPH_VARIANTS) as paragraphType[];
 
   const matchSnapshotWithTag = (variant: paragraphType) => {
-    test(`tag with upperCase as true ${variant}`, () => {
+    test(`tag with lineHeight as true ${variant}`, () => {
       const { asFragment } = render(
         <Paragraph variant={variant} lineHeight={true}>
           {paragraphText}

--- a/src/General/Typography/Paragraph.test.tsx
+++ b/src/General/Typography/Paragraph.test.tsx
@@ -3,6 +3,7 @@ import Paragraph from './Paragraph';
 import { PrimaryColor } from '../../Utils/Colors';
 
 import '@testing-library/jest-dom/extend-expect';
+import 'jest-styled-components';
 import { render } from '@testing-library/react';
 
 import {
@@ -51,4 +52,21 @@ it('display the ellipsis', () => {
       white-space: nowrap;
       text-overflow: ellipsis;
   `);
+});
+
+describe('displays the correct line height, when lineHeight value is set to true', () => {
+  const variants = Object.values(PARAGRAPH_VARIANTS) as paragraphType[];
+
+  const matchSnapshotWithTag = (variant: paragraphType) => {
+    test(`tag with upperCase as true ${variant}`, () => {
+      const { asFragment } = render(
+        <Paragraph variant={variant} lineHeight={true}>
+          {paragraphText}
+        </Paragraph>
+      );
+      expect(asFragment()).toMatchSnapshot();
+    });
+  };
+
+  variants.forEach(variant => matchSnapshotWithTag(variant));
 });

--- a/src/General/Typography/Paragraph.tsx
+++ b/src/General/Typography/Paragraph.tsx
@@ -15,6 +15,7 @@ const Paragraph: React.FunctionComponent<Props> = props => {
     bold,
     color = SecondaryColor.black,
     ellipsis,
+    lineHeight = false,
     ...restProps
   } = props;
 
@@ -25,6 +26,7 @@ const Paragraph: React.FunctionComponent<Props> = props => {
       bold={bold}
       color={color}
       ellipsis={ellipsis}
+      lineHeight={lineHeight}
       {...restProps}
     >
       {children}
@@ -35,6 +37,7 @@ const Paragraph: React.FunctionComponent<Props> = props => {
 interface Props extends ParagraphProps {
   className?: string;
   children: React.ReactNode;
+  lineHeight?: boolean;
 }
 
 export default Paragraph;

--- a/src/General/Typography/Paragraph.tsx
+++ b/src/General/Typography/Paragraph.tsx
@@ -15,7 +15,7 @@ const Paragraph: React.FunctionComponent<Props> = props => {
     bold,
     color = SecondaryColor.black,
     ellipsis,
-    lineHeight = false,
+    shouldSetLineHeight = false,
     ...restProps
   } = props;
 
@@ -26,7 +26,7 @@ const Paragraph: React.FunctionComponent<Props> = props => {
       bold={bold}
       color={color}
       ellipsis={ellipsis}
-      lineHeight={lineHeight}
+      shouldSetLineHeight={shouldSetLineHeight}
       {...restProps}
     >
       {children}
@@ -37,7 +37,7 @@ const Paragraph: React.FunctionComponent<Props> = props => {
 interface Props extends ParagraphProps {
   className?: string;
   children: React.ReactNode;
-  lineHeight?: boolean;
+  shouldSetLineHeight?: boolean;
 }
 
 export default Paragraph;

--- a/src/General/Typography/ParagraphStyles.ts
+++ b/src/General/Typography/ParagraphStyles.ts
@@ -14,6 +14,13 @@ export const PARAGRAPH_FONT_SIZES = {
   [PARAGRAPH_VARIANTS.smallest]: 12,
 };
 
+export const PARAGRAPH_LINE_HEIGHTS = {
+  [PARAGRAPH_VARIANTS.subtitle]: 30.6,
+  [PARAGRAPH_VARIANTS.regular]: 27.2,
+  [PARAGRAPH_VARIANTS.caption]: 23.8,
+  [PARAGRAPH_VARIANTS.smallest]: 20.4,
+};
+
 export type paragraphType = 'subtitle' | 'regular' | 'caption' | 'smallest';
 
 export interface ParagraphProps {
@@ -21,15 +28,17 @@ export interface ParagraphProps {
   color?: string;
   ellipsis?: boolean;
   variant?: paragraphType;
+  lineHeight: boolean;
 }
 
 export const Paragraph = styled.p<ParagraphProps>`
   margin: 0;
   font-size: ${props => PARAGRAPH_FONT_SIZES[props.variant]}px;
+  line-height: ${props =>
+    props.lineHeight ? `${PARAGRAPH_LINE_HEIGHTS[props.variant]}px` : 'normal'};
   font-weight: ${props => (props.bold ? 'bold' : 'normal')};
   font-stretch: normal;
   font-style: normal;
-  line-height: normal;
   letter-spacing: normal;
   color: ${props => props.color};
 

--- a/src/General/Typography/ParagraphStyles.ts
+++ b/src/General/Typography/ParagraphStyles.ts
@@ -28,14 +28,16 @@ export interface ParagraphProps {
   color?: string;
   ellipsis?: boolean;
   variant?: paragraphType;
-  lineHeight?: boolean;
+  shouldSetLineHeight?: boolean;
 }
 
 export const Paragraph = styled.p<ParagraphProps>`
   margin: 0;
   font-size: ${props => PARAGRAPH_FONT_SIZES[props.variant]}px;
   line-height: ${props =>
-    props.lineHeight ? `${PARAGRAPH_LINE_HEIGHTS[props.variant]}px` : 'normal'};
+    props.shouldSetLineHeight
+      ? `${PARAGRAPH_LINE_HEIGHTS[props.variant]}px`
+      : 'normal'};
   font-weight: ${props => (props.bold ? 'bold' : 'normal')};
   font-stretch: normal;
   font-style: normal;

--- a/src/General/Typography/ParagraphStyles.ts
+++ b/src/General/Typography/ParagraphStyles.ts
@@ -28,7 +28,7 @@ export interface ParagraphProps {
   color?: string;
   ellipsis?: boolean;
   variant?: paragraphType;
-  lineHeight: boolean;
+  lineHeight?: boolean;
 }
 
 export const Paragraph = styled.p<ParagraphProps>`

--- a/src/General/Typography/Title.test.tsx
+++ b/src/General/Typography/Title.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import 'jest-styled-components';
 import '@testing-library/jest-dom/extend-expect';
 import { render } from '@testing-library/react';
 
@@ -41,4 +42,21 @@ it('display the ellipsis', () => {
       white-space: nowrap; 
       text-overflow: ellipsis;
     `);
+});
+
+describe('displays the correct text case, when upperCase value is set to true', () => {
+  const tags = Object.values(TITLE_VARIANTS) as tagType[];
+
+  const matchSnapshotWithTag = (tag: tagType) => {
+    test(`tag with upperCase as true ${tag}`, () => {
+      const { asFragment } = render(
+        <Title tag={tag} upperCase={true}>
+          {titleText}
+        </Title>
+      );
+      expect(asFragment()).toMatchSnapshot();
+    });
+  };
+
+  tags.forEach(tag => matchSnapshotWithTag(tag));
 });

--- a/src/General/Typography/Title.test.tsx
+++ b/src/General/Typography/Title.test.tsx
@@ -44,13 +44,13 @@ it('display the ellipsis', () => {
     `);
 });
 
-describe('displays the correct text case, when upperCase value is set to true', () => {
+describe('displays the correct text case, when uppercase value is set to true', () => {
   const tags = Object.values(TITLE_VARIANTS) as tagType[];
 
   const matchSnapshotWithTag = (tag: tagType) => {
-    test(`tag with upperCase as true ${tag}`, () => {
+    test(`tag with uppercase as true ${tag}`, () => {
       const { asFragment } = render(
-        <Title tag={tag} upperCase={true}>
+        <Title tag={tag} uppercase={true}>
           {titleText}
         </Title>
       );

--- a/src/General/Typography/Title.tsx
+++ b/src/General/Typography/Title.tsx
@@ -11,7 +11,7 @@ const Title: React.FunctionComponent<Props> = (props: Props) => {
     color = SecondaryColor.black,
     ellipsis,
     tag = 'h1',
-    upperCase = false,
+    uppercase = false,
     ...restProps
   } = props;
 
@@ -21,7 +21,7 @@ const Title: React.FunctionComponent<Props> = (props: Props) => {
       as={tag}
       color={color}
       ellipsis={ellipsis}
-      upperCase={upperCase}
+      uppercase={uppercase}
       {...restProps}
     >
       {children}
@@ -37,7 +37,7 @@ interface Props {
   color?: string;
   ellipsis?: boolean;
   tag?: tagType;
-  upperCase?: boolean;
+  uppercase?: boolean;
 }
 
 export default Title;

--- a/src/General/Typography/Title.tsx
+++ b/src/General/Typography/Title.tsx
@@ -11,6 +11,7 @@ const Title: React.FunctionComponent<Props> = (props: Props) => {
     color = SecondaryColor.black,
     ellipsis,
     tag = 'h1',
+    upperCase = false,
     ...restProps
   } = props;
 
@@ -20,6 +21,7 @@ const Title: React.FunctionComponent<Props> = (props: Props) => {
       as={tag}
       color={color}
       ellipsis={ellipsis}
+      upperCase={upperCase}
       {...restProps}
     >
       {children}
@@ -35,6 +37,7 @@ interface Props {
   color?: string;
   ellipsis?: boolean;
   tag?: tagType;
+  upperCase?: boolean;
 }
 
 export default Title;

--- a/src/General/Typography/TitleStyles.ts
+++ b/src/General/Typography/TitleStyles.ts
@@ -24,7 +24,7 @@ interface TitleProps {
   as: tagType;
   color?: string;
   ellipsis?: boolean;
-  upperCase?: boolean;
+  uppercase?: boolean;
 }
 
 export const Title = styled.h1<TitleProps>`
@@ -35,7 +35,7 @@ export const Title = styled.h1<TitleProps>`
   letter-spacing: normal;
   color: ${props => props.color};
   text-transform: ${props => {
-    if (props.upperCase) return 'uppercase';
+    if (props.uppercase) return 'uppercase';
   }};
   ${props => {
     switch (props.as) {
@@ -43,17 +43,17 @@ export const Title = styled.h1<TitleProps>`
         return `
         font-size: ${TITLE_FONT_SIZES.h1}px;
         font-weight: 900;
-        line-height: ${props.upperCase ? '60px' : '70px'};
+        line-height: ${props.uppercase ? '60px' : '70px'};
       `;
       case TITLE_VARIANTS.h2:
         return `
         font-size: ${TITLE_FONT_SIZES.h2}px;
-        line-height: line-height: ${props.upperCase ? '43.2px' : '50.4px'};
+        line-height: line-height: ${props.uppercase ? '43.2px' : '50.4px'};
       `;
       case TITLE_VARIANTS.h3:
         return `
         font-size: ${TITLE_FONT_SIZES.h3}px;
-        line-height: line-height: ${props.upperCase ? '36px' : '42px'};
+        line-height: line-height: ${props.uppercase ? '36px' : '42px'};
       `;
       case TITLE_VARIANTS.h4:
         return `
@@ -74,7 +74,7 @@ export const Title = styled.h1<TitleProps>`
         return `
         font-size: ${TITLE_FONT_SIZES.h1}px;
         font-weight: 900;
-        line-height: ${props.upperCase ? '60px' : '70px'};
+        line-height: ${props.uppercase ? '60px' : '70px'};
     `;
     }
   }};

--- a/src/General/Typography/TitleStyles.ts
+++ b/src/General/Typography/TitleStyles.ts
@@ -24,6 +24,7 @@ interface TitleProps {
   as: tagType;
   color?: string;
   ellipsis?: boolean;
+  upperCase?: boolean;
 }
 
 export const Title = styled.h1<TitleProps>`
@@ -33,45 +34,47 @@ export const Title = styled.h1<TitleProps>`
   font-style: normal;
   letter-spacing: normal;
   color: ${props => props.color};
-
+  text-transform: ${props => {
+    if (props.upperCase) return 'uppercase';
+  }};
   ${props => {
     switch (props.as) {
       case TITLE_VARIANTS.h1:
         return `
         font-size: ${TITLE_FONT_SIZES.h1}px;
         font-weight: 900;
-        line-height: 1.2em;
+        line-height: ${props.upperCase ? '60px' : '70px'};
       `;
       case TITLE_VARIANTS.h2:
         return `
         font-size: ${TITLE_FONT_SIZES.h2}px;
-        line-height: 1.2em;
+        line-height: line-height: ${props.upperCase ? '43.2px' : '50.4px'};
       `;
       case TITLE_VARIANTS.h3:
         return `
         font-size: ${TITLE_FONT_SIZES.h3}px;
-        line-height: 1.4em;
+        line-height: line-height: ${props.upperCase ? '36px' : '42px'};
       `;
       case TITLE_VARIANTS.h4:
         return `
         font-size: ${TITLE_FONT_SIZES.h4}px;
-        line-height: 1.4em;
+        line-height: 36.4px;
       `;
       case TITLE_VARIANTS.h5:
         return `
         font-size: ${TITLE_FONT_SIZES.h5}px;
-        line-height: 1.4em;
+        line-height: 28px;
       `;
       case TITLE_VARIANTS.h6:
         return `
         font-size: ${TITLE_FONT_SIZES.h6}px;
-        line-height: 1.4em;
+        line-height: 25.2px;
       `;
       default:
         return `
         font-size: ${TITLE_FONT_SIZES.h1}px;
         font-weight: 900;
-        line-height: 1.2em;
+        line-height: ${props.upperCase ? '60px' : '70px'};
     `;
     }
   }};

--- a/src/General/Typography/__snapshots__/Paragraph.test.tsx.snap
+++ b/src/General/Typography/__snapshots__/Paragraph.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`displays the correct line height, when lineHeight value is set to true tag with upperCase as true caption 1`] = `
+exports[`displays the correct line height, when lineHeight value is set to true tag with lineHeight as true caption 1`] = `
 <DocumentFragment>
   .c0 {
   margin: 0;
@@ -25,7 +25,7 @@ exports[`displays the correct line height, when lineHeight value is set to true 
 </DocumentFragment>
 `;
 
-exports[`displays the correct line height, when lineHeight value is set to true tag with upperCase as true regular 1`] = `
+exports[`displays the correct line height, when lineHeight value is set to true tag with lineHeight as true regular 1`] = `
 <DocumentFragment>
   .c0 {
   margin: 0;
@@ -50,7 +50,7 @@ exports[`displays the correct line height, when lineHeight value is set to true 
 </DocumentFragment>
 `;
 
-exports[`displays the correct line height, when lineHeight value is set to true tag with upperCase as true smallest 1`] = `
+exports[`displays the correct line height, when lineHeight value is set to true tag with lineHeight as true smallest 1`] = `
 <DocumentFragment>
   .c0 {
   margin: 0;
@@ -75,7 +75,7 @@ exports[`displays the correct line height, when lineHeight value is set to true 
 </DocumentFragment>
 `;
 
-exports[`displays the correct line height, when lineHeight value is set to true tag with upperCase as true subtitle 1`] = `
+exports[`displays the correct line height, when lineHeight value is set to true tag with lineHeight as true subtitle 1`] = `
 <DocumentFragment>
   .c0 {
   margin: 0;

--- a/src/General/Typography/__snapshots__/Paragraph.test.tsx.snap
+++ b/src/General/Typography/__snapshots__/Paragraph.test.tsx.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`displays the correct line height, when lineHeight value is set to true tag with upperCase as true caption 1`] = `
+<DocumentFragment>
+  .c0 {
+  margin: 0;
+  font-size: 14px;
+  line-height: 23.8px;
+  font-weight: normal;
+  font-stretch: normal;
+  font-style: normal;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  color: #000000;
+}
+
+<p
+    class="c0 aries-typography-paragraph"
+    color="#000000"
+  >
+    As the first sign in the zodiac, the presence of Aries always marks the beginning of something energetic and turbulent. They are continuously looking for dynamic, speed and competition, always being the first in everything - from work to social gatherings.
+  </p>
+</DocumentFragment>
+`;
+
+exports[`displays the correct line height, when lineHeight value is set to true tag with upperCase as true regular 1`] = `
+<DocumentFragment>
+  .c0 {
+  margin: 0;
+  font-size: 16px;
+  line-height: 27.2px;
+  font-weight: normal;
+  font-stretch: normal;
+  font-style: normal;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  color: #000000;
+}
+
+<p
+    class="c0 aries-typography-paragraph"
+    color="#000000"
+  >
+    As the first sign in the zodiac, the presence of Aries always marks the beginning of something energetic and turbulent. They are continuously looking for dynamic, speed and competition, always being the first in everything - from work to social gatherings.
+  </p>
+</DocumentFragment>
+`;
+
+exports[`displays the correct line height, when lineHeight value is set to true tag with upperCase as true smallest 1`] = `
+<DocumentFragment>
+  .c0 {
+  margin: 0;
+  font-size: 12px;
+  line-height: 20.4px;
+  font-weight: normal;
+  font-stretch: normal;
+  font-style: normal;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  color: #000000;
+}
+
+<p
+    class="c0 aries-typography-paragraph"
+    color="#000000"
+  >
+    As the first sign in the zodiac, the presence of Aries always marks the beginning of something energetic and turbulent. They are continuously looking for dynamic, speed and competition, always being the first in everything - from work to social gatherings.
+  </p>
+</DocumentFragment>
+`;
+
+exports[`displays the correct line height, when lineHeight value is set to true tag with upperCase as true subtitle 1`] = `
+<DocumentFragment>
+  .c0 {
+  margin: 0;
+  font-size: 18px;
+  line-height: 30.6px;
+  font-weight: normal;
+  font-stretch: normal;
+  font-style: normal;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  color: #000000;
+}
+
+<p
+    class="c0 aries-typography-paragraph"
+    color="#000000"
+  >
+    As the first sign in the zodiac, the presence of Aries always marks the beginning of something energetic and turbulent. They are continuously looking for dynamic, speed and competition, always being the first in everything - from work to social gatherings.
+  </p>
+</DocumentFragment>
+`;

--- a/src/General/Typography/__snapshots__/Paragraph.test.tsx.snap
+++ b/src/General/Typography/__snapshots__/Paragraph.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`displays the correct line height, when lineHeight value is set to true tag with lineHeight as true caption 1`] = `
+exports[`displays the correct line height, when shouldSetLineHeight value is set to true tag with shouldSetLineHeight as true caption 1`] = `
 <DocumentFragment>
   .c0 {
   margin: 0;
@@ -25,7 +25,7 @@ exports[`displays the correct line height, when lineHeight value is set to true 
 </DocumentFragment>
 `;
 
-exports[`displays the correct line height, when lineHeight value is set to true tag with lineHeight as true regular 1`] = `
+exports[`displays the correct line height, when shouldSetLineHeight value is set to true tag with shouldSetLineHeight as true regular 1`] = `
 <DocumentFragment>
   .c0 {
   margin: 0;
@@ -50,7 +50,7 @@ exports[`displays the correct line height, when lineHeight value is set to true 
 </DocumentFragment>
 `;
 
-exports[`displays the correct line height, when lineHeight value is set to true tag with lineHeight as true smallest 1`] = `
+exports[`displays the correct line height, when shouldSetLineHeight value is set to true tag with shouldSetLineHeight as true smallest 1`] = `
 <DocumentFragment>
   .c0 {
   margin: 0;
@@ -75,7 +75,7 @@ exports[`displays the correct line height, when lineHeight value is set to true 
 </DocumentFragment>
 `;
 
-exports[`displays the correct line height, when lineHeight value is set to true tag with lineHeight as true subtitle 1`] = `
+exports[`displays the correct line height, when shouldSetLineHeight value is set to true tag with shouldSetLineHeight as true subtitle 1`] = `
 <DocumentFragment>
   .c0 {
   margin: 0;

--- a/src/General/Typography/__snapshots__/Title.test.tsx.snap
+++ b/src/General/Typography/__snapshots__/Title.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`displays the correct text case, when upperCase value is set to true tag with upperCase as true h1 1`] = `
+exports[`displays the correct text case, when uppercase value is set to true tag with uppercase as true h1 1`] = `
 <DocumentFragment>
   .c0 {
   margin: 0;
@@ -27,7 +27,7 @@ exports[`displays the correct text case, when upperCase value is set to true tag
 </DocumentFragment>
 `;
 
-exports[`displays the correct text case, when upperCase value is set to true tag with upperCase as true h2 1`] = `
+exports[`displays the correct text case, when uppercase value is set to true tag with uppercase as true h2 1`] = `
 <DocumentFragment>
   .c0 {
   margin: 0;
@@ -53,7 +53,7 @@ exports[`displays the correct text case, when upperCase value is set to true tag
 </DocumentFragment>
 `;
 
-exports[`displays the correct text case, when upperCase value is set to true tag with upperCase as true h3 1`] = `
+exports[`displays the correct text case, when uppercase value is set to true tag with uppercase as true h3 1`] = `
 <DocumentFragment>
   .c0 {
   margin: 0;
@@ -79,7 +79,7 @@ exports[`displays the correct text case, when upperCase value is set to true tag
 </DocumentFragment>
 `;
 
-exports[`displays the correct text case, when upperCase value is set to true tag with upperCase as true h4 1`] = `
+exports[`displays the correct text case, when uppercase value is set to true tag with uppercase as true h4 1`] = `
 <DocumentFragment>
   .c0 {
   margin: 0;
@@ -105,7 +105,7 @@ exports[`displays the correct text case, when upperCase value is set to true tag
 </DocumentFragment>
 `;
 
-exports[`displays the correct text case, when upperCase value is set to true tag with upperCase as true h5 1`] = `
+exports[`displays the correct text case, when uppercase value is set to true tag with uppercase as true h5 1`] = `
 <DocumentFragment>
   .c0 {
   margin: 0;
@@ -131,7 +131,7 @@ exports[`displays the correct text case, when upperCase value is set to true tag
 </DocumentFragment>
 `;
 
-exports[`displays the correct text case, when upperCase value is set to true tag with upperCase as true h6 1`] = `
+exports[`displays the correct text case, when uppercase value is set to true tag with uppercase as true h6 1`] = `
 <DocumentFragment>
   .c0 {
   margin: 0;

--- a/src/General/Typography/__snapshots__/Title.test.tsx.snap
+++ b/src/General/Typography/__snapshots__/Title.test.tsx.snap
@@ -1,0 +1,158 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`displays the correct text case, when upperCase value is set to true tag with upperCase as true h1 1`] = `
+<DocumentFragment>
+  .c0 {
+  margin: 0;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: normal;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  color: #000000;
+  text-transform: uppercase;
+  font-size: 50px;
+  font-weight: 900;
+  line-height: 60px;
+}
+
+<h1
+    class="c0 aries-typography-title"
+    color="#000000"
+  >
+    Glints Aries
+  </h1>
+</DocumentFragment>
+`;
+
+exports[`displays the correct text case, when upperCase value is set to true tag with upperCase as true h2 1`] = `
+<DocumentFragment>
+  .c0 {
+  margin: 0;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: normal;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  color: #000000;
+  text-transform: uppercase;
+  font-size: 36px;
+  line-height: line-height:43.2px;
+}
+
+<h2
+    class="c0 aries-typography-title"
+    color="#000000"
+  >
+    Glints Aries
+  </h2>
+</DocumentFragment>
+`;
+
+exports[`displays the correct text case, when upperCase value is set to true tag with upperCase as true h3 1`] = `
+<DocumentFragment>
+  .c0 {
+  margin: 0;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: normal;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  color: #000000;
+  text-transform: uppercase;
+  font-size: 30px;
+  line-height: line-height:36px;
+}
+
+<h3
+    class="c0 aries-typography-title"
+    color="#000000"
+  >
+    Glints Aries
+  </h3>
+</DocumentFragment>
+`;
+
+exports[`displays the correct text case, when upperCase value is set to true tag with upperCase as true h4 1`] = `
+<DocumentFragment>
+  .c0 {
+  margin: 0;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: normal;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  color: #000000;
+  text-transform: uppercase;
+  font-size: 26px;
+  line-height: 36.4px;
+}
+
+<h4
+    class="c0 aries-typography-title"
+    color="#000000"
+  >
+    Glints Aries
+  </h4>
+</DocumentFragment>
+`;
+
+exports[`displays the correct text case, when upperCase value is set to true tag with upperCase as true h5 1`] = `
+<DocumentFragment>
+  .c0 {
+  margin: 0;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: normal;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  color: #000000;
+  text-transform: uppercase;
+  font-size: 22px;
+  line-height: 28px;
+}
+
+<h5
+    class="c0 aries-typography-title"
+    color="#000000"
+  >
+    Glints Aries
+  </h5>
+</DocumentFragment>
+`;
+
+exports[`displays the correct text case, when upperCase value is set to true tag with upperCase as true h6 1`] = `
+<DocumentFragment>
+  .c0 {
+  margin: 0;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: normal;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  color: #000000;
+  text-transform: uppercase;
+  font-size: 18px;
+  line-height: 25.2px;
+}
+
+<h6
+    class="c0 aries-typography-title"
+    color="#000000"
+  >
+    Glints Aries
+  </h6>
+</DocumentFragment>
+`;

--- a/src/General/Typography/__snapshots__/Typography.test.tsx.snap
+++ b/src/General/Typography/__snapshots__/Typography.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Typography> should contain the Title and Paragraph components: <Typography.Paragraph> should render a p tag with the text Glints Aries 1`] = `
 <p
-  className="ParagraphStyles__Paragraph-sc-1w5f8q5-0 gCSEMQ aries-typography-paragraph"
+  className="ParagraphStyles__Paragraph-sc-1w5f8q5-0 eMIiiu aries-typography-paragraph"
   color="#000000"
 >
   Glints Aries
@@ -11,7 +11,7 @@ exports[`<Typography> should contain the Title and Paragraph components: <Typogr
 
 exports[`<Typography> should contain the Title and Paragraph components: <Typography.Title> should render a h1 tag with the text Glints Aries 1`] = `
 <h1
-  className="TitleStyles__Title-sc-6snwzj-0 hMAqSP aries-typography-title"
+  className="TitleStyles__Title-sc-6snwzj-0 hsXxvx aries-typography-title"
   color="#000000"
 >
   Glints Aries

--- a/stories/General/TypographyStory.tsx
+++ b/stories/General/TypographyStory.tsx
@@ -263,6 +263,11 @@ ReactDOM.render(
       competition, always being the first in everything - from work to social
       gatherings.
     </Paragraph>
+    <Paragraph variant="smallest">
+      Label
+      <br />
+      This is a sample label
+    </Paragraph>
   </div>,
   mountNode
 );`}
@@ -311,6 +316,11 @@ ReactDOM.render(
         turbulent. They are continuously looking for dynamic, speed and
         competition, always being the first in everything - from work to social
         gatherings.
+      </Paragraph>
+      <Paragraph variant="smallest">
+        Label
+        <br />
+        This is a sample label
       </Paragraph>
     </div>
   </StorybookComponent>

--- a/stories/General/TypographyStory.tsx
+++ b/stories/General/TypographyStory.tsx
@@ -10,6 +10,7 @@ import {
 import {
   PARAGRAPH_VARIANTS,
   PARAGRAPH_FONT_SIZES,
+  PARAGRAPH_LINE_HEIGHTS,
 } from '../../src/General/Typography/ParagraphStyles';
 import Heading from '../../src/General/Heading';
 import { PrimaryColor } from '../../src/Utils/Colors';
@@ -83,6 +84,14 @@ const paragraphProps = {
       possibleValue: <code>true | false</code>,
       require: 'no',
       description: 'Display ellipsis when the title overflows.',
+    },
+    {
+      name: 'lineHeight',
+      type: 'boolean',
+      defaultValue: <code>false</code>,
+      possibleValue: <code>true | false</code>,
+      require: 'no',
+      description: 'Adds a lineheight value to the paragraph',
     },
     {
       name: 'variant',
@@ -326,11 +335,114 @@ ReactDOM.render(
   </StorybookComponent>
 );
 
+const ParagraphStoryWithLineHeight = () => (
+  <StorybookComponent
+    usage={`import { Typography, PrimaryColor } from 'glints-aries';
+
+const { Paragraph } = Typography;
+
+ReactDOM.render(
+  <div style={{ display: 'grid', gridRowGap: '15px' }}>
+    <Paragraph variant="subtitle" lineHeight={true}>
+      Subtitle <br />
+      As the first sign in the zodiac, the presence of Aries always marks the
+      beginning of something energetic and turbulent.
+    </Paragraph>
+    <Paragraph variant="regular" lineHeight={true}>
+      Regular <br />
+      As the first sign in the zodiac, the presence of Aries always marks the
+      beginning of something energetic and turbulent.
+    </Paragraph>
+    <Paragraph variant="caption" lineHeight={true}>
+      Caption <br />
+      As the first sign in the zodiac, the presence of Aries always marks the
+      beginning of something energetic and turbulent.
+    </Paragraph>
+    <Paragraph variant="smallest" lineHeight={true}>
+      Smallest <br />
+      As the first sign in the zodiac, the presence of Aries always marks the
+      beginning of something energetic and turbulent.
+    </Paragraph>
+    <Paragraph bold lineHeight={true}>
+      Bold Paragraph <br />
+      As the first sign in the zodiac, the presence of Aries always marks the
+      beginning of something energetic and turbulent.
+    </Paragraph>
+    <Paragraph color={PrimaryColor.glintsred} lineHeight={true}>
+      Colored Paragraph <br />
+      As the first sign in the zodiac, the presence of Aries always marks the
+      beginning of something energetic and turbulent.
+    </Paragraph>
+    <Paragraph ellipsis lineHeight={true}>
+      Paragraph with Ellipses - As the first sign in the zodiac, the presence
+      of Aries always marks the beginning of something energetic and
+      turbulent. They are continuously looking for dynamic, speed and
+      competition, always being the first in everything - from work to social
+      gatherings.
+    </Paragraph>
+  </div>,
+  mountNode
+);`}
+  >
+    <Heading style={{ fontSize: '24px', marginBottom: '1em' }}>
+      Typography.Paragraph With Line Height
+    </Heading>
+    <div style={{ display: 'grid', gridRowGap: '15px' }}>
+      <Paragraph variant="subtitle" lineHeight={true}>
+        Subtitle - Font Size: {PARAGRAPH_FONT_SIZES.subtitle}px and Line Height:{' '}
+        {PARAGRAPH_LINE_HEIGHTS.subtitle}px
+        <br />
+        As the first sign in the zodiac, the presence of Aries always marks the
+        beginning of something energetic and turbulent.
+      </Paragraph>
+      <Paragraph variant="regular" lineHeight={true}>
+        Regular - {PARAGRAPH_FONT_SIZES.regular}px and Line Height:{' '}
+        {PARAGRAPH_LINE_HEIGHTS.regular}px
+        <br />
+        As the first sign in the zodiac, the presence of Aries always marks the
+        beginning of something energetic and turbulent.
+      </Paragraph>
+      <Paragraph variant="caption" lineHeight={true}>
+        Caption - {PARAGRAPH_FONT_SIZES.caption}px and Line Height:{' '}
+        {PARAGRAPH_LINE_HEIGHTS.caption}px
+        <br />
+        As the first sign in the zodiac, the presence of Aries always marks the
+        beginning of something energetic and turbulent.
+      </Paragraph>
+      <Paragraph variant="smallest" lineHeight={true}>
+        Smallest - {PARAGRAPH_FONT_SIZES.smallest}px and Line Height:{' '}
+        {PARAGRAPH_LINE_HEIGHTS.smallest}px
+        <br />
+        As the first sign in the zodiac, the presence of Aries always marks the
+        beginning of something energetic and turbulent.
+      </Paragraph>
+      <Paragraph bold lineHeight={true}>
+        Bold Paragraph <br />
+        As the first sign in the zodiac, the presence of Aries always marks the
+        beginning of something energetic and turbulent.
+      </Paragraph>
+      <Paragraph color={PrimaryColor.glintsred} lineHeight={true}>
+        Colored Paragraph <br />
+        As the first sign in the zodiac, the presence of Aries always marks the
+        beginning of something energetic and turbulent.
+      </Paragraph>
+      <Paragraph ellipsis lineHeight={true}>
+        Paragraph with Ellipses - As the first sign in the zodiac, the presence
+        of Aries always marks the beginning of something energetic and
+        turbulent. They are continuously looking for dynamic, speed and
+        competition, always being the first in everything - from work to social
+        gatherings.
+      </Paragraph>
+    </div>
+  </StorybookComponent>
+);
+
 const TypographyStory = () => (
   <React.Fragment>
     <TitleStory />
     <UpperCaseTitleStory />
     <ParagraphStory />
+    <ParagraphStoryWithLineHeight />
   </React.Fragment>
 );
 

--- a/stories/General/TypographyStory.tsx
+++ b/stories/General/TypographyStory.tsx
@@ -86,12 +86,12 @@ const paragraphProps = {
       description: 'Display ellipsis when the title overflows.',
     },
     {
-      name: 'lineHeight',
+      name: 'shouldSetLineHeight',
       type: 'boolean',
       defaultValue: <code>false</code>,
       possibleValue: <code>true | false</code>,
       require: 'no',
-      description: 'Adds a lineheight value to the paragraph',
+      description: 'Adds a line-height value to the paragraph',
     },
     {
       name: 'variant',
@@ -343,37 +343,37 @@ const { Paragraph } = Typography;
 
 ReactDOM.render(
   <div style={{ display: 'grid', gridRowGap: '15px' }}>
-    <Paragraph variant="subtitle" lineHeight={true}>
+    <Paragraph variant="subtitle" shouldSetLineHeight={true}>
       Subtitle <br />
       As the first sign in the zodiac, the presence of Aries always marks the
       beginning of something energetic and turbulent.
     </Paragraph>
-    <Paragraph variant="regular" lineHeight={true}>
+    <Paragraph variant="regular" shouldSetLineHeight={true}>
       Regular <br />
       As the first sign in the zodiac, the presence of Aries always marks the
       beginning of something energetic and turbulent.
     </Paragraph>
-    <Paragraph variant="caption" lineHeight={true}>
+    <Paragraph variant="caption" shouldSetLineHeight={true}>
       Caption <br />
       As the first sign in the zodiac, the presence of Aries always marks the
       beginning of something energetic and turbulent.
     </Paragraph>
-    <Paragraph variant="smallest" lineHeight={true}>
+    <Paragraph variant="smallest" shouldSetLineHeight={true}>
       Smallest <br />
       As the first sign in the zodiac, the presence of Aries always marks the
       beginning of something energetic and turbulent.
     </Paragraph>
-    <Paragraph bold lineHeight={true}>
+    <Paragraph bold shouldSetLineHeight={true}>
       Bold Paragraph <br />
       As the first sign in the zodiac, the presence of Aries always marks the
       beginning of something energetic and turbulent.
     </Paragraph>
-    <Paragraph color={PrimaryColor.glintsred} lineHeight={true}>
+    <Paragraph color={PrimaryColor.glintsred} shouldSetLineHeight={true}>
       Colored Paragraph <br />
       As the first sign in the zodiac, the presence of Aries always marks the
       beginning of something energetic and turbulent.
     </Paragraph>
-    <Paragraph ellipsis lineHeight={true}>
+    <Paragraph ellipsis shouldSetLineHeight={true}>
       Paragraph with Ellipses - As the first sign in the zodiac, the presence
       of Aries always marks the beginning of something energetic and
       turbulent. They are continuously looking for dynamic, speed and
@@ -388,45 +388,45 @@ ReactDOM.render(
       Typography.Paragraph With Line Height
     </Heading>
     <div style={{ display: 'grid', gridRowGap: '15px' }}>
-      <Paragraph variant="subtitle" lineHeight={true}>
+      <Paragraph variant="subtitle" shouldSetLineHeight={true}>
         Subtitle - Font Size: {PARAGRAPH_FONT_SIZES.subtitle}px and Line Height:{' '}
         {PARAGRAPH_LINE_HEIGHTS.subtitle}px
         <br />
         As the first sign in the zodiac, the presence of Aries always marks the
         beginning of something energetic and turbulent.
       </Paragraph>
-      <Paragraph variant="regular" lineHeight={true}>
+      <Paragraph variant="regular" shouldSetLineHeight={true}>
         Regular - {PARAGRAPH_FONT_SIZES.regular}px and Line Height:{' '}
         {PARAGRAPH_LINE_HEIGHTS.regular}px
         <br />
         As the first sign in the zodiac, the presence of Aries always marks the
         beginning of something energetic and turbulent.
       </Paragraph>
-      <Paragraph variant="caption" lineHeight={true}>
+      <Paragraph variant="caption" shouldSetLineHeight={true}>
         Caption - {PARAGRAPH_FONT_SIZES.caption}px and Line Height:{' '}
         {PARAGRAPH_LINE_HEIGHTS.caption}px
         <br />
         As the first sign in the zodiac, the presence of Aries always marks the
         beginning of something energetic and turbulent.
       </Paragraph>
-      <Paragraph variant="smallest" lineHeight={true}>
+      <Paragraph variant="smallest" shouldSetLineHeight={true}>
         Smallest - {PARAGRAPH_FONT_SIZES.smallest}px and Line Height:{' '}
         {PARAGRAPH_LINE_HEIGHTS.smallest}px
         <br />
         As the first sign in the zodiac, the presence of Aries always marks the
         beginning of something energetic and turbulent.
       </Paragraph>
-      <Paragraph bold lineHeight={true}>
+      <Paragraph bold shouldSetLineHeight={true}>
         Bold Paragraph <br />
         As the first sign in the zodiac, the presence of Aries always marks the
         beginning of something energetic and turbulent.
       </Paragraph>
-      <Paragraph color={PrimaryColor.glintsred} lineHeight={true}>
+      <Paragraph color={PrimaryColor.glintsred} shouldSetLineHeight={true}>
         Colored Paragraph <br />
         As the first sign in the zodiac, the presence of Aries always marks the
         beginning of something energetic and turbulent.
       </Paragraph>
-      <Paragraph ellipsis lineHeight={true}>
+      <Paragraph ellipsis shouldSetLineHeight={true}>
         Paragraph with Ellipses - As the first sign in the zodiac, the presence
         of Aries always marks the beginning of something energetic and
         turbulent. They are continuously looking for dynamic, speed and

--- a/stories/General/TypographyStory.tsx
+++ b/stories/General/TypographyStory.tsx
@@ -36,7 +36,7 @@ const titleProps = {
       description: 'Display ellipsis when the title overflows.',
     },
     {
-      name: 'upperCase',
+      name: 'uppercase',
       type: 'boolean',
       defaultValue: <code>false</code>,
       possibleValue: <code>true | false</code>,
@@ -162,7 +162,7 @@ ReactDOM.render(
   </StorybookComponent>
 );
 
-const UpperCaseTitleStory = () => (
+const UppercaseTitleStory = () => (
   <StorybookComponent
     title="Typography"
     code="import { Typography } from 'glints-aries'"
@@ -172,16 +172,16 @@ const { Title } = Typography;
 
 ReactDOM.render(
   <div style={{ display: 'grid', gridRowGap: '15px' }}>
-    <Title tag="h1" upperCase={true}>Heading 1</Title>
-    <Title tag="h2" upperCase={true}>Heading 2</Title>
-    <Title tag="h3" upperCase={true}>Heading 3</Title>
-    <Title tag="h4" upperCase={true}>Heading 4</Title>
-    <Title tag="h5" upperCase={true}>Heading 5</Title>
-    <Title tag="h6" upperCase={true}>Heading 6</Title>
-    <Title tag="h5" color={PrimaryColor.glintsred} upperCase={true}>
+    <Title tag="h1" uppercase={true}>Heading 1</Title>
+    <Title tag="h2" uppercase={true}>Heading 2</Title>
+    <Title tag="h3" uppercase={true}>Heading 3</Title>
+    <Title tag="h4" uppercase={true}>Heading 4</Title>
+    <Title tag="h5" uppercase={true}>Heading 5</Title>
+    <Title tag="h6" uppercase={true}>Heading 6</Title>
+    <Title tag="h5" color={PrimaryColor.glintsred} uppercase={true}>
       Colored Title
     </Title>
-    <Title tag="h5" ellipsis upperCase={true}>
+    <Title tag="h5" ellipsis uppercase={true}>
       Title with Ellipses - As the first sign in the zodiac, the presence of
       Aries always marks the beginning of something energetic and turbulent.
       They are continuously looking for dynamic, speed and competition, always
@@ -195,28 +195,28 @@ ReactDOM.render(
       Typography - Upper Case Title
     </Heading>
     <div style={{ display: 'grid', gridRowGap: '15px' }}>
-      <Title tag="h1" upperCase={true}>
+      <Title tag="h1" uppercase={true}>
         Heading 1 - {TITLE_FONT_SIZES.h1}px
       </Title>
-      <Title tag="h2" upperCase={true}>
+      <Title tag="h2" uppercase={true}>
         Heading 2 - {TITLE_FONT_SIZES.h2}px
       </Title>
-      <Title tag="h3" upperCase={true}>
+      <Title tag="h3" uppercase={true}>
         Heading 3 - {TITLE_FONT_SIZES.h3}px
       </Title>
-      <Title tag="h4" upperCase={true}>
+      <Title tag="h4" uppercase={true}>
         Heading 4 - {TITLE_FONT_SIZES.h4}px
       </Title>
-      <Title tag="h5" upperCase={true}>
+      <Title tag="h5" uppercase={true}>
         Heading 5 - {TITLE_FONT_SIZES.h5}px
       </Title>
-      <Title tag="h6" upperCase={true}>
+      <Title tag="h6" uppercase={true}>
         Heading 6 - {TITLE_FONT_SIZES.h6}px
       </Title>
-      <Title tag="h5" color={PrimaryColor.glintsred} upperCase={true}>
+      <Title tag="h5" color={PrimaryColor.glintsred} uppercase={true}>
         Colored Title
       </Title>
-      <Title tag="h5" ellipsis upperCase={true}>
+      <Title tag="h5" ellipsis uppercase={true}>
         Title with Ellipses - As the first sign in the zodiac, the presence of
         Aries always marks the beginning of something energetic and turbulent.
         They are continuously looking for dynamic, speed and competition, always
@@ -440,7 +440,7 @@ ReactDOM.render(
 const TypographyStory = () => (
   <React.Fragment>
     <TitleStory />
-    <UpperCaseTitleStory />
+    <UppercaseTitleStory />
     <ParagraphStory />
     <ParagraphStoryWithLineHeight />
   </React.Fragment>

--- a/stories/General/TypographyStory.tsx
+++ b/stories/General/TypographyStory.tsx
@@ -35,6 +35,14 @@ const titleProps = {
       description: 'Display ellipsis when the title overflows.',
     },
     {
+      name: 'upperCase',
+      type: 'boolean',
+      defaultValue: <code>false</code>,
+      possibleValue: <code>true | false</code>,
+      require: 'no',
+      description: 'Makes the title in all upper case',
+    },
+    {
       name: 'tag',
       type: 'string',
       defaultValue: <code>h1</code>,
@@ -136,6 +144,70 @@ ReactDOM.render(
         Colored Title
       </Title>
       <Title tag="h5" ellipsis>
+        Title with Ellipses - As the first sign in the zodiac, the presence of
+        Aries always marks the beginning of something energetic and turbulent.
+        They are continuously looking for dynamic, speed and competition, always
+        being the first in everything - from work to social gatherings.
+      </Title>
+    </div>
+  </StorybookComponent>
+);
+
+const UpperCaseTitleStory = () => (
+  <StorybookComponent
+    title="Typography"
+    code="import { Typography } from 'glints-aries'"
+    usage={`import { Typography, PrimaryColor } from 'glints-aries';
+
+const { Title } = Typography;
+
+ReactDOM.render(
+  <div style={{ display: 'grid', gridRowGap: '15px' }}>
+    <Title tag="h1" upperCase={true}>Heading 1</Title>
+    <Title tag="h2" upperCase={true}>Heading 2</Title>
+    <Title tag="h3" upperCase={true}>Heading 3</Title>
+    <Title tag="h4" upperCase={true}>Heading 4</Title>
+    <Title tag="h5" upperCase={true}>Heading 5</Title>
+    <Title tag="h6" upperCase={true}>Heading 6</Title>
+    <Title tag="h5" color={PrimaryColor.glintsred} upperCase={true}>
+      Colored Title
+    </Title>
+    <Title tag="h5" ellipsis upperCase={true}>
+      Title with Ellipses - As the first sign in the zodiac, the presence of
+      Aries always marks the beginning of something energetic and turbulent.
+      They are continuously looking for dynamic, speed and competition, always
+      being the first in everything - from work to social gatherings.
+    </Title>
+  </div>,
+  mountNode
+);`}
+  >
+    <Heading style={{ fontSize: '24px', marginBottom: '1em' }}>
+      Typography - Upper Case Title
+    </Heading>
+    <div style={{ display: 'grid', gridRowGap: '15px' }}>
+      <Title tag="h1" upperCase={true}>
+        Heading 1 - {TITLE_FONT_SIZES.h1}px
+      </Title>
+      <Title tag="h2" upperCase={true}>
+        Heading 2 - {TITLE_FONT_SIZES.h2}px
+      </Title>
+      <Title tag="h3" upperCase={true}>
+        Heading 3 - {TITLE_FONT_SIZES.h3}px
+      </Title>
+      <Title tag="h4" upperCase={true}>
+        Heading 4 - {TITLE_FONT_SIZES.h4}px
+      </Title>
+      <Title tag="h5" upperCase={true}>
+        Heading 5 - {TITLE_FONT_SIZES.h5}px
+      </Title>
+      <Title tag="h6" upperCase={true}>
+        Heading 6 - {TITLE_FONT_SIZES.h6}px
+      </Title>
+      <Title tag="h5" color={PrimaryColor.glintsred} upperCase={true}>
+        Colored Title
+      </Title>
+      <Title tag="h5" ellipsis upperCase={true}>
         Title with Ellipses - As the first sign in the zodiac, the presence of
         Aries always marks the beginning of something energetic and turbulent.
         They are continuously looking for dynamic, speed and competition, always
@@ -247,6 +319,7 @@ ReactDOM.render(
 const TypographyStory = () => (
   <React.Fragment>
     <TitleStory />
+    <UpperCaseTitleStory />
     <ParagraphStory />
   </React.Fragment>
 );


### PR DESCRIPTION
Fixes: #202 

For **title** the line height is different for upper case and lower case titles, so added a upperCase prop to check.

For **paragraph** the line height values are set only for one of the two projects according to design, so added a lineHeight prop, to check if lineHeight should be set for the paragraph.

Doc: https://docs.google.com/document/d/1pHImZ2YXcG0WxMU5ll1y9zBygyErR2EjR8xu3Y2lgDw/edit

Abstract: https://app.abstract.com/projects/da6f9bdf-2057-45bf-9dda-8dbf0d261eac/branches/master/commits/latest/files/DDF7C217-39F9-45D7-8C53-8D8C88D5FC37/layers/02442D8E-2A5E-4B3E-8A67-BE74ACFAC7DD?collectionId=dbdd8e8c-4db0-40f5-b871-69245a509a63&collectionLayerId=7911adde-85ae-4992-8c0a-7969529f2b73

