### PR TITLE
Button: Add isRoundedCorner prop

### DIFF
--- a/src/General/Button/Button.tsx
+++ b/src/General/Button/Button.tsx
@@ -149,6 +149,7 @@ export interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   endIcon?: React.ReactNode;
   theme?: string;
   forwardedRef?: React.RefObject<HTMLButtonElement>;
+  isRoundedCorner?: boolean;
 }
 
 const forwardRef = (props: Props, ref: React.RefObject<HTMLButtonElement>) => (

--- a/src/General/Button/ButtonStyle.ts
+++ b/src/General/Button/ButtonStyle.ts
@@ -321,6 +321,7 @@ export const GhostBtn = styled(Button)<GhostBtnProps>`
       : `${generalButtonPadding[0] - 2}px ${generalButtonPadding[1] - 2}px`};
   border: 2px solid ${SecondaryColor.actionblue};
   color: ${SecondaryColor.actionblue};
+  border-radius: ${({ isRoundedCorner }) => (isRoundedCorner ? '8px' : '0px')};
 
   &:hover {
     transition: background-color 0.5s;
@@ -349,6 +350,7 @@ export const GhostBtn = styled(Button)<GhostBtnProps>`
 
 interface GhostBtnProps {
   block?: boolean;
+  isRoundedCorner?: boolean;
 }
 
 export const GhostBtnContainer = styled.div<GhostBtnContainerProps>`
@@ -356,7 +358,7 @@ export const GhostBtnContainer = styled.div<GhostBtnContainerProps>`
   display: ${({ block }) => (block ? 'flex' : 'inline-flex')};
   z-index: 1;
 
-  ${({ disabled }) => {
+  ${({ disabled, isRoundedCorner }) => {
     if (!disabled) {
       return `
         &:active {
@@ -377,6 +379,7 @@ export const GhostBtnContainer = styled.div<GhostBtnContainerProps>`
           z-index: -1;
           transition: all .2s;
           cursor: pointer;
+          border-radius: ${isRoundedCorner ? '8px' : '0px'};
         }
 
         &:hover:after {
@@ -410,6 +413,7 @@ export const GhostBtnContainer = styled.div<GhostBtnContainerProps>`
 interface GhostBtnContainerProps {
   block?: boolean;
   disabled?: boolean;
+  isRoundedCorner?: boolean;
 }
 
 /*

--- a/src/General/Button/ButtonStyle.ts
+++ b/src/General/Button/ButtonStyle.ts
@@ -47,14 +47,17 @@ const Button = styled.button<ButtonProps>`
 interface SolidBtnContainerProps {
   block?: boolean;
   disabled?: boolean;
+  isRoundedCorner?: boolean;
 }
 
 interface SolidBtnProps {
   block?: boolean;
+  isRoundedCorner?: boolean;
 }
 
 export const SolidBtn = styled(Button)<SolidBtnProps>`
   width: ${({ block }) => block && '100%'};
+  border-radius: ${({ isRoundedCorner }) => (isRoundedCorner ? '8px' : '0px')};
 
   &:active {
     background-color: ${Greyscale.black};
@@ -110,8 +113,8 @@ export const SolidBtnContainer = styled.div<SolidBtnContainerProps>`
   position: relative;
   display: ${({ block }) => (block ? 'flex' : 'inline-flex')};
   z-index: 1;
-
-  ${({ disabled }) => {
+  border-radius: ${({ isRoundedCorner }) => (isRoundedCorner ? '8px' : '0px')};
+  ${({ disabled, isRoundedCorner }) => {
     if (!disabled) {
       return `
       &:active {
@@ -133,6 +136,7 @@ export const SolidBtnContainer = styled.div<SolidBtnContainerProps>`
         z-index: -1;
         transition: all .2s;
         cursor: pointer;
+        border-radius: ${isRoundedCorner ? '8px' : '0px'};
       }
 
       &:hover:after {
@@ -181,11 +185,6 @@ export const SolidBtnContainer = styled.div<SolidBtnContainerProps>`
  * SolidShadow Button
  */
 
-interface SolidShadowContainerProps {
-  block?: boolean;
-  disabled?: boolean;
-}
-
 interface SolidShadowBtnProps {
   block?: boolean;
 }
@@ -213,6 +212,11 @@ export const SolidShadowBtn = styled(Button)<SolidShadowBtnProps>`
     `;
   }}
 `;
+
+interface SolidShadowContainerProps {
+  block?: boolean;
+  disabled?: boolean;
+}
 
 export const SolidShadowContainer = styled.div<SolidShadowContainerProps>`
   position: relative;
@@ -311,6 +315,11 @@ export const SolidShadowContainer = styled.div<SolidShadowContainerProps>`
  * Ghost Button
  */
 
+interface GhostBtnProps {
+  block?: boolean;
+  isRoundedCorner?: boolean;
+}
+
 export const GhostBtn = styled(Button)<GhostBtnProps>`
   transition: background-color 0.5s;
   width: ${({ block }) => block && '100%'};
@@ -348,8 +357,9 @@ export const GhostBtn = styled(Button)<GhostBtnProps>`
   }}
 `;
 
-interface GhostBtnProps {
+interface GhostBtnContainerProps {
   block?: boolean;
+  disabled?: boolean;
   isRoundedCorner?: boolean;
 }
 
@@ -410,23 +420,23 @@ export const GhostBtnContainer = styled.div<GhostBtnContainerProps>`
   }
 `;
 
-interface GhostBtnContainerProps {
-  block?: boolean;
-  disabled?: boolean;
-  isRoundedCorner?: boolean;
-}
-
 /*
  * White-Grey Button
  */
+
+interface WhiteGreyBtnProps {
+  block?: boolean;
+  isRoundedCorner?: boolean;
+}
 export const WhiteGreyBtn = styled(Button)<WhiteGreyBtnProps>`
   width: ${({ block }) => block && '100%'};
 
-  ${({ disabled }) => {
+  ${({ disabled, isRoundedCorner }) => {
     if (!disabled) {
       return `
         background-color: ${Greyscale.white};
         color: ${SecondaryColor.actionblue};
+        border-radius: ${isRoundedCorner ? '8px' : '0px'};
 
         &:hover {
           background-color: ${Greyscale.softgrey};
@@ -445,10 +455,6 @@ export const WhiteGreyBtn = styled(Button)<WhiteGreyBtnProps>`
     `;
   }}
 `;
-
-interface WhiteGreyBtnProps {
-  block?: boolean;
-}
 
 /*
  * Link Button

--- a/src/General/Button/GhostButton.tsx
+++ b/src/General/Button/GhostButton.tsx
@@ -10,6 +10,7 @@ const GhostButton: React.FunctionComponent<Props> = ({
   block,
   small,
   tag,
+  isRoundedCorner,
   ...defaultProps
 }) => (
   <GhostBtnContainer
@@ -17,6 +18,7 @@ const GhostButton: React.FunctionComponent<Props> = ({
     theme={theme}
     disabled={disabled}
     block={block}
+    isRoundedCorner={isRoundedCorner}
   >
     <GhostBtn
       className="ghostbtn-content"
@@ -25,6 +27,7 @@ const GhostButton: React.FunctionComponent<Props> = ({
       block={block}
       small={small}
       as={(tag as React.ElementType) || 'button'}
+      isRoundedCorner={isRoundedCorner}
       {...defaultProps}
     >
       {children}
@@ -40,6 +43,7 @@ interface Props extends React.ComponentPropsWithoutRef<typeof GhostBtn> {
   block?: boolean;
   small?: boolean;
   tag?: React.ElementType;
+  isRoundedCorner?: boolean;
 }
 
 export default GhostButton;

--- a/src/General/Button/SolidButton.tsx
+++ b/src/General/Button/SolidButton.tsx
@@ -10,6 +10,7 @@ const SolidButton: React.FunctionComponent<Props> = ({
   block,
   small,
   tag,
+  isRoundedCorner,
   ...defaultProps
 }) => (
   <SolidBtnContainer
@@ -17,6 +18,7 @@ const SolidButton: React.FunctionComponent<Props> = ({
     theme={theme}
     disabled={disabled}
     block={block}
+    isRoundedCorner={isRoundedCorner}
   >
     <SolidBtn
       className="solid-btn-content"
@@ -25,6 +27,7 @@ const SolidButton: React.FunctionComponent<Props> = ({
       block={block}
       small={small}
       as={(tag as React.ElementType) || 'button'}
+      isRoundedCorner={isRoundedCorner}
       {...defaultProps}
     >
       {children}
@@ -40,6 +43,7 @@ interface Props extends React.ComponentPropsWithoutRef<typeof SolidBtn> {
   block?: boolean;
   small?: boolean;
   tag?: React.ElementType;
+  isRoundedCorner?: boolean;
 }
 
 export default SolidButton;

--- a/src/Utils/StyleConfig.ts
+++ b/src/Utils/StyleConfig.ts
@@ -29,6 +29,13 @@ export const ButtonVariant = {
   LINK: 'link',
 };
 
+export const RoundedCornerButtonVariant = {
+  SOLID_WHITE: 'solid-white',
+  SOLID_BLUE: 'solid-blue',
+  GHOST: 'ghost',
+  WHITE_GREY: 'white-grey',
+};
+
 export const PsychedelicTheme = {
   BLUE_DOMINANT: 'blue-dominant',
   BLUE_DEFAULT: 'blue-default',

--- a/stories/General/ButtonStory.tsx
+++ b/stories/General/ButtonStory.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import omit from 'lodash/omit';
-
+import Typography from '../../src/General/Typography';
 import StorybookComponent from '../StorybookComponent';
 import Button from '../../src/General/Button';
 import Heading from '../../src/General/Heading';
@@ -11,7 +11,10 @@ import {
   ArrowRoundForwardIcon,
 } from '../../src/General/Icon/components';
 
-import { ButtonVariant } from '../../src/Utils/StyleConfig';
+import {
+  ButtonVariant,
+  RoundedCornerButtonVariant,
+} from '../../src/Utils/StyleConfig';
 
 const ButtonVariantWithoutLink = omit(ButtonVariant, ['LINK']);
 const AllButtonNamesWithoutLink =
@@ -75,6 +78,14 @@ const ButtonVariantStory = () => {
       {Object.values(ButtonVariant).map(variant => (
         <ButtonRow key={variant}>
           <Button variant={variant}>{variant}</Button>
+        </ButtonRow>
+      ))}
+      <Typography.Paragraph>Button with rounded corner</Typography.Paragraph>
+      {Object.values(RoundedCornerButtonVariant).map(variant => (
+        <ButtonRow key={variant}>
+          <Button variant={variant} isRoundedCorner={true}>
+            {variant}
+          </Button>
         </ButtonRow>
       ))}
     </StorybookComponent>


### PR DESCRIPTION
The new rounded corner ghost button has appeared in 3 places on DST, it's time to add it to Aries.

Since we haven't seen the rounded corner style to be applied to other button variants, not applying it to the variants.


Screenshots:
![Screen Shot 2020-12-15 at 11 07 29 AM](https://user-images.githubusercontent.com/11376798/102166109-af465180-3ec6-11eb-974f-083f6f28d2cb.png)
![Screen Shot 2020-12-15 at 11 07 38 AM](https://user-images.githubusercontent.com/11376798/102166137-b0777e80-3ec6-11eb-8f9a-26b6a29706f0.png)
