### PR TITLE
Add Disabled State for Checkbox

### DIFF
--- a/src/Input/Checkbox/Checkbox.test.tsx
+++ b/src/Input/Checkbox/Checkbox.test.tsx
@@ -8,13 +8,13 @@ import Checkbox, { CheckboxProps } from './Checkbox';
 const props = {
   id: 'software-engineer',
   value: 'Software Engineer',
-  onClick: jest.fn().mockImplementation(event => event.target.value),
+  onChange: jest.fn().mockImplementation(event => event.target.value),
 };
 
 function setupCheckbox(props: CheckboxProps) {
-  const { id, value, onClick, ...restProps } = props;
+  const { id, value, onChange, ...restProps } = props;
   const { getByText, getByLabelText, asFragment, ...utils } = render(
-    <Checkbox id={id} value={value} onClick={onClick} {...restProps} />
+    <Checkbox id={id} value={value} onChange={onChange} {...restProps} />
   );
   const checkboxInput = getByLabelText(value as string) as HTMLInputElement;
   const checkboxLabel = getByText(value as string) as HTMLLabelElement;
@@ -22,7 +22,7 @@ function setupCheckbox(props: CheckboxProps) {
 }
 
 afterEach(() => {
-  props.onClick.mockClear();
+  props.onChange.mockClear();
 });
 
 describe(`<Checkbox> rendering`, () => {
@@ -44,28 +44,28 @@ describe(`<Checkbox> rendering`, () => {
   });
 });
 
-it('when toggling checkbox, it should fire onClick once and become checked, then fire onClick once and become unchecked', () => {
+it('when toggling checkbox, it should fire onChange once and become checked, then fire onChange once and become unchecked', () => {
   const { checkboxInput, checkboxLabel } = setupCheckbox(props);
 
   fireEvent.click(checkboxLabel);
-  expect(props.onClick).toHaveBeenCalledTimes(1);
+  expect(props.onChange).toHaveBeenCalledTimes(1);
   expect(checkboxInput.checked).toEqual(true);
 
-  props.onClick.mockClear();
+  props.onChange.mockClear();
 
   fireEvent.click(checkboxLabel);
-  expect(props.onClick).toHaveBeenCalledTimes(1);
+  expect(props.onChange).toHaveBeenCalledTimes(1);
   expect(checkboxInput.checked).toEqual(false);
 });
 
-it('when controlled, it should fire onClick but remain unchanged', () => {
+it('when controlled, it should fire onChange but remain unchanged', () => {
   const { checkboxInput, checkboxLabel } = setupCheckbox({
     ...props,
     checked: false,
   });
 
   fireEvent.click(checkboxLabel);
-  expect(props.onClick).toHaveBeenCalledTimes(1);
+  expect(props.onChange).toHaveBeenCalledTimes(1);
   expect(checkboxInput.checked).toEqual(false);
 });
 
@@ -93,7 +93,7 @@ it('should not react to inputs when disabled', () => {
   });
 
   fireEvent.click(checkboxLabel);
-  expect(props.onClick).toHaveBeenCalledTimes(0);
+  expect(props.onChange).toHaveBeenCalledTimes(0);
   expect(checkboxInput.checked).toEqual(false);
 });
 
@@ -133,9 +133,9 @@ describe('when it is rendered', () => {
     expect(checkboxInput.value).toEqual(props.value);
   });
 
-  it('should return the input value when onClick is passed a function: event => event.target.value', () => {
+  it('should return the input value when onChange is passed a function: event => event.target.value', () => {
     const { checkboxLabel } = setupCheckbox(props);
     fireEvent.click(checkboxLabel);
-    expect(props.onClick.mock.results[0].value).toEqual(props.value);
+    expect(props.onChange.mock.results[0].value).toEqual(props.value);
   });
 });

--- a/src/Input/Checkbox/Checkbox.tsx
+++ b/src/Input/Checkbox/Checkbox.tsx
@@ -8,7 +8,7 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
   id,
   label,
   value,
-  onClick,
+  onChange,
   size = 'small',
   border = false,
   className,
@@ -18,10 +18,10 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
 }: CheckboxProps) => {
   const [internalChecked, setInternalChecked] = React.useState(false);
 
-  const handleClick = (e: React.MouseEvent<HTMLInputElement, MouseEvent>) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInternalChecked(internalChecked => !internalChecked);
-    if (onClick !== undefined) {
-      return onClick(e);
+    if (onChange !== undefined) {
+      return onChange(e);
     }
   };
 
@@ -43,7 +43,8 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
         type="checkbox"
         id={id}
         value={value}
-        onClick={handleClick}
+        // onClick={handleClick}
+        onChange={handleChange}
         checked={combinedChecked}
         disabled={disabled}
         {...restProps}

--- a/src/Input/Checkbox/Checkbox.tsx
+++ b/src/Input/Checkbox/Checkbox.tsx
@@ -13,6 +13,7 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
   border = false,
   className,
   checked,
+  disabled = false,
   ...restProps
 }: CheckboxProps) => {
   const [internalChecked, setInternalChecked] = React.useState(false);
@@ -36,6 +37,7 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
       size={size}
       border={border}
       checked={combinedChecked}
+      disabled={disabled}
     >
       <input
         type="checkbox"
@@ -43,6 +45,7 @@ const Checkbox: React.FunctionComponent<CheckboxProps> = ({
         value={value}
         onClick={handleClick}
         checked={combinedChecked}
+        disabled={disabled}
         {...restProps}
       />
       <label htmlFor={id} tabIndex={-1}>
@@ -59,6 +62,7 @@ export interface CheckboxProps extends HTMLInputProps {
   size?: 'large' | 'small';
   border?: boolean;
   value?: string;
+  disabled?: boolean;
 }
 
 export default Checkbox;

--- a/src/Input/Checkbox/CheckboxStyle.ts
+++ b/src/Input/Checkbox/CheckboxStyle.ts
@@ -1,6 +1,14 @@
 import styled from 'styled-components';
-import { SecondaryColor } from '../../Utils/Colors';
+import { Greyscale, SecondaryColor } from '../../Utils/Colors';
 import { CheckboxProps } from './Checkbox';
+
+const getBoxColor = (hasBorder: boolean, isDisabled: boolean) => {
+  if (isDisabled) {
+    return hasBorder ? SecondaryColor.lightblue : SecondaryColor.lightgreen;
+  } else {
+    return hasBorder ? SecondaryColor.actionblue : SecondaryColor.darkgreen;
+  }
+};
 
 export const CheckboxContainer = styled.div<CheckboxProps>`
   position: relative;
@@ -11,6 +19,14 @@ export const CheckboxContainer = styled.div<CheckboxProps>`
   &:focus {
     outline: none;
   }
+
+  ${({ disabled }) => {
+    if (disabled) {
+      return `
+           color: ${Greyscale.lightgrey};
+          `;
+    }
+  }};
 
   input {
     padding: 0;
@@ -42,15 +58,9 @@ export const CheckboxContainer = styled.div<CheckboxProps>`
     }
 
     &:checked + label:before {
-      background: ${({ border }) =>
-        border
-          ? `${SecondaryColor.actionblue}`
-          : `${SecondaryColor.darkgreen}`};
+      background: ${({ border, disabled }) => getBoxColor(border, disabled)};
       border: 2px solid
-        ${({ border }) =>
-          border
-            ? `${SecondaryColor.actionblue}`
-            : `${SecondaryColor.darkgreen}`};
+        ${({ border, disabled }) => getBoxColor(border, disabled)};
     }
   }
 
@@ -61,7 +71,7 @@ export const CheckboxContainer = styled.div<CheckboxProps>`
     line-height: 1.5;
     cursor: pointer;
     outline: none;
-    ${({ border }) => {
+    ${({ border, disabled }) => {
       if (border) {
         return `
           border: 1px solid #aaaaaa;
@@ -70,8 +80,8 @@ export const CheckboxContainer = styled.div<CheckboxProps>`
           border-radius: 2px;
           padding: 10px 15px;
           &:hover {
-            background: rgba(1, 126, 183, 0.1);
-            border-color: ${SecondaryColor.actionblue};
+            background: ${!disabled && 'rgba(1, 126, 183, 0.1)'};
+            border-color: ${!disabled && SecondaryColor.actionblue};
           }
         `;
       }
@@ -89,7 +99,9 @@ export const CheckboxContainer = styled.div<CheckboxProps>`
       content: '';
       appearance: none;
       background-color: transparent;
-      border: 2px solid ${SecondaryColor.lightblack};
+      border: 2px solid
+        ${({ disabled }) =>
+          disabled ? SecondaryColor.lightgrey : SecondaryColor.lightblack};
       padding: 0.6em;
       display: inline-block;
       position: relative;

--- a/src/Input/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/Input/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -1,29 +1,99 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Checkbox> should render an input with id, value and onClick props and a label with the text Software Engineer 1`] = `
-<div
-  aria-checked={false}
-  aria-labelledby="software-engineer"
-  checked={false}
-  className="CheckboxStyle__CheckboxContainer-c3ckvs-0 hMztQF aries-checkbox"
-  disabled={false}
-  role="checkbox"
-  size="small"
-  tabIndex={0}
->
-  <input
-    checked={false}
-    disabled={false}
-    id="software-engineer"
-    onClick={[Function]}
-    type="checkbox"
-    value="Software Engineer"
-  />
-  <label
-    htmlFor="software-engineer"
-    tabIndex={-1}
+exports[`<Checkbox> rendering should match snapshot when border=true 1`] = `
+<DocumentFragment>
+  <div
+    aria-checked="false"
+    aria-labelledby="software-engineer"
+    class="CheckboxStyle__CheckboxContainer-c3ckvs-0 fqQViy aries-checkbox"
+    role="checkbox"
+    tabindex="0"
   >
-    Software Engineer
-  </label>
-</div>
+    <input
+      id="software-engineer"
+      type="checkbox"
+      value="Software Engineer"
+    />
+    <label
+      for="software-engineer"
+      tabindex="-1"
+    >
+      Software Engineer
+    </label>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Checkbox> rendering should match snapshot when disabled=true 1`] = `
+<DocumentFragment>
+  <div
+    aria-checked="false"
+    aria-labelledby="software-engineer"
+    class="CheckboxStyle__CheckboxContainer-c3ckvs-0 ggzlDu aries-checkbox"
+    disabled=""
+    role="checkbox"
+    tabindex="0"
+  >
+    <input
+      disabled=""
+      id="software-engineer"
+      type="checkbox"
+      value="Software Engineer"
+    />
+    <label
+      for="software-engineer"
+      tabindex="-1"
+    >
+      Software Engineer
+    </label>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Checkbox> rendering should match snapshot when no special props are passed 1`] = `
+<DocumentFragment>
+  <div
+    aria-checked="false"
+    aria-labelledby="software-engineer"
+    class="CheckboxStyle__CheckboxContainer-c3ckvs-0 hMztQF aries-checkbox"
+    role="checkbox"
+    tabindex="0"
+  >
+    <input
+      id="software-engineer"
+      type="checkbox"
+      value="Software Engineer"
+    />
+    <label
+      for="software-engineer"
+      tabindex="-1"
+    >
+      Software Engineer
+    </label>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Checkbox> rendering should match snapshot when size="large" 1`] = `
+<DocumentFragment>
+  <div
+    aria-checked="false"
+    aria-labelledby="software-engineer"
+    class="CheckboxStyle__CheckboxContainer-c3ckvs-0 fScztP aries-checkbox"
+    role="checkbox"
+    tabindex="0"
+  >
+    <input
+      id="software-engineer"
+      type="checkbox"
+      value="Software Engineer"
+    />
+    <label
+      for="software-engineer"
+      tabindex="-1"
+    >
+      Software Engineer
+    </label>
+  </div>
+</DocumentFragment>
 `;

--- a/src/Input/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/Input/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -5,13 +5,15 @@ exports[`<Checkbox> should render an input with id, value and onClick props and 
   aria-checked={false}
   aria-labelledby="software-engineer"
   checked={false}
-  className="CheckboxStyle__CheckboxContainer-c3ckvs-0 kydnPF aries-checkbox"
+  className="CheckboxStyle__CheckboxContainer-c3ckvs-0 hMztQF aries-checkbox"
+  disabled={false}
   role="checkbox"
   size="small"
   tabIndex={0}
 >
   <input
     checked={false}
+    disabled={false}
     id="software-engineer"
     onClick={[Function]}
     type="checkbox"

--- a/stories/Input/CheckboxStory.tsx
+++ b/stories/Input/CheckboxStory.tsx
@@ -60,6 +60,17 @@ const CheckboxStory = () => (
       usage={'<Checkbox id="software-engineer" value="Software Engineer" />'}
     >
       <Checkbox id="software-engineer" value="Software Engineer" />
+      <Checkbox
+        id="software-engineer-disabled"
+        value="Software Engineer"
+        disabled={true}
+      />
+      <Checkbox
+        id="software-engineer-checked-disabled"
+        value="Software Engineer"
+        checked={true}
+        disabled={true}
+      />
     </StorybookComponent>
 
     <Divider theme="grey" />
@@ -93,6 +104,19 @@ const CheckboxStory = () => (
         id="software-engineer-border"
         value="Software Engineer"
         border={true}
+      />
+      <Checkbox
+        id="software-engineer-border-disabled"
+        value="Software Engineer"
+        border={true}
+        disabled={true}
+      />
+      <Checkbox
+        id="software-engineer-border-checked-disabled"
+        value="Software Engineer"
+        border={true}
+        checked={true}
+        disabled={true}
       />
     </StorybookComponent>
 


### PR DESCRIPTION
Closes #495 

There is a breaking change here: #498 made the checkbox controllable but that causes a warning about controlling in `input` with `checked` without a `onChange` prop. We were using `onClick` instead. In React, for a controlled component, it should be `onChange`. Changing this will also require the consumers of this component to switch to the `onChange` prop.