### PR TITLE
Remove all <code> elements from docs

### DIFF
--- a/src/Display/Slider/Slider.tsx
+++ b/src/Display/Slider/Slider.tsx
@@ -214,11 +214,11 @@ export interface Props {
   className?: string;
   /** The index of the page that will be shown initally (before the first manual- or auto-scroll). Note that the index starts at 1. */
   initialItem?: number;
-  /** If <code>true</code>, the dot controls will be superimposed on the current page */
+  /** If true, the dot controls will be superimposed on the current page */
   fullContent?: boolean;
-  /** If <code>true</code>, the arrow controls will have a white color */
+  /** If true, the arrow controls will have a white color */
   arrowWhite?: boolean;
-  /** If <code>true</code>, dot controls will be removed */
+  /** If true, dot controls will be removed */
   removeDots?: boolean;
   /** Sets the left icon. Receives the "disabled" flag as an argument. */
   renderLeftIcon?: (disabled: boolean) => React.ReactElement;
@@ -226,7 +226,7 @@ export interface Props {
   renderRightIcon?: (disabled: boolean) => React.ReactElement;
   /** Called with the new index after a new Slider page has been shown */
   afterChange?: Function;
-  /** If <code>true</code>, the Slider will flip through its pages at a regular interval */
+  /** If true, the Slider will flip through its pages at a regular interval */
   autoplay?: boolean;
   containerRef?: React.RefObject<HTMLDivElement>;
 }

--- a/src/Display/Swipeable/Swipeable.tsx
+++ b/src/Display/Swipeable/Swipeable.tsx
@@ -4,7 +4,7 @@ import { SwipeableContainer } from './SwipeableStyle';
 
 import SwipeableItem from './SwipeableItem';
 
-/** You can add any number of <code> <Swipeable.Item /> </code> components as children of the Swipeable component, controlling the behavior of an individual swipeable item.  */
+/** You can add any number of  <Swipeable.Item />  components as children of the Swipeable component, controlling the behavior of an individual swipeable item.  */
 export const Swipeable: Swipeable = ({ children, className }) => (
   <SwipeableContainer className={classNames('aries-swipeable', className)}>
     {children}

--- a/src/Display/Tooltip/Tooltip.tsx
+++ b/src/Display/Tooltip/Tooltip.tsx
@@ -93,8 +93,8 @@ export interface Classes {
 export type Position = 'top' | 'right' | 'bottom' | 'left';
 
 interface BaseProps extends HTMLAttributes<HTMLHeadingElement> {
-  //   /** This is an object with three keys: <code>container</code>,
-  //    * <code>content</code> and <code>message</code>. Use them to attach
+  //   /** This is an object with three keys: container,
+  //    * content and message. Use them to attach
   //    * additional classes to the respective elements. */
   classes?: Classes;
   position?: Position;

--- a/src/General/Divider/Divider.tsx
+++ b/src/General/Divider/Divider.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { DividerContainer } from './DividerStyle';
 
 /**
- * Use <code>className</code> or <code>style</code> to change the divider's
+ * Use className or style to change the divider's
  * height
  */
 export const Divider: FC<Props> = ({

--- a/src/General/Loading/Loading.tsx
+++ b/src/General/Loading/Loading.tsx
@@ -2,7 +2,7 @@ import React, { FC, HTMLAttributes } from 'react';
 import classNames from 'classnames';
 import { LoadingContainer, Spinner } from './LoadingStyle';
 
-/** The loading spinner does not support resizing at the moment, but as a workaround you can use the <code>className</code> attribute to change it's styles manually. */
+/** The loading spinner does not support resizing at the moment, but as a workaround you can use the className attribute to change it's styles manually. */
 export const Loading: FC<Props> = props => {
   const { className } = props;
 

--- a/src/General/Tag/Tag.tsx
+++ b/src/General/Tag/Tag.tsx
@@ -67,7 +67,7 @@ interface ButtonTagProps {
 
 export type TagActionType = 'add' | 'reset';
 interface ActionTagProps {
-  /** (Only for tags with <code>variant</code>=<code>action</code>). Chooses which kind of action the tag will indicate. */
+  /** (Only for tags with variant=action). Chooses which kind of action the tag will indicate. */
   action?: TagActionType;
   /** A function triggered when icon or action tag is clicked. */
   onClick?(e: React.MouseEvent<HTMLDivElement, MouseEvent>): void;
@@ -76,7 +76,7 @@ interface ActionTagProps {
 export type TagVariantType = 'button' | 'action';
 export interface Props extends BasicTagProps, ButtonTagProps, ActionTagProps {
   children: React.ReactNode;
-  /** <code>button</code> tags usually show a single piece of information, while <code>action</code> tags are elements in a list (e.g. a list of selected options). */
+  /** button tags usually show a single piece of information, while action tags are elements in a list (e.g. a list of selected options). */
   variant?: TagVariantType;
 }
 

--- a/src/Input/DownshiftSelect/Select.stories.tsx
+++ b/src/Input/DownshiftSelect/Select.stories.tsx
@@ -94,7 +94,7 @@ Interactive.args = { label: 'Select An Item', helperText: 'Type to filter' };
 Interactive.parameters = {
   docs: {
     description: {
-      story: `You can pass a transformFunction to make the combobox filter the provided items according to custom logic. In the example above, the filter function uses <code>String.includes</code> instead of the default <code>String.startsWith</code>.`,
+      story: `You can pass a transformFunction to make the combobox filter the provided items according to custom logic. In the example above, the filter function uses String.includes instead of the default String.startsWith.`,
     },
   },
 };
@@ -134,7 +134,7 @@ TransformFunctionForCustomFilter.args = {
 TransformFunctionForCustomFilter.parameters = {
   docs: {
     description: {
-      story: `You can pass a transformFunction to make the combobox filter the provided items according to custom logic. In the example above, the filter function uses <code>String.startsWith</code> instead of the default <code>String.includes</code>.`,
+      story: `You can pass a transformFunction to make the combobox filter the provided items according to custom logic. In the example above, the filter function uses String.startsWith instead of the default String.includes.`,
     },
   },
 };
@@ -159,7 +159,7 @@ CustomComponents.parameters = {
   docs: {
     description: {
       story: `You can override the components that comprise the Combobox. These components are available at the moment: ${componentNames.map(
-        name => `<code>${name}</code>`
+        name => `${name}`
       )}`,
     },
   },
@@ -173,7 +173,7 @@ RemoveToggleButton.parameters = {
   docs: {
     description: {
       story:
-        'Remove the toggle button by passing <code>components={{ ToggleButton: () => null }}</code>',
+        'Remove the toggle button by passing components={{ ToggleButton: () => null }}',
     },
   },
 };
@@ -191,7 +191,7 @@ InitiallyOpen.parameters = {
   docs: {
     description: {
       story:
-        'Pass <code>isOpenInitially=true</code> to open and focus the Select on render. (Set to <code>false</code> in this story because it would steal focus from the other stories otherwise).',
+        'Pass isOpenInitially=true to open and focus the Select on render. (Set to false in this story because it would steal focus from the other stories otherwise).',
     },
   },
 };
@@ -221,7 +221,7 @@ DownshiftOptions.parameters = {
   docs: {
     description: {
       story:
-        'If the options afforded by the Select component are not enough, you can also use the <code>downshift</code> prop to pass custom options to the internal <code>useCombobox</code> hook. You can read the documentation <a href="https://github.com/downshift-js/downshift/blob/master/src/hooks/useCombobox/README.md">here</a>. Use this with caution, future versions of this component might break your custom functionality.',
+        'If the options afforded by the Select component are not enough, you can also use the downshift prop to pass custom options to the internal useCombobox hook. You can read the documentation <a href="https://github.com/downshift-js/downshift/blob/master/src/hooks/useCombobox/README.md">here</a>. Use this with caution, future versions of this component might break your custom functionality.',
     },
   },
 };
@@ -243,7 +243,7 @@ DisableTyping.parameters = {
   docs: {
     description: {
       story:
-        "With <code>disableTyping=true</code>, the internal <code>input</code> will be set to <code>readonly</code>. This is helpful when there's only a small or fixed amount of items. This can be combined with setting <code>transformFunction</code> to the identity function to disable the filtering after an option has been chosen.",
+        "With disableTyping=true, the internal input will be set to readonly. This is helpful when there's only a small or fixed amount of items. This can be combined with setting transformFunction to the identity function to disable the filtering after an option has been chosen.",
     },
   },
 };
@@ -255,8 +255,7 @@ DisabledOptions.args = {
 DisabledOptions.parameters = {
   docs: {
     description: {
-      story:
-        "Use the items' <code>disabled</code> prop to disable individual items.",
+      story: "Use the items' disabled prop to disable individual items.",
     },
   },
 };
@@ -293,7 +292,7 @@ ControlledSelectedItem.parameters = {
   docs: {
     description: {
       story:
-        'Use <code>selectedItem</code> and <code>setSelectedItem</code> to control the currently selected item. <strong>In many cases, you will want to use this to react to selections made by the user.</strong> Use <code>null</code> as the controlled <code>selectedItem</code> when no item is selected: So if you want to have a controlled Select with no item selected by default, use <code>useState(null)</code>.',
+        'Use selectedItem and setSelectedItem to control the currently selected item. <strong>In many cases, you will want to use this to react to selections made by the user.</strong> Use null as the controlled selectedItem when no item is selected: So if you want to have a controlled Select with no item selected by default, use useState(null).',
     },
   },
 };
@@ -320,7 +319,7 @@ ControlledIsOpen.parameters = {
   docs: {
     description: {
       story:
-        "Use <code>isOpen</code> and <code>onIsOpenChange</code> to control the state of the Select's menu. Note that clicking outside of the Select closes the select (calls <code>onIsOpenChange</code> with <code>false</code>) so if you're trying to build a 'toggle' button, clicking that button will first close the menu.",
+        "Use isOpen and onIsOpenChange to control the state of the Select's menu. Note that clicking outside of the Select closes the select (calls onIsOpenChange with false) so if you're trying to build a 'toggle' button, clicking that button will first close the menu.",
     },
   },
 };
@@ -351,7 +350,7 @@ ControlledInputValue.parameters = {
   docs: {
     description: {
       story:
-        "Use <code>inputValue</code> and <code>setInputValue</code> to control the input value (this value is used for the search function, don't confuse it with <code>selectedItem</code>",
+        "Use inputValue and setInputValue to control the input value (this value is used for the search function, don't confuse it with selectedItem",
     },
   },
 };
@@ -366,7 +365,7 @@ Invalid.parameters = {
   docs: {
     description: {
       story:
-        'Use <code>invalid=true</code> to toggle the Select into an error state. It is recommended that you use <code>helperText</code> to describe the error when you do this.',
+        'Use invalid=true to toggle the Select into an error state. It is recommended that you use helperText to describe the error when you do this.',
     },
   },
 };
@@ -379,7 +378,7 @@ DisableAutocomplete.parameters = {
   docs: {
     description: {
       story:
-        "Intrinsic props are usually passed down to the internal <code>input</code> element, so to disable autocompletion just pass <code>autocomplete='off'</code>.",
+        "Intrinsic props are usually passed down to the internal input element, so to disable autocompletion just pass autocomplete='off'.",
     },
   },
 };
@@ -408,7 +407,7 @@ FocusCallbacks.parameters = {
   docs: {
     description: {
       story:
-        'Intrinsic props are usually passed down to the internal <code>input</code> element, so you can simply use <code>onFocus</code> and <code>onBlur</code> to capture those events.',
+        'Intrinsic props are usually passed down to the internal input element, so you can simply use onFocus and onBlur to capture those events.',
     },
   },
 };
@@ -427,8 +426,7 @@ export const OnClearCallback: Story<Props> = () => {
 OnClearCallback.parameters = {
   docs: {
     description: {
-      story:
-        'Use <code>onClear</code> to capture the when the clear-button is clicked.',
+      story: 'Use onClear to capture the when the clear-button is clicked.',
     },
   },
 };
@@ -452,7 +450,7 @@ ConfigurableWidth.parameters = {
   docs: {
     description: {
       story:
-        "By default, the select has a 100% width. To change the width, just pass a custom <code>Container</code> subcomponent. Note that you might also have to adjust other subcomponent's styles if you want to make it really short (less than 300px).",
+        "By default, the select has a 100% width. To change the width, just pass a custom Container subcomponent. Note that you might also have to adjust other subcomponent's styles if you want to make it really short (less than 300px).",
     },
   },
 };
@@ -473,7 +471,7 @@ Small.parameters = {
   docs: {
     description: {
       story:
-        "<p>By default, the Select dictates a font-size of 16px that cascades through (almost) all sub-components. Appropriate spaces are defined using <code>em</code>, so if you want to resize the Select, just change the container's font-size.</p><p>The exception to the 16px default is the helper text, which also just uses an <code>em</code> relative value.</p>",
+        "<p>By default, the Select dictates a font-size of 16px that cascades through (almost) all sub-components. Appropriate spaces are defined using em, so if you want to resize the Select, just change the container's font-size.</p><p>The exception to the 16px default is the helper text, which also just uses an em relative value.</p>",
     },
   },
 };
@@ -495,7 +493,7 @@ EmptyListText.parameters = {
   docs: {
     description: {
       story:
-        'When, after applying the <code>transformFunction</code> the list of items is empty, a special message will be shown in the dropdown. This message can be customized with <code>emptyListText</code>. You can also style this',
+        'When, after applying the transformFunction the list of items is empty, a special message will be shown in the dropdown. This message can be customized with emptyListText. You can also style this',
     },
   },
 };

--- a/src/Input/DownshiftSelect/Select.tsx
+++ b/src/Input/DownshiftSelect/Select.tsx
@@ -129,7 +129,7 @@ export interface Props {
   /** Called each time the text input loses focus */
   onBlur?: React.FocusEventHandler<HTMLInputElement>;
 
-  /** Text to be displayed in <code>EmptyList</code> when <code>transformFunction</code> returns an empty list */
+  /** Text to be displayed in EmptyList when transformFunction returns an empty list */
   emptyListText?: string;
 }
 

--- a/src/Input/NumberInput/NumberInput.tsx
+++ b/src/Input/NumberInput/NumberInput.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import TextField from '../TextField';
 import { TextFieldInput } from '../TextField/TextFieldStyle';
 
-/** Use <code>onChange</code> to listen to input changes.
- * Use <code>onBlur</code> to listen to focus loss.
+/** Use onChange to listen to input changes.
+ * Use onBlur to listen to focus loss.
  * <br/>
- * Use <code>status</code> to set different styles for the Input Field based on status.
+ * Use status to set different styles for the Input Field based on status.
  * <br/>
- * Use <code>small</code> to set the size of the input field. The <code>...rest</code> is passed to the
+ * Use small to set the size of the input field. The ...rest is passed to the
  * internal field input. */
 export const NumberInput = (props: Props) => {
   return <TextField {...props} type="number" />;

--- a/src/Input/RadioButton/RadioButton.tsx
+++ b/src/Input/RadioButton/RadioButton.tsx
@@ -9,8 +9,8 @@ import {
   Border,
 } from './RadioButtonStyle';
 
-/** The <code>className</code> will be passed to
- * the main radio button container. <code>...inputProps</code> is passed to the
+/** The className will be passed to
+ * the main radio button container. ...inputProps is passed to the
  * input tag. */
 export const RadioButton: React.FunctionComponent<Props> = ({
   className,

--- a/src/Input/TextField/TextField.tsx
+++ b/src/Input/TextField/TextField.tsx
@@ -22,12 +22,12 @@ export const isFilled = (type: textFieldType, value: any) => {
   return value !== '';
 };
 
-/** Use <code>onChange</code> to listen to input changes.
- * Use <code>onBlur</code> to listen to focus loss.
+/** Use onChange to listen to input changes.
+ * Use onBlur to listen to focus loss.
  * <br/>
- * Use <code>status</code> to set different styles for the Text Field based on status.
+ * Use status to set different styles for the Text Field based on status.
  * <br/>
- * Use <code>small</code> to set the size of the text field. The <code>...rest</code> is passed to the
+ * Use small to set the size of the text field. The ...rest is passed to the
  * internal text field input. */
 export const TextField: React.FunctionComponent<Props> = ({
   value,

--- a/src/Input/Textarea/Textarea.tsx
+++ b/src/Input/Textarea/Textarea.tsx
@@ -13,12 +13,12 @@ const MIN_ROWS = 4;
 const MAX_ROWS = 12;
 // Rows are required to set the textarea height depending on the content added.
 
-/** Use <code>onChange</code> to listen to input changes. Use
- * <code>onBlur</code> to listen to focus loss.
+/** Use onChange to listen to input changes. Use
+ * onBlur to listen to focus loss.
  * <br/>
- * Note that currently, <code>Textarea</code> has some non-standard behaviour
- * when forwarding standard props: The <code>className</code> will be passed to
- * the internal 'container' while the <code>...rest</code> is passed to the
+ * Note that currently, Textarea has some non-standard behaviour
+ * when forwarding standard props: The className will be passed to
+ * the internal 'container' while the ...rest is passed to the
  * internal textarea. */
 export const Textarea: FC<Props> = ({
   label,

--- a/src/Input/ToggleSwitch/ToggleSwitch.tsx
+++ b/src/Input/ToggleSwitch/ToggleSwitch.tsx
@@ -19,7 +19,7 @@ export interface ToggleSwitchProps {
   className?: string;
 }
 
-/** The <code>className</code> and <code>...defaultProps</code> are passed to the main toggle container. */
+/** The className and ...defaultProps are passed to the main toggle container. */
 export const ToggleSwitch: React.FunctionComponent<ToggleSwitchProps> = ({
   active,
   defaultActive = false,


### PR DESCRIPTION
I don't know why. I don't know how. `<code>` just produces an error (https://github.com/glints-dev/glints-aries/issues/664) but luckily `<Code>` does the same thing without the error.