### PR TITLE
Select: Set noOptionResult to null to hide no result option

### DIFF
--- a/src/Input/Select/Select.test.tsx
+++ b/src/Input/Select/Select.test.tsx
@@ -6,7 +6,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { fireEvent, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import Select from './Select';
+import Select, { Props } from './Select';
 import { PrimaryColor } from '../../Utils/Colors';
 
 const props = {
@@ -38,8 +38,10 @@ const SelectComponentWithExtraProps = (extraProps = {}) => (
 
 const SelectComponent = SelectComponentWithExtraProps();
 
-function setupOpenSelectMenu() {
-  const { getByRole, queryAllByTestId, getByTestId } = render(SelectComponent);
+function setupOpenSelectMenu(extraProps?: Partial<Props>) {
+  const { getByRole, queryAllByTestId, getByTestId } = render(
+    SelectComponentWithExtraProps(extraProps)
+  );
   const selectInput = getByRole('combobox') as HTMLInputElement;
   const selectList = getByTestId('listbox');
   const selectLabel = getByTestId('select-label');
@@ -258,6 +260,18 @@ describe('when no results are found', () => {
       target: { value: 'z' },
     });
     expect(selectList).toHaveTextContent(/^No results found$/);
+  });
+});
+
+describe('when no results are found and noOptionResult is null', () => {
+  it('should display "No results found"', () => {
+    const { selectInput, selectList } = setupOpenSelectMenu({
+      noOptionResult: null,
+    });
+    fireEvent.change(selectInput, {
+      target: { value: 'z' },
+    });
+    expect(selectList).not.toHaveTextContent(/^No results found$/);
   });
 });
 

--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -430,7 +430,7 @@ export interface Props
   isLoading?: boolean;
   /** Sets placeholder value for the Text Field. */
   label?: string;
-  /** Sets message to display when no option matches. */
+  /** Sets message to display when no option matches, set it to null when the message is not needed. */
   noOptionResult?: string;
   /** Removes drop icon. */
   removeDropIcon?: boolean;

--- a/src/Input/Select/SelectList.tsx
+++ b/src/Input/Select/SelectList.tsx
@@ -49,15 +49,17 @@ const SelectList: React.FunctionComponent<Props> = ({
         <Loading />
       </SelectItem>
     ) : (
-      <SelectItem
-        disabled
-        role="option"
-        data-testid="option"
-        aria-hidden={false}
-        aria-disabled="true"
-      >
-        {noOptionResult}
-      </SelectItem>
+      Boolean(noOptionResult) && (
+        <SelectItem
+          disabled
+          role="option"
+          data-testid="option"
+          aria-hidden={false}
+          aria-disabled="true"
+        >
+          {noOptionResult}
+        </SelectItem>
+      )
     )}
   </SelectListWrapper>
 );


### PR DESCRIPTION
We have a requirement that when there is no option found in a Select component, we don't want it to display `No result found`.

https://glints.atlassian.net/browse/GM-840