### PR TITLE
Feature/checkbox fontsize

### DIFF
--- a/src/Input/Checkbox/Checkbox.stories.tsx
+++ b/src/Input/Checkbox/Checkbox.stories.tsx
@@ -4,6 +4,18 @@ import { Story, Meta } from '@storybook/react';
 import { Checkbox, CheckboxProps } from './Checkbox';
 import { BaseContainer } from '../../Layout/GlintsContainer/GlintsContainer';
 
+import styled from 'styled-components';
+
+const TestBox = styled.div<{ fontSize: string }>`
+  div {
+    font-size: ${({ fontSize }) => fontSize};
+  }
+
+  &:not(:last-child) {
+    margin-bottom: 4px;
+  }
+`;
+
 export default {
   title: 'General/Checkbox',
   component: Checkbox,
@@ -33,4 +45,29 @@ Sizes.args = {
   value: 'large-engineer',
   label: 'Large Engineer',
   size: 'large',
+};
+
+const FontSizeStory: Story<CheckboxProps> = args => (
+  <div>
+    <TestBox fontSize="10px">
+      <Checkbox {...args} checked={true} id="10px" value="10px" label="10px" />
+    </TestBox>
+    <TestBox fontSize="14px">
+      <Checkbox {...args} checked={true} id="14px" value="14px" label="14px" />
+    </TestBox>
+    <TestBox fontSize="18px">
+      <Checkbox {...args} checked={true} id="18px" value="18px" label="18px" />
+    </TestBox>
+    <TestBox fontSize="48px">
+      <Checkbox {...args} checked={true} id="48px" value="48px" label="48px" />
+    </TestBox>
+  </div>
+);
+export const FontSize = FontSizeStory.bind({});
+FontSize.parameters = {
+  docs: {
+    description: {
+      story: `If you change the checkbox root div's font-size, the entire checkbox will adjust its size accordingly.`,
+    },
+  },
 };

--- a/src/Input/Checkbox/CheckboxStyle.ts
+++ b/src/Input/Checkbox/CheckboxStyle.ts
@@ -2,6 +2,26 @@ import styled, { css } from 'styled-components';
 import { Greyscale, SecondaryColor } from '../../Utils/Colors';
 import { CheckboxProps } from './Checkbox';
 
+const borderedTickStyles = css`
+  margin-top: 0.61em;
+  margin-left: 0.89em;
+`;
+
+const borderedLabelStyles = css`
+  border: 1px solid #aaaaaa;
+  cursor: pointer;
+  border-radius: 8px;
+  padding: 0.57em 0.86em;
+  &:hover {
+    background: rgba(1, 126, 183, 0.1);
+    border-color: ${SecondaryColor.actionblue};
+  }
+`;
+
+const checkedLabelStyles = css`
+  border-color: ${SecondaryColor.actionblue};
+`;
+
 export const CheckboxContainer = styled.div<CheckboxProps>`
   position: relative;
   display: inline-flex;
@@ -24,33 +44,20 @@ export const CheckboxContainer = styled.div<CheckboxProps>`
       content: '';
       display: block;
       position: absolute;
-      /* top: ${({ size }) => (size === 'small' ? '0.13em' : '0.24em')}; */
       top: 0.13em;
-      /* left: ${({ size }) => (size === 'small' ? '0.45em' : '0.54em')}; */
       left: 0.45em;
       width: 0.43em;
       height: 0.86em;
       border: solid ${Greyscale.white};
       border-width: 0 0.143em 0.143em 0;
       transform: rotate(45deg);
-      ${({ border, size }) => {
-        if (border) {
-          return css`
-            /* margin-top: ${size === 'small' ? '0.61em' : '0.57em'}; */
-            margin-top: 0.61em;
-            margin-left: 0.89em;
-          `;
-        }
-      }};
+      ${({ border }) => border && borderedTickStyles};
     }
 
     &:checked + label:before {
       background: ${({ border }) =>
-        border
-          ? `${SecondaryColor.actionblue}`
-          : `${SecondaryColor.darkgreen}`};
-      border-color: ${({ border }) =>
-        `${border ? SecondaryColor.actionblue : SecondaryColor.darkgreen}`};
+        border ? SecondaryColor.actionblue : SecondaryColor.darkgreen};
+      border-color: transparent;
     }
   }
 
@@ -61,28 +68,8 @@ export const CheckboxContainer = styled.div<CheckboxProps>`
     line-height: 1;
     cursor: pointer;
     outline: none;
-    ${({ border }) => {
-      if (border) {
-        return css`
-          border: 1px solid #aaaaaa;
-          cursor: pointer;
-          border-radius: 8px;
-          padding: 0.57em 0.86em;
-          &:hover {
-            background: rgba(1, 126, 183, 0.1);
-            border-color: ${SecondaryColor.actionblue};
-          }
-        `;
-      }
-    }};
-
-    ${({ checked }) => {
-      if (checked) {
-        return css`
-          border-color: ${SecondaryColor.actionblue};
-        `;
-      }
-    }};
+    ${({ border }) => border && borderedLabelStyles};
+    ${({ checked }) => checked && checkedLabelStyles};
 
     &:before {
       content: '';
@@ -95,9 +82,7 @@ export const CheckboxContainer = styled.div<CheckboxProps>`
       cursor: pointer;
       margin-right: 10px;
       border-radius: 4px;
-      /* width: ${({ size }) => (size === 'small' ? '1.29em' : '1.45em')}; */
       width: 1.29em;
-      /* height: ${({ size }) => (size === 'small' ? '1.29em' : '1.45em')}; */
       height: 1.29em;
       box-sizing: border-box;
     }

--- a/src/Input/Checkbox/CheckboxStyle.ts
+++ b/src/Input/Checkbox/CheckboxStyle.ts
@@ -24,8 +24,10 @@ export const CheckboxContainer = styled.div<CheckboxProps>`
       content: '';
       display: block;
       position: absolute;
-      top: ${({ size }) => (size === 'small' ? '0.13em' : '0.24em')};
-      left: ${({ size }) => (size === 'small' ? '0.45em' : '0.54em')};
+      /* top: ${({ size }) => (size === 'small' ? '0.13em' : '0.24em')}; */
+      top: 0.13em;
+      /* left: ${({ size }) => (size === 'small' ? '0.45em' : '0.54em')}; */
+      left: 0.45em;
       width: 0.43em;
       height: 0.86em;
       border: solid ${Greyscale.white};
@@ -34,7 +36,8 @@ export const CheckboxContainer = styled.div<CheckboxProps>`
       ${({ border, size }) => {
         if (border) {
           return css`
-            margin-top: ${size === 'small' ? '0.61em' : '0.57em'};
+            /* margin-top: ${size === 'small' ? '0.61em' : '0.57em'}; */
+            margin-top: 0.61em;
             margin-left: 0.89em;
           `;
         }
@@ -92,8 +95,10 @@ export const CheckboxContainer = styled.div<CheckboxProps>`
       cursor: pointer;
       margin-right: 10px;
       border-radius: 4px;
-      width: ${({ size }) => (size === 'small' ? '1.29em' : '1.45em')};
-      height: ${({ size }) => (size === 'small' ? '1.29em' : '1.45em')};
+      /* width: ${({ size }) => (size === 'small' ? '1.29em' : '1.45em')}; */
+      width: 1.29em;
+      /* height: ${({ size }) => (size === 'small' ? '1.29em' : '1.45em')}; */
+      height: 1.29em;
       box-sizing: border-box;
     }
   }

--- a/src/Input/Checkbox/CheckboxStyle.ts
+++ b/src/Input/Checkbox/CheckboxStyle.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { Greyscale, SecondaryColor } from '../../Utils/Colors';
 import { CheckboxProps } from './Checkbox';
 
@@ -24,18 +24,18 @@ export const CheckboxContainer = styled.div<CheckboxProps>`
       content: '';
       display: block;
       position: absolute;
-      top: ${({ size }) => (size === 'small' ? '1.8px' : '3.3px')};
-      left: ${({ size }) => (size === 'small' ? '6.3px' : '7.5px')};
-      width: 6px;
-      height: 12px;
+      top: ${({ size }) => (size === 'small' ? '0.13em' : '0.24em')};
+      left: ${({ size }) => (size === 'small' ? '0.45em' : '0.54em')};
+      width: 0.43em;
+      height: 0.86em;
       border: solid ${Greyscale.white};
-      border-width: 0 2px 2px 0;
+      border-width: 0 0.143em 0.143em 0;
       transform: rotate(45deg);
       ${({ border, size }) => {
         if (border) {
-          return `
-            margin-top: ${size === 'small' ? '8.5px' : '8px'};
-            margin-left: 12.5px;
+          return css`
+            margin-top: ${size === 'small' ? '0.61em' : '0.57em'};
+            margin-left: 0.89em;
           `;
         }
       }};
@@ -60,11 +60,11 @@ export const CheckboxContainer = styled.div<CheckboxProps>`
     outline: none;
     ${({ border }) => {
       if (border) {
-        return `
+        return css`
           border: 1px solid #aaaaaa;
           cursor: pointer;
           border-radius: 8px;
-          padding: 8px 12px;
+          padding: 0.57em 0.86em;
           &:hover {
             background: rgba(1, 126, 183, 0.1);
             border-color: ${SecondaryColor.actionblue};
@@ -75,7 +75,7 @@ export const CheckboxContainer = styled.div<CheckboxProps>`
 
     ${({ checked }) => {
       if (checked) {
-        return `
+        return css`
           border-color: ${SecondaryColor.actionblue};
         `;
       }
@@ -86,15 +86,14 @@ export const CheckboxContainer = styled.div<CheckboxProps>`
       appearance: none;
       background-color: transparent;
       border: 1px solid ${Greyscale.grey};
-      padding: 0.6em;
       display: inline-block;
       position: relative;
       vertical-align: middle;
       cursor: pointer;
       margin-right: 10px;
       border-radius: 4px;
-      height: 18px;
-      width: 18px;
+      width: ${({ size }) => (size === 'small' ? '1.29em' : '1.45em')};
+      height: ${({ size }) => (size === 'small' ? '1.29em' : '1.45em')};
       box-sizing: border-box;
     }
   }

--- a/src/Input/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/Input/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<Checkbox> should render an input with id, value and onClick props and 
   aria-checked={false}
   aria-labelledby="software-engineer"
   checked={false}
-  className="CheckboxStyle__CheckboxContainer-c3ckvs-0 bHFhAr aries-checkbox"
+  className="CheckboxStyle__CheckboxContainer-c3ckvs-0 bbRgMp aries-checkbox"
   role="checkbox"
   size="small"
   tabIndex={0}


### PR DESCRIPTION
Fixes #590.

Main change here is to use `em` instead of `px` in various places of the Checkbox styles to ensure that they scale with the `font-size`. Also, I made it so that the `size` prop now just determines the Checkbox's `font-size` and removed all other references to remove unnecessary complexity.

I wasn't sure how to write tests for this so I added an example to the storybook.

Plus some cleanup.