### PR TITLE
Breakpoints: Go back to max-width based device definitions

### DIFF
--- a/src/Display/Modal/ModalStyle.ts
+++ b/src/Display/Modal/ModalStyle.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { ScreenSize } from '../../Utils/StyleConfig';
+import { Device } from '../../Utils/StyleConfig';
 import { SecondaryColor } from '../../Utils/Colors';
 import { sizeType } from './Modal';
 
@@ -88,7 +88,7 @@ export const ModalContentArea = styled.div<ModalContentAreaProps>`
     }
   }}
     
-  @media (max-width: ${ScreenSize.mobileM}px) {
+  @media ${Device.mobileM} {
     width: 95vw;
   }
 
@@ -153,7 +153,7 @@ export const ModalBody = styled.section<ModalBodyProps>`
   }}
   padding: ${({ hideContentArea }) => (hideContentArea ? '0' : '20px 30px')};
 
-  @media (max-width: ${ScreenSize.mobileM}px) {
+  @media ${Device.mobileM} {
     padding: ${({ hideContentArea }) => (hideContentArea ? '0' : '20px 15px')};
   }
 `;
@@ -172,7 +172,7 @@ export const ModalFooter = styled.footer<{ isChildrenInMultiLines: boolean }>`
   justify-content: flex-end;
   border-top: 1px solid ${SecondaryColor.lightgrey};
 
-  @media (max-width: ${ScreenSize.mobileM}px) {
+  @media ${Device.mobileM} {
     padding: 15px;
   }
 

--- a/src/Display/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/Display/Modal/__snapshots__/Modal.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<Modal> should render with a title, content, footer and an onClick hand
   >
     <div
       aria-modal="true"
-      className="ModalStyle__ModalContentArea-bg1vyz-2 jirXwS modal-content"
+      className="ModalStyle__ModalContentArea-bg1vyz-2 bJBUZy modal-content"
       data-testid="dialog"
       onClick={[Function]}
       role="dialog"
@@ -45,14 +45,14 @@ exports[`<Modal> should render with a title, content, footer and an onClick hand
         </button>
       </header>
       <section
-        className="ModalStyle__ModalBody-bg1vyz-4 hFySQU modal-body"
+        className="ModalStyle__ModalBody-bg1vyz-4 chdliM modal-body"
       >
         <p>
           Modal Content
         </p>
       </section>
       <footer
-        className="ModalStyle__ModalFooter-bg1vyz-5 gIpemn modal-footer"
+        className="ModalStyle__ModalFooter-bg1vyz-5 eTNoyD modal-footer"
       >
         <button>
           Modal Footer

--- a/src/Layout/Grid/__snapshots__/Grid.test.tsx.snap
+++ b/src/Layout/Grid/__snapshots__/Grid.test.tsx.snap
@@ -68,27 +68,27 @@ exports[`<Grid/> snapshots should match snapshot with props alignContent and jus
   }
 }
 
-@media (min-width:768px) {
+@media (max-width:768px) {
   .c0 {
     width: 720px;
     margin: 0 16px;
   }
 }
 
-@media (min-width:1024px) {
+@media (max-width:1024px) {
   .c0 {
     width: 960px;
     margin: 0 auto;
   }
 }
 
-@media (min-width:1260px) {
+@media (max-width:1260px) {
   .c0 {
     width: 1140px;
   }
 }
 
-@media (min-width:1440px) {
+@media (max-width:1440px) {
   .c0 {
     width: 1260px;
   }
@@ -325,27 +325,27 @@ exports[`<Grid/> snapshots should match snapshot without props alignContent and 
   }
 }
 
-@media (min-width:768px) {
+@media (max-width:768px) {
   .c0 {
     width: 720px;
     margin: 0 16px;
   }
 }
 
-@media (min-width:1024px) {
+@media (max-width:1024px) {
   .c0 {
     width: 960px;
     margin: 0 auto;
   }
 }
 
-@media (min-width:1260px) {
+@media (max-width:1260px) {
   .c0 {
     width: 1140px;
   }
 }
 
-@media (min-width:1440px) {
+@media (max-width:1440px) {
   .c0 {
     width: 1260px;
   }

--- a/src/Utils/StyleConfig.ts
+++ b/src/Utils/StyleConfig.ts
@@ -61,11 +61,12 @@ export const ScreenSize = {
 };
 
 export const Device = {
-  mobileS: `(max-width: ${ScreenSize.mobileM - 1}px)`,
-  mobileM: `(min-width: ${ScreenSize.mobileM}px)`,
-  mobileL: `(min-width: ${ScreenSize.mobileL}px)`,
-  tablet: `(min-width: ${ScreenSize.tablet}px)`,
-  desktopS: `(min-width: ${ScreenSize.desktopS}px)`,
-  desktopM: `(min-width: ${ScreenSize.desktopM}px)`,
-  desktopL: `(min-width: ${ScreenSize.desktopL}px)`,
+  mobileS: `(max-width: ${ScreenSize.mobileS}px)`,
+  mobileM: `(max-width: ${ScreenSize.mobileM}px)`,
+  mobileL: `(max-width: ${ScreenSize.mobileL}px)`,
+  tablet: `(max-width: ${ScreenSize.tablet}px)`,
+  desktopS: `(max-width: ${ScreenSize.desktopS}px)`,
+  desktopM: `(max-width: ${ScreenSize.desktopM}px)`,
+  desktopL: `(max-width: ${ScreenSize.desktopL}px)`,
+  desktopXL: `(min-width: ${ScreenSize.desktopL + 1}px)`,
 };


### PR DESCRIPTION
The recent changes to `Device` broke too many designs for no reason. See discussion here: https://glints.slack.com/archives/CS09D0LJX/p1606182342022200

This PR effectively reverts those changes and adds a new device class `desktopXL` for viewports wider than 1440px.

Also reverts the changes made on `Modal` in https://github.com/glints-dev/glints-aries/pull/529 as those are not necessary anymore.