### PR TITLE
Tag: make BasicTag clickable

### DIFF
--- a/src/General/Tag/Tag.tsx
+++ b/src/General/Tag/Tag.tsx
@@ -48,7 +48,7 @@ const Tag: React.FunctionComponent<Props> = ({
     );
   }
   return (
-    <BasicTag block={block} outline={outline} {...resetProps}>
+    <BasicTag block={block} outline={outline} onClick={onClick} {...resetProps}>
       {children}
     </BasicTag>
   );


### PR DESCRIPTION
## Why and What Changed
To make `BasicTag` clickable to support the new sort tag in the job filter feature.

<img src="https://user-images.githubusercontent.com/13249748/101852687-316a0980-3b99-11eb-8d7b-017e6fb698cd.png" width="500" />

I haven't written a test for this change because I plan to let Kevin improve the entire Tag testing later.