### PR TITLE
Select: Fix null active element caused by dynamic select options

### DIFF
--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -127,10 +127,19 @@ const Select: ISelect = (props: Props) => {
   );
 
   React.useEffect(
-    function updateOptions() {
+    function updateOptionsAndActiveIndex() {
       setOptions(availableOptions);
+
+      if (!isFocus) {
+        const selectedOptionIndex = availableOptions.findIndex(option =>
+          toLower(option.props.children).includes(toLower(inputValue))
+        );
+        if (activeOptionIndex !== selectedOptionIndex) {
+          setActiveOptionIndex(selectedOptionIndex);
+        }
+      }
     },
-    [availableOptions]
+    [activeOptionIndex, availableOptions, inputValue, isFocus]
   );
 
   React.useEffect(function registerClickOutsideListener() {

--- a/src/Input/Select/select.dynamicOptions.test.tsx
+++ b/src/Input/Select/select.dynamicOptions.test.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import 'jest-styled-components';
+import '@testing-library/jest-dom/extend-expect';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import Select from './Select';
+
+const DynamicSelect = () => {
+  const [value, setValue] = React.useState('');
+  const allOptions = [
+    'Accountant',
+    'Business Development',
+    'Software Engineer',
+  ];
+  const filteredOptions = allOptions.filter(option => option.includes(value));
+  return (
+    <Select
+      label="Jobs"
+      value={value}
+      onChange={value => setValue(value)}
+      onInputChange={e => setValue(e.target.value)}
+    >
+      {filteredOptions.map(val => (
+        <Select.Option value={val} key={val}>
+          {val}
+        </Select.Option>
+      ))}
+    </Select>
+  );
+};
+
+describe('Dynamic <Select/>', () => {
+  it('should set the first option in the list as the active element after selecting an item in a dynamic list', () => {
+    const { getByRole, queryAllByTestId, getByTestId } = render(
+      <DynamicSelect />
+    );
+    const selectInput = getByRole('combobox') as HTMLInputElement;
+    const selectList = getByTestId('listbox');
+    const lastOption = queryAllByTestId('option')[2];
+
+    userEvent.click(selectInput);
+    userEvent.click(lastOption);
+    expect(selectList.hasAttribute('open')).toBe(false);
+
+    userEvent.click(selectInput);
+    expect(selectList.hasAttribute('open')).toBe(true);
+
+    const firstOption = queryAllByTestId('option')[0];
+    expect(firstOption).toHaveClass('active');
+  });
+});


### PR DESCRIPTION
This bug only occurs for a dynamic list i.e. the number of items in the select list changes

- When the nth item in the list is selected, the active index is n
- When the SelectList is opened again, there may be < n items so there is no active item
- For this case, we need to reset the active index to 0 to ensure that there is an 'active' item in the SelectList.

In this example, when I open the select list the second time, the first item in the list is not `active`
https://www.loom.com/share/33571f7ae01941f39e7c8544bf13cc24

Resolves https://github.com/glints-dev/glints-aries/issues/442