### PR TITLE
Button: Remove the default button type

### DIFF
--- a/src/General/Button/Button.tsx
+++ b/src/General/Button/Button.tsx
@@ -55,7 +55,6 @@ const renderButton: React.FunctionComponent<Props> = ({
   startIcon,
   endIcon,
   theme,
-  type = 'button',
   ...defaultProps
 }) => {
   const content = (
@@ -77,7 +76,6 @@ const renderButton: React.FunctionComponent<Props> = ({
           onClick={onClick}
           block={block}
           small={small}
-          type={type}
           {...defaultProps}
         >
           {content}
@@ -91,7 +89,6 @@ const renderButton: React.FunctionComponent<Props> = ({
           onClick={onClick}
           block={block}
           small={small}
-          type={type}
           {...defaultProps}
         >
           {content}
@@ -105,7 +102,6 @@ const renderButton: React.FunctionComponent<Props> = ({
           onClick={onClick}
           block={block}
           small={small}
-          type={type}
           {...defaultProps}
         >
           {content}
@@ -118,7 +114,6 @@ const renderButton: React.FunctionComponent<Props> = ({
           disabled={disabled}
           onClick={onClick}
           block={block}
-          type={type}
           {...defaultProps}
         >
           {children}
@@ -133,7 +128,6 @@ const renderButton: React.FunctionComponent<Props> = ({
           onClick={onClick}
           block={block}
           small={small}
-          type={type}
           {...defaultProps}
         >
           {content}

--- a/src/General/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/General/Button/__snapshots__/Button.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`<Button> should render with text "click me" and an onClick handler 1`] 
   <button
     className="ButtonStyle__Button-jyb3o2-0 ButtonStyle__SolidBtn-jyb3o2-1 dvDyKq solid-btn-content"
     onClick={[MockFunction]}
-    type="button"
   >
     click me
   </button>

--- a/src/Input/SearchFilter/__snapshots__/SearchFilter.test.tsx.snap
+++ b/src/Input/SearchFilter/__snapshots__/SearchFilter.test.tsx.snap
@@ -21,7 +21,6 @@ exports[`<SearchFilter> should render with an input with a button, and a list wi
     >
       <button
         className="ButtonStyle__Button-jyb3o2-0 ButtonStyle__SolidBtn-jyb3o2-1 hnveqg solid-btn-content"
-        type="button"
       >
         Search
       </button>


### PR DESCRIPTION
Removed the explicitly defined button type.
It would keep the default value as submit.
Also now that the button extends `React.ButtonHTMLAttributes<HTMLButtonElement>` , typescript won't complain on having type as a prop.