### PR TITLE
Checkbox: remove the gradient shadow inside checkbox

### DIFF
--- a/src/Input/Checkbox/CheckboxStyle.ts
+++ b/src/Input/Checkbox/CheckboxStyle.ts
@@ -90,8 +90,6 @@ export const CheckboxContainer = styled.div<CheckboxProps>`
       appearance: none;
       background-color: transparent;
       border: 2px solid ${SecondaryColor.lightblack};
-      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05),
-        inset 0px -15px 10px -12px rgba(0, 0, 0, 0.05);
       padding: 0.6em;
       display: inline-block;
       position: relative;

--- a/src/Input/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/Input/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<Checkbox> should render an input with id, value and onClick props and 
   aria-checked={false}
   aria-labelledby="software-engineer"
   checked={false}
-  className="CheckboxStyle__CheckboxContainer-c3ckvs-0 kOOvvC aries-checkbox"
+  className="CheckboxStyle__CheckboxContainer-c3ckvs-0 kydnPF aries-checkbox"
   role="checkbox"
   size="small"
   tabIndex={0}


### PR DESCRIPTION
Confirmed with designer Gun, he said the checkbox should be flat, so we can just remove the `box-shadow` to resolve this issue.