### PR TITLE
Tooltip: fix null pointer of contentRef.current

### DIFF
--- a/src/Display/Tooltip/Tooltip.tsx
+++ b/src/Display/Tooltip/Tooltip.tsx
@@ -22,9 +22,9 @@ const Tooltip: React.FunctionComponent<Props> = ({
 
   const hideTooltipIfTouchOutside = React.useCallback(
     (event: TouchEvent | React.TouchEvent) => {
-      const hasTouchedOutsideOfTooltipContent = !contentRef.current.contains(
-        event.target as HTMLElement
-      );
+      const hasTouchedOutsideOfTooltipContent =
+        contentRef.current &&
+        !contentRef.current.contains(event.target as HTMLElement);
 
       if (hasTouchedOutsideOfTooltipContent) {
         hideTooltip();

--- a/src/Display/Tooltip/Tooltip.tsx
+++ b/src/Display/Tooltip/Tooltip.tsx
@@ -34,14 +34,13 @@ const Tooltip: React.FunctionComponent<Props> = ({
     []
   );
 
-  const handleTouchStart = (event: React.TouchEvent) => {
+  const handleTouchStart = () => {
     if (!isShow) {
       showTooltip();
       document.addEventListener('touchstart', hideTooltipIfTouchOutside);
-    } else {
-      hideTooltipIfTouchOutside(event);
     }
   };
+
   return (
     <TooltipContainer
       className={classNames('aries-tooltip', classes.container)}


### PR DESCRIPTION
I suspected the cause is because the `hideTooltipIfTouchOutside` was triggered twice if the user clicked the trigger button when Tooltip was showing. However, I cannot reproduce it so I added the check for `contentRef.current` to be safer.