### PR TITLE
Fix: Box responsive spacing object type check

### DIFF
--- a/src/Layout/Box/Box.test.tsx
+++ b/src/Layout/Box/Box.test.tsx
@@ -35,3 +35,15 @@ describe('<Box />', () => {
     expect(asFragment()).toMatchSnapshot();
   });
 });
+
+describe('<Box /> ensure default space theme is overwritten', () => {
+  it('should have "padding: 4px" style when padding is 4', () => {
+    const { container } = render(<Box p={4} />);
+    expect(container.firstChild).toHaveStyle('padding: 4px');
+  });
+
+  it('should have "margin: 8px" style when margin is 8', () => {
+    const { container } = render(<Box m={8} />);
+    expect(container.firstChild).toHaveStyle('margin: 8px');
+  });
+});

--- a/src/Layout/Box/index.tsx
+++ b/src/Layout/Box/index.tsx
@@ -1,10 +1,19 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import { space } from 'styled-system';
-import { breakpointAliasMap, MarginProps, PaddingProps } from './types';
+import { MarginProps, PaddingProps } from './types';
+import { ScreenSize } from '../../Utils/StyleConfig';
 
 const theme = {
-  breakpoints: breakpointAliasMap,
+  breakpoints: {
+    mobileS: `${ScreenSize.mobileS}px`,
+    mobileM: `${ScreenSize.mobileM}px`,
+    mobileL: `${ScreenSize.mobileL}px`,
+    tablet: `${ScreenSize.tablet}px`,
+    desktopS: `${ScreenSize.desktopS}px`,
+    desktopM: `${ScreenSize.desktopM}px`,
+    desktopL: `${ScreenSize.desktopL}px`,
+  },
 };
 
 export type Props = MarginProps & PaddingProps;

--- a/src/Layout/Box/index.tsx
+++ b/src/Layout/Box/index.tsx
@@ -14,6 +14,12 @@ const theme = {
     desktopM: `${ScreenSize.desktopM}px`,
     desktopL: `${ScreenSize.desktopL}px`,
   },
+  /*
+    To overwrite default space theme in case <Box p={8} /> will be styled as
+    `padding: 512px` instead of `padding: 8px`. Because the index 8 of default
+    space theme is 512, can refer to https://styled-system.com/api/#defaults
+  */
+  space: [0],
 };
 
 export type Props = MarginProps & PaddingProps;

--- a/src/Layout/Box/types.ts
+++ b/src/Layout/Box/types.ts
@@ -1,4 +1,4 @@
-import { SpacingScaleValues } from '../Spacing';
+import { Spacing } from '../Spacing';
 
 // Responsive
 export type BreakpointAliases =
@@ -12,15 +12,17 @@ export type BreakpointAliases =
   | 'desktopL';
 
 // Space
-type ResponsiveSpacing = {
-  [key in BreakpointAliases]?: SpacingScaleValues | 'auto';
+export type SpacingScaleValues = typeof Spacing[keyof typeof Spacing] | 'auto';
+
+export type ResponsiveSpacing = {
+  [key in BreakpointAliases]?: SpacingScaleValues;
 };
 type MarginTypes = 'm' | 'mt' | 'mb' | 'ml' | 'mr' | 'my' | 'mx';
 export type MarginProps = {
-  [key in MarginTypes]?: SpacingScaleValues | 'auto' | ResponsiveSpacing;
+  [key in MarginTypes]?: SpacingScaleValues | ResponsiveSpacing;
 };
 
 type PaddingTypes = 'p' | 'pt' | 'pb' | 'pl' | 'pr' | 'py' | 'px';
 export type PaddingProps = {
-  [key in PaddingTypes]?: SpacingScaleValues | 'auto' | ResponsiveSpacing;
+  [key in PaddingTypes]?: SpacingScaleValues | ResponsiveSpacing;
 };

--- a/src/Layout/Box/types.ts
+++ b/src/Layout/Box/types.ts
@@ -1,4 +1,3 @@
-import { ScreenSize } from '../../Utils/StyleConfig';
 import { SpacingScaleValues } from '../Spacing';
 
 // Responsive
@@ -11,15 +10,6 @@ export type BreakpointAliases =
   | 'desktopS'
   | 'desktopM'
   | 'desktopL';
-export const breakpointAliasMap = {
-  mobileS: `${ScreenSize.mobileS}px`,
-  mobileM: `${ScreenSize.mobileM}px`,
-  mobileL: `${ScreenSize.mobileL}px`,
-  tablet: `${ScreenSize.tablet}px`,
-  desktopS: `${ScreenSize.desktopS}px`,
-  desktopM: `${ScreenSize.desktopM}px`,
-  desktopL: `${ScreenSize.desktopL}px`,
-};
 
 // Space
 type ResponsiveSpacing = {

--- a/src/Layout/Spacing/index.tsx
+++ b/src/Layout/Spacing/index.tsx
@@ -1,22 +1,4 @@
-export type SpacingScaleTypes =
-  | '128'
-  | '96'
-  | '64'
-  | '32'
-  | '24'
-  | '16'
-  | '8'
-  | '4'
-  | '2'
-  | '0';
-
-export type SpacingScaleValues = 128 | 96 | 64 | 32 | 24 | 16 | 8 | 4 | 2 | 0;
-
-type SpacingScale = {
-  [key in SpacingScaleTypes]: SpacingScaleValues;
-};
-
-export const Spacing: SpacingScale = {
+export const Spacing = {
   128: 128,
   96: 96,
   64: 64,
@@ -27,4 +9,4 @@ export const Spacing: SpacingScale = {
   4: 4,
   2: 2,
   0: 0,
-};
+} as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export { default as Drawer } from './Navigation/Drawer';
 export { default as Dropdown } from './Navigation/Dropdown';
 export { default as Gallery } from './Display/Gallery';
 export { Box } from './Layout/Box';
+export { ResponsiveSpacing } from './Layout/Box/types';
 export { Flex } from './Layout/Flex';
 export { default as Grid } from './Layout/Grid';
 export { default as Heading } from './General/Heading';

--- a/stories/Layout/BoxStory/BoxSpaceStory.tsx
+++ b/stories/Layout/BoxStory/BoxSpaceStory.tsx
@@ -116,7 +116,7 @@ const typeValue = (
 
 const possibleValue = (
   <>
-    {32} | {'"auto"'} | <code>{'{default: 32, ds: 64}'}</code>
+    {32} | {'"auto"'} | <code>{'{default: 32, desktopS: 64}'}</code>
   </>
 );
 

--- a/stories/Layout/BoxStory/BoxSpaceStory.tsx
+++ b/stories/Layout/BoxStory/BoxSpaceStory.tsx
@@ -16,6 +16,7 @@ import {
   contentWidth,
   contentHeight,
 } from './BoxSpaceStoryStyle';
+import { ResponsiveSpacing } from '../../../src/Layout/Box/types';
 
 const marginProps = [
   {
@@ -81,9 +82,9 @@ const paddingProps = [
 
 const directions = ['top', 'right', 'bottom', 'left'];
 
-const usage = `import { Box } from 'glints-aries'
+const usage = `import { Box, ResponsiveSpacing } from 'glints-aries'
 // responsive space object
-const responsivePadding = {
+const responsivePadding: ResponsiveSpacing = {
     default: 32,
     desktopS: 64
 };
@@ -137,6 +138,11 @@ export const propsObject = {
   })),
 };
 
+const responsivePadding: ResponsiveSpacing = {
+  default: 32,
+  desktopS: 64,
+};
+
 const BoxSpaceStory = () => (
   <StorybookComponent title="Box" usage={usage} propsObject={propsObject}>
     <Heading>Space</Heading>
@@ -153,13 +159,7 @@ const BoxSpaceStory = () => (
           </SpaceText>
         );
       })}
-      <CustomBox
-        p={{
-          default: 32,
-          desktopS: 64,
-        }}
-        m={64}
-      >
+      <CustomBox p={responsivePadding} m={64}>
         {directions.map(direction => {
           const calcPosition = (space: number) =>
             direction === 'left' || direction === 'right'

--- a/stories/Layout/SpacingStory.tsx
+++ b/stories/Layout/SpacingStory.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import StorybookComponent from '../StorybookComponent';
 import { StorybookTable } from '../StorybookTable';
 import { SecondaryColor } from '../../src/Utils/Colors';
-import { SpacingScaleValues, Spacing } from '../../src/Layout/Spacing';
+import { Spacing } from '../../src/Layout/Spacing';
 
 type Data = {
   value: number;
@@ -14,7 +14,7 @@ const dataSource: Data[] = Object.values(Spacing)
   .sort(function(a, b) {
     return b - a;
   })
-  .map((value: SpacingScaleValues) => {
+  .map(value => {
     return {
       value: value,
       usage: value > 64 ? 'Layout' : 'Element Layout',


### PR DESCRIPTION
### Why
Previously, the code snippet below 
```
const containerPaddingTop = {
  default: 24,
  desktopS: 32,
};
// ...
<Box pt={containerPaddingTop} /> 
```
got the type error
```
Type '{ default: number; desktopSs: number; }' is not assignable to type `ResponsiveSpacing`.
```
```
type SpacingScaleValues = 0 | 32 | 128 | 96 | 64 | 24 | 16 | 8 | 4 | 2 | "auto";
type ResponsiveSpacing = {
    default?: SpacingScaleValues;
    mobileS?: SpacingScaleValues;
    mobileM?: SpacingScaleValues;
    mobileL?: SpacingScaleValues;
    tablet?: SpacingScaleValues;
    desktopS?: SpacingScaleValues;
    desktopM?: SpacingScaleValues;
    desktopL?: SpacingScaleValues;
};
```
Because TS infer the value of `containerPaddingTop` is a number type which is not assignable to `SpacingScaleValues`. And I also noticed TS cannot check the property of `containerPaddingTop` which means if it has any non-existing property in `ResponsiveSpacing`, it won't get a type error.
So I think we should just export `ResponsiveSpacing` to let TS help us type check the property and value both.
```
import { Box, ResponsiveSpacing } from 'glints-aries'

const responsivePadding: ResponsiveSpacing = {
    default: 32,
    desktopS: 64
};
// ...
<Box p={responsivePadding} />
```