### PR TITLE
Select: Blur on outside mousedown instead of click

### DIFF
--- a/src/Input/Select/Select.test.tsx
+++ b/src/Input/Select/Select.test.tsx
@@ -421,7 +421,7 @@ describe('<Select/> on click outside', () => {
 
     fireEvent.focus(selectInput);
     expect(selectList.hasAttribute('open')).toEqual(true);
-    fireEvent.click(outside);
+    fireEvent.mouseDown(outside);
     expect(selectList.hasAttribute('open')).toEqual(false);
   });
 
@@ -706,7 +706,7 @@ describe('<Select/> defaultOpen', () => {
     const outside = queryByText('outside');
 
     expect(selectList.hasAttribute('open')).toEqual(true);
-    fireEvent.click(outside);
+    fireEvent.mouseDown(outside);
     expect(selectList.hasAttribute('open')).toEqual(false);
   });
 

--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -157,8 +157,9 @@ const Select: React.FC<Props> & {
         setIsFocus(false);
       }
     };
-    document.addEventListener('click', onClickOutside, false);
-    return () => document.removeEventListener('click', onClickOutside, false);
+    document.addEventListener('mousedown', onClickOutside, false);
+    return () =>
+      document.removeEventListener('mousedown', onClickOutside, false);
   }, []);
 
   React.useEffect(


### PR DESCRIPTION
This avoids a problem where selecting text in the input by dragging the mouse over the text and releasing the mouse outside the Select component closed the Select dropdown too early.

Fixes #582 

Can see here: https://5fbcb813bd13c900214bb971-vabztpcise.chromatic.com/?path=/docs/input-select--default-select