### PR TITLE
Dropdown: improve test coverage

### DIFF
--- a/src/Navigation/Dropdown/Dropdown.test.tsx
+++ b/src/Navigation/Dropdown/Dropdown.test.tsx
@@ -314,6 +314,61 @@ describe('<Dropdown/> keydown event', () => {
     ).toBeVisible();
   });
 
+  test('when the first option is highlighted, pressing up arrow key should not affect anything', async () => {
+    render(
+      <Dropdown label="Career">
+        <DropdownItem value="pm">Product Manager</DropdownItem>
+        <DropdownItem value="se">Software Engineer</DropdownItem>
+      </Dropdown>
+    );
+
+    const dropdown = queryByRole(document.body, 'menuitem');
+    fireEvent.click(dropdown);
+
+    const optionPM = queryByText(document.body, 'Product Manager');
+    const optionSE = queryByText(document.body, 'Software Engineer');
+    expect(optionPM).toHaveStyle(`background: ${Greyscale.softgrey}`);
+    expect(optionSE).not.toHaveStyle(`background: ${Greyscale.softgrey}`);
+
+    fireEvent.keyDown(dropdown, { key: 'UpArrow', keyCode: 38 });
+
+    expect(optionPM).toHaveStyle(`background: ${Greyscale.softgrey}`);
+    expect(optionSE).not.toHaveStyle(`background: ${Greyscale.softgrey}`);
+    expect(document.querySelector('.dropdown-listbox')).toBeVisible();
+    expect(
+      queryByText(document.querySelector('.dropdown-content'), 'Career')
+    ).toBeVisible();
+  });
+
+  test('when the last option is highlighted, pressing down arrow key should not affect anything', async () => {
+    render(
+      <Dropdown label="Career">
+        <DropdownItem value="pm">Product Manager</DropdownItem>
+        <DropdownItem value="se">Software Engineer</DropdownItem>
+      </Dropdown>
+    );
+
+    const dropdown = queryByRole(document.body, 'menuitem');
+    fireEvent.click(dropdown);
+
+    const optionPM = queryByText(document.body, 'Product Manager');
+    const optionSE = queryByText(document.body, 'Software Engineer');
+    expect(optionPM).toHaveStyle(`background: ${Greyscale.softgrey}`);
+    expect(optionSE).not.toHaveStyle(`background: ${Greyscale.softgrey}`);
+
+    fireEvent.keyDown(dropdown, { key: 'DownArrow', keyCode: 40 });
+    expect(optionPM).not.toHaveStyle(`background: ${Greyscale.softgrey}`);
+    expect(optionSE).toHaveStyle(`background: ${Greyscale.softgrey}`);
+
+    fireEvent.keyDown(dropdown, { key: 'DownArrow', keyCode: 40 });
+    expect(optionPM).not.toHaveStyle(`background: ${Greyscale.softgrey}`);
+    expect(optionSE).toHaveStyle(`background: ${Greyscale.softgrey}`);
+    expect(document.querySelector('.dropdown-listbox')).toBeVisible();
+    expect(
+      queryByText(document.querySelector('.dropdown-content'), 'Career')
+    ).toBeVisible();
+  });
+
   test('press esc key should close dropdown', async () => {
     render(
       <Dropdown label="Career">

--- a/src/Navigation/Dropdown/Dropdown.test.tsx
+++ b/src/Navigation/Dropdown/Dropdown.test.tsx
@@ -134,7 +134,7 @@ describe('<Dropdown/> with DropdownBody props', () => {
 });
 
 describe('<Dropdown/> mouse event', () => {
-  test('options should appear when clicking on it, if prop hoverToOpen is falsy', () => {
+  test('options should appear when clicking on it and should not disappear when mouse leaving, if prop hoverToOpen is falsy', () => {
     const { queryByRole, queryByText } = render(
       <Dropdown label="Career">
         <DropdownItem value="pm">Product Manager</DropdownItem>
@@ -148,6 +148,10 @@ describe('<Dropdown/> mouse event', () => {
     const optionPM = queryByText('Product Manager');
     const optionSE = queryByText('Software Engineer');
 
+    expect(optionPM).toBeVisible();
+    expect(optionSE).toBeVisible();
+
+    fireEvent.mouseLeave(dropdown);
     expect(optionPM).toBeVisible();
     expect(optionSE).toBeVisible();
   });
@@ -172,6 +176,20 @@ describe('<Dropdown/> mouse event', () => {
     fireEvent.mouseLeave(dropdown);
     expect(optionPM).not.toBeVisible();
     expect(optionSE).not.toBeVisible();
+  });
+
+  test('options should not appear when mouse hovering on it, if prop hoverToOpen is falsy', () => {
+    const optionText = 'Product Manager';
+    const { queryByRole, queryByText } = render(
+      <Dropdown label="Career">
+        <DropdownItem value="pm">{optionText}</DropdownItem>
+      </Dropdown>
+    );
+
+    const dropdown = queryByRole('menuitem');
+    fireEvent.mouseOver(dropdown);
+    const option = queryByText(optionText);
+    expect(option).not.toBeVisible();
   });
 
   test('dropdown button should be highlighted when mouse is hovering on', () => {

--- a/src/Navigation/Dropdown/Dropdown.test.tsx
+++ b/src/Navigation/Dropdown/Dropdown.test.tsx
@@ -350,3 +350,44 @@ describe('<Dropdown/> logic', () => {
     expect(onChange.mock.calls[0][0]).toEqual('pm');
   });
 });
+
+describe('<DropdownItem/> onClick', () => {
+  test('onClick callback should be called when it is a function', async () => {
+    const onClick = jest.fn();
+    const menuText = 'Product Manager';
+    render(
+      <Dropdown label="Career">
+        <DropdownItem value="pm" onClick={onClick}>
+          {menuText}
+        </DropdownItem>
+      </Dropdown>
+    );
+
+    const dropdown = queryByRole(document.body, 'menuitem');
+    fireEvent.click(dropdown);
+    const option = queryByText(document.body, menuText);
+    fireEvent.mouseDown(option);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('onClick callback should not be called when it is not a function', async () => {
+    const onClick = 'invalid-on-click';
+    const menuText = 'Product Manager';
+    render(
+      <Dropdown label="Career">
+        <DropdownItem value="pm" onClick={onClick}>
+          {menuText}
+        </DropdownItem>
+      </Dropdown>
+    );
+
+    const dropdown = queryByRole(document.body, 'menuitem');
+    fireEvent.click(dropdown);
+    const option = queryByText(document.body, menuText);
+    expect(option).toBeVisible();
+
+    fireEvent.mouseDown(option);
+    expect(option).not.toBeVisible();
+  });
+});

--- a/src/Navigation/Dropdown/Dropdown.test.tsx
+++ b/src/Navigation/Dropdown/Dropdown.test.tsx
@@ -412,3 +412,19 @@ describe('<DropdownBody/> onClick', () => {
     expect(dropdownContent).toBeVisible();
   });
 });
+
+describe('<DropdownBody/> prop disable', () => {
+  test('dropdown should not open when it is clicked', async () => {
+    const optionText = 'Product Manager';
+    const { queryByRole, queryByText } = render(
+      <Dropdown label="Career" disabled={true}>
+        <DropdownItem value="pm">{optionText}</DropdownItem>
+      </Dropdown>
+    );
+
+    const dropdown = queryByRole('menuitem');
+    fireEvent.click(dropdown);
+    const option = queryByText(optionText);
+    expect(option).not.toBeVisible();
+  });
+});

--- a/src/Navigation/Dropdown/Dropdown.test.tsx
+++ b/src/Navigation/Dropdown/Dropdown.test.tsx
@@ -391,3 +391,24 @@ describe('<DropdownItem/> onClick', () => {
     expect(option).not.toBeVisible();
   });
 });
+
+describe('<DropdownBody/> onClick', () => {
+  test('clicking DropdownBody should not close dropdown', async () => {
+    render(
+      <Dropdown label="Career">
+        <DropdownItem value="pm">Product Manager</DropdownItem>
+        <DropdownItem value="se">Software Engineer</DropdownItem>
+      </Dropdown>
+    );
+
+    const dropdown = queryByRole(document.body, 'menuitem');
+    fireEvent.click(dropdown);
+
+    const dropdownContent = queryByRole(document.body, 'listbox');
+    expect(dropdownContent).toBeVisible();
+
+    const dropdownBody = document.querySelector('.dropdown-listbox');
+    fireEvent.click(dropdownBody);
+    expect(dropdownContent).toBeVisible();
+  });
+});

--- a/src/Navigation/Dropdown/Dropdown.test.tsx
+++ b/src/Navigation/Dropdown/Dropdown.test.tsx
@@ -152,7 +152,7 @@ describe('<Dropdown/> mouse event', () => {
     expect(optionSE).toBeVisible();
   });
 
-  test('options should appear when mouse hovering on it, if prop hoverToOpen is truthy', () => {
+  test('options should appear when mouse hovering on it and disappear when mouse leaving, if prop hoverToOpen is truthy', () => {
     const { queryByRole, queryByText } = render(
       <Dropdown label="Career" hoverToOpen={true}>
         <DropdownItem value="pm">Product Manager</DropdownItem>
@@ -168,6 +168,10 @@ describe('<Dropdown/> mouse event', () => {
 
     expect(optionPM).toBeVisible();
     expect(optionSE).toBeVisible();
+
+    fireEvent.mouseLeave(dropdown);
+    expect(optionPM).not.toBeVisible();
+    expect(optionSE).not.toBeVisible();
   });
 
   test('dropdown button should be highlighted when mouse is hovering on', () => {

--- a/src/Navigation/Dropdown/Dropdown.test.tsx
+++ b/src/Navigation/Dropdown/Dropdown.test.tsx
@@ -221,8 +221,8 @@ describe('<Dropdown/> mouse event', () => {
     const optionSE = queryByText('Software Engineer');
     fireEvent.mouseOver(optionPM);
 
-    expect(optionPM).toHaveStyle(`background: ${Greyscale.softgrey}`);
-    expect(optionSE).not.toHaveStyle(`background: ${Greyscale.softgrey}`);
+    expect(optionPM).toHaveClass('active');
+    expect(optionSE).not.toHaveClass('active');
   });
 
   test('selected option should be displayed', async () => {
@@ -277,16 +277,16 @@ describe('<Dropdown/> keydown event', () => {
 
     const optionPM = queryByText(document.body, 'Product Manager');
     const optionSE = queryByText(document.body, 'Software Engineer');
-    expect(optionPM).toHaveStyle(`background: ${Greyscale.softgrey}`);
-    expect(optionSE).not.toHaveStyle(`background: ${Greyscale.softgrey}`);
+    expect(optionPM).toHaveClass('active');
+    expect(optionSE).not.toHaveClass('active');
 
     fireEvent.keyDown(dropdown, { key: 'DownArrow', keyCode: 40 });
-    expect(optionPM).not.toHaveStyle(`background: ${Greyscale.softgrey}`);
-    expect(optionSE).toHaveStyle(`background: ${Greyscale.softgrey}`);
+    expect(optionPM).not.toHaveClass('active');
+    expect(optionSE).toHaveClass('active');
 
     fireEvent.keyDown(dropdown, { key: 'UpArrow', keyCode: 38 });
-    expect(optionPM).toHaveStyle(`background: ${Greyscale.softgrey}`);
-    expect(optionSE).not.toHaveStyle(`background: ${Greyscale.softgrey}`);
+    expect(optionPM).toHaveClass('active');
+    expect(optionSE).not.toHaveClass('active');
   });
 
   test('press enter key should select an highlighted option', async () => {
@@ -301,7 +301,7 @@ describe('<Dropdown/> keydown event', () => {
     fireEvent.click(dropdown);
 
     const optionPM = queryByText(document.body, 'Product Manager');
-    expect(optionPM).toHaveStyle(`background: ${Greyscale.softgrey}`);
+    expect(optionPM).toHaveClass('active');
 
     fireEvent.keyDown(dropdown, { key: 'Enter', keyCode: 13 });
     expect(optionPM).not.toBeVisible();
@@ -327,13 +327,13 @@ describe('<Dropdown/> keydown event', () => {
 
     const optionPM = queryByText(document.body, 'Product Manager');
     const optionSE = queryByText(document.body, 'Software Engineer');
-    expect(optionPM).toHaveStyle(`background: ${Greyscale.softgrey}`);
-    expect(optionSE).not.toHaveStyle(`background: ${Greyscale.softgrey}`);
+    expect(optionPM).toHaveClass('active');
+    expect(optionSE).not.toHaveClass('active');
 
     fireEvent.keyDown(dropdown, { key: 'UpArrow', keyCode: 38 });
 
-    expect(optionPM).toHaveStyle(`background: ${Greyscale.softgrey}`);
-    expect(optionSE).not.toHaveStyle(`background: ${Greyscale.softgrey}`);
+    expect(optionPM).toHaveClass('active');
+    expect(optionSE).not.toHaveClass('active');
     expect(document.querySelector('.dropdown-listbox')).toBeVisible();
     expect(
       queryByText(document.querySelector('.dropdown-content'), 'Career')
@@ -353,16 +353,16 @@ describe('<Dropdown/> keydown event', () => {
 
     const optionPM = queryByText(document.body, 'Product Manager');
     const optionSE = queryByText(document.body, 'Software Engineer');
-    expect(optionPM).toHaveStyle(`background: ${Greyscale.softgrey}`);
-    expect(optionSE).not.toHaveStyle(`background: ${Greyscale.softgrey}`);
+    expect(optionPM).toHaveClass('active');
+    expect(optionSE).not.toHaveClass('active');
 
     fireEvent.keyDown(dropdown, { key: 'DownArrow', keyCode: 40 });
-    expect(optionPM).not.toHaveStyle(`background: ${Greyscale.softgrey}`);
-    expect(optionSE).toHaveStyle(`background: ${Greyscale.softgrey}`);
+    expect(optionPM).not.toHaveClass('active');
+    expect(optionSE).toHaveClass('active');
 
     fireEvent.keyDown(dropdown, { key: 'DownArrow', keyCode: 40 });
-    expect(optionPM).not.toHaveStyle(`background: ${Greyscale.softgrey}`);
-    expect(optionSE).toHaveStyle(`background: ${Greyscale.softgrey}`);
+    expect(optionPM).not.toHaveClass('active');
+    expect(optionSE).toHaveClass('active');
     expect(document.querySelector('.dropdown-listbox')).toBeVisible();
     expect(
       queryByText(document.querySelector('.dropdown-content'), 'Career')

--- a/src/Navigation/Dropdown/Dropdown.test.tsx
+++ b/src/Navigation/Dropdown/Dropdown.test.tsx
@@ -444,12 +444,17 @@ describe('<DropdownItem/> onClick', () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  test('onClick callback should not be called when it is not a function', async () => {
+  test('invalid onClick value should not break anything', async () => {
     const onClick = 'invalid-on-click';
     const menuText = 'Product Manager';
     render(
       <Dropdown label="Career">
-        <DropdownItem value="pm" onClick={onClick}>
+        <DropdownItem
+          value="pm"
+          // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+          // @ts-ignore
+          onClick={onClick}
+        >
           {menuText}
         </DropdownItem>
       </Dropdown>

--- a/src/Navigation/Dropdown/Dropdown.tsx
+++ b/src/Navigation/Dropdown/Dropdown.tsx
@@ -70,18 +70,16 @@ export const Dropdown = ({
 
     if (itemElement.dataset.value) {
       setDropdownLabel(itemElement.innerHTML);
-      setIsOpen(false);
 
-      if (onChange !== undefined) {
+      if (onChange && typeof onChange === 'function') {
         onChange(itemElement.dataset.value);
       }
-    } else {
-      setIsOpen(false);
     }
 
-    if (onClick !== undefined) {
+    if (onClick && typeof onClick === 'function') {
       onClick(e);
     }
+    setIsOpen(false);
   };
 
   const handleMouseEnter = setCursor;

--- a/src/Navigation/Dropdown/DropdownItem.test.tsx
+++ b/src/Navigation/Dropdown/DropdownItem.test.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+
+import '@testing-library/jest-dom/extend-expect';
+import { render } from '@testing-library/react';
+
+import DropdownItem from './DropdownItem';
+
+describe('<DropdownItem /> prop className', () => {
+  const matchSnapshot = (className: string) => {
+    test(`should match snapshot when class name ${className} is passed`, () => {
+      const { asFragment } = render(
+        <DropdownItem className={className}>Product Manager</DropdownItem>
+      );
+
+      expect(asFragment()).toMatchSnapshot();
+    });
+  };
+
+  ['test', undefined].forEach(matchSnapshot);
+});

--- a/src/Navigation/Dropdown/DropdownItem.tsx
+++ b/src/Navigation/Dropdown/DropdownItem.tsx
@@ -14,6 +14,8 @@ const DropdownItem: React.FunctionComponent<Props> = props => {
 
 export interface Props
   extends React.ComponentPropsWithoutRef<typeof DropdownItemWrapper> {
+  value?: any;
+  onClick?: (e: React.MouseEvent<HTMLLIElement, MouseEvent>) => void;
   children: React.ReactNode;
 }
 

--- a/src/Navigation/Dropdown/__snapshots__/DropdownItem.test.tsx.snap
+++ b/src/Navigation/Dropdown/__snapshots__/DropdownItem.test.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<DropdownItem /> prop className should match snapshot when class name test is passed 1`] = `
+<DocumentFragment>
+  <li
+    class="DropdownStyle__DropdownItemWrapper-sc-1sc3c6h-4 bnpgGr test"
+  >
+    Product Manager
+  </li>
+</DocumentFragment>
+`;
+
+exports[`<DropdownItem /> prop className should match snapshot when class name undefined is passed 1`] = `
+<DocumentFragment>
+  <li
+    class="DropdownStyle__DropdownItemWrapper-sc-1sc3c6h-4 bnpgGr"
+  >
+    Product Manager
+  </li>
+</DocumentFragment>
+`;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/13249748/109263565-70296a80-783e-11eb-9ce6-fdd0abd71889.png)

After: 
![image](https://user-images.githubusercontent.com/13249748/109263638-93541a00-783e-11eb-8431-15289df09900.png)


The lines 71 and 141 are related to the `itemElement` prop, I suspect it is not used anymore, so create an issue https://github.com/glints-dev/glints-aries/issues/614 to check it in the next sprint.
