### PR TITLE
Modal: Restore previous media queries

### DIFF
--- a/src/Display/Gallery/__snapshots__/Gallery.test.tsx.snap
+++ b/src/Display/Gallery/__snapshots__/Gallery.test.tsx.snap
@@ -299,13 +299,13 @@ exports[`<Gallery /> active item click on gallery item 1`] = `
   border: 1px solid #FFFFFF;
 }
 
-@media (min-width:480px) {
+@media (max-width:480) {
   .c5 {
     width: 95vw;
   }
 }
 
-@media (min-width:480px) {
+@media (max-width:480) {
   .c8 {
     padding: 0;
   }
@@ -988,13 +988,13 @@ exports[`<Gallery /> active item click on gallery thumbnail 1`] = `
   border: 1px solid #FFFFFF;
 }
 
-@media (min-width:480px) {
+@media (max-width:480) {
   .c5 {
     width: 95vw;
   }
 }
 
-@media (min-width:480px) {
+@media (max-width:480) {
   .c8 {
     padding: 0;
   }
@@ -1520,13 +1520,13 @@ exports[`<Gallery /> rendering should match snapshot when imagesDisplayed is set
   cursor: pointer;
 }
 
-@media (min-width:480px) {
+@media (max-width:480) {
   .c5 {
     width: 95vw;
   }
 }
 
-@media (min-width:480px) {
+@media (max-width:480) {
   .c8 {
     padding: 0;
   }
@@ -1727,13 +1727,13 @@ exports[`<Gallery /> rendering should match snapshot when item is less than defa
   margin: 5px;
 }
 
-@media (min-width:480px) {
+@media (max-width:480) {
   .c5 {
     width: 95vw;
   }
 }
 
-@media (min-width:480px) {
+@media (max-width:480) {
   .c8 {
     padding: 0;
   }
@@ -1943,13 +1943,13 @@ exports[`<Gallery /> rendering should match snapshot when slider is not shown 1`
   cursor: pointer;
 }
 
-@media (min-width:480px) {
+@media (max-width:480) {
   .c5 {
     width: 95vw;
   }
 }
 
-@media (min-width:480px) {
+@media (max-width:480) {
   .c8 {
     padding: 0;
   }
@@ -2372,13 +2372,13 @@ exports[`<Gallery /> rendering should match snapshot when slider is shown 1`] = 
   border: 1px solid #FFFFFF;
 }
 
-@media (min-width:480px) {
+@media (max-width:480) {
   .c5 {
     width: 95vw;
   }
 }
 
-@media (min-width:480px) {
+@media (max-width:480) {
   .c8 {
     padding: 0;
   }

--- a/src/Display/Modal/ModalStyle.ts
+++ b/src/Display/Modal/ModalStyle.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { Device } from '../../Utils/StyleConfig';
+import { ScreenSize } from '../../Utils/StyleConfig';
 import { SecondaryColor } from '../../Utils/Colors';
 import { sizeType } from './Modal';
 
@@ -88,7 +88,7 @@ export const ModalContentArea = styled.div<ModalContentAreaProps>`
     }
   }}
     
-  @media ${Device.mobileM} {
+  @media (max-width: ${ScreenSize.mobileM}) {
     width: 95vw;
   }
 
@@ -153,7 +153,7 @@ export const ModalBody = styled.section<ModalBodyProps>`
   }}
   padding: ${({ hideContentArea }) => (hideContentArea ? '0' : '20px 30px')};
 
-  @media ${Device.mobileM} {
+  @media (max-width: ${ScreenSize.mobileM}) {
     padding: ${({ hideContentArea }) => (hideContentArea ? '0' : '20px 15px')};
   }
 `;
@@ -172,7 +172,7 @@ export const ModalFooter = styled.footer<{ isChildrenInMultiLines: boolean }>`
   justify-content: flex-end;
   border-top: 1px solid ${SecondaryColor.lightgrey};
 
-  @media ${Device.mobileM} {
+  @media (max-width: ${ScreenSize.mobileM}) {
     padding: 15px;
   }
 

--- a/src/Display/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/Display/Modal/__snapshots__/Modal.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<Modal> should render with a title, content, footer and an onClick hand
   >
     <div
       aria-modal="true"
-      className="ModalStyle__ModalContentArea-bg1vyz-2 ggspNU modal-content"
+      className="ModalStyle__ModalContentArea-bg1vyz-2 dzRQNW modal-content"
       data-testid="dialog"
       onClick={[Function]}
       role="dialog"
@@ -45,14 +45,14 @@ exports[`<Modal> should render with a title, content, footer and an onClick hand
         </button>
       </header>
       <section
-        className="ModalStyle__ModalBody-bg1vyz-4 kFYDlC modal-body"
+        className="ModalStyle__ModalBody-bg1vyz-4 lhSCsw modal-body"
       >
         <p>
           Modal Content
         </p>
       </section>
       <footer
-        className="ModalStyle__ModalFooter-bg1vyz-5 ikyScB modal-footer"
+        className="ModalStyle__ModalFooter-bg1vyz-5 uYhtP modal-footer"
       >
         <button>
           Modal Footer


### PR DESCRIPTION
This fixes a regression where the modal didn't have the correct width
because the definitions of our device classes changed.