### PR TITLE
fix(gallery): change image width to 100% in carousel mode

### DIFF
--- a/src/Display/Gallery/GalleryStyle.ts
+++ b/src/Display/Gallery/GalleryStyle.ts
@@ -64,7 +64,7 @@ export const GalleryImageWrapper = styled.div`
 
   img {
     height: 50vh;
-    width: auto;
+    width: 100%;
     object-fit: contain;
   }
 `;

--- a/src/Display/Gallery/__snapshots__/Gallery.test.tsx.snap
+++ b/src/Display/Gallery/__snapshots__/Gallery.test.tsx.snap
@@ -232,7 +232,7 @@ exports[`<Gallery /> active item click on gallery item 1`] = `
 
 .c13 img {
   height: 50vh;
-  width: auto;
+  width: 100%;
   object-fit: contain;
 }
 
@@ -888,7 +888,7 @@ exports[`<Gallery /> active item click on gallery thumbnail 1`] = `
 
 .c13 img {
   height: 50vh;
-  width: auto;
+  width: 100%;
   object-fit: contain;
 }
 
@@ -2242,7 +2242,7 @@ exports[`<Gallery /> rendering should match snapshot when slider is shown 1`] = 
 
 .c13 img {
   height: 50vh;
-  width: auto;
+  width: 100%;
   object-fit: contain;
 }
 


### PR DESCRIPTION
Images in  carousel will be overlapping when view in mobile when there are wide images. Setting the width to 100% instead of auto will fix this.

<img width="301" alt="Screen Shot 2022-05-09 at 2 51 13 PM" src="https://user-images.githubusercontent.com/105256293/167532229-88c5d810-8f1b-4725-9f9a-3279bbc34add.png">
