### PR TITLE
Popover: expose fitContent

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "classnames": "^2.2.6",
     "downshift": "^6.1.3",
     "moment": "^2.24.0",
-    "polaris-glints": "^15.9.0",
+    "polaris-glints": "^15.12.0",
     "react-id-generator": "^3.0.1",
     "styled-system": "^5.1.5"
   },

--- a/src/@next/Popover/PopoverFilter.stories.tsx
+++ b/src/@next/Popover/PopoverFilter.stories.tsx
@@ -87,6 +87,8 @@ const PopoverAsFilterExample = () => {
           activator={cityActivator}
           autofocusTarget="first-node"
           onClose={togglePopoverCityActive}
+          fullWidth
+          fitContent
         >
           <Popover.Pane fixed>
             <Popover.Section>

--- a/src/@next/Popover/PopoverFilter.stories.tsx
+++ b/src/@next/Popover/PopoverFilter.stories.tsx
@@ -117,6 +117,7 @@ const PopoverAsFilterExample = () => {
           autofocusTarget="first-node"
           onClose={toggleSalaryActive}
           fullWidth
+          fitContent
         >
           <Popover.Pane fixed>
             <Popover.Section>

--- a/src/@next/Popover/PopoverStyle.ts
+++ b/src/@next/Popover/PopoverStyle.ts
@@ -45,6 +45,10 @@ export const StyledPopover: any = createGlobalStyle`
 .Polaris-Popover--fullWidth {
   margin: 0.3125rem auto 0 auto;
   width: 100%;
+
+  &.Polaris-Popover--fitContent {
+    width: fit-content;
+  }
 }
 
 .Polaris-Popover--fullWidth .Polaris-Popover__Content {

--- a/src/@next/Select/Select.tsx
+++ b/src/@next/Select/Select.tsx
@@ -28,6 +28,8 @@ export interface SelectProps {
   onRemoveTag?({ option }: { option: string }): void;
   onSelect?({ value }: { value: string }): void;
   options?: Option[];
+  /** sets whether OptionList will follow content's width */
+  optionListFitContent?: boolean;
   placeholder?: string;
   prefix?: React.ReactNode;
   /** sets whether Select is searchable */
@@ -50,13 +52,14 @@ export const Select = ({
   hasError = false,
   helpText,
   label,
+  listHeight,
   loadingOptions = false,
   onClose,
   onRemoveTag,
   onSelect,
+  optionListFitContent = false,
   options = [],
   placeholder,
-  listHeight,
   prefix,
   searchable = false,
   searchableProps,
@@ -203,8 +206,10 @@ export const Select = ({
       onClose={handleClose}
       autofocusTarget="none"
       preventFocusOnClose
+      preferredAlignment="left"
       preferredPosition="below"
       fullWidth
+      fitContent={optionListFitContent}
       zIndexOverride={zIndexOverride}
     >
       {!disabled && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -11524,10 +11524,10 @@ pnp-webpack-plugin@1.6.4:
   dependencies:
     ts-pnp "^1.1.6"
 
-polaris-glints@^15.9.0:
-  version "15.9.0"
-  resolved "https://registry.yarnpkg.com/polaris-glints/-/polaris-glints-15.9.0.tgz#f5d0c80357f5aff231d981a0634b4efa7aa562c0"
-  integrity sha512-XEl9ASnDP1wEf9BU/WhL9CGvd+V+VKT6/Pz09RczpRzBj8X3sy38s1UdM40HNBiIwnvf3rkGk6QnF8oQUTKWxg==
+polaris-glints@^15.12.0:
+  version "15.12.0"
+  resolved "https://registry.yarnpkg.com/polaris-glints/-/polaris-glints-15.12.0.tgz#ffbf6feea5477c2d7d37f0c55e577c3c6e62a003"
+  integrity sha512-bMnrGsovExbVGUsenhnZKfDvgP7clK8lgPYO2r6jHD4Ykp/JIAOWm35M2u4QzS2ov8te20vNfxVeDXiwho8l+w==
   dependencies:
     "@shopify/polaris-icons" "^6.7.0"
     "@shopify/polaris-tokens" "^6.3.0"


### PR DESCRIPTION
| Before 🖼️  | After 🛠️ |
|----|----|
![Screenshot 2023-06-06 at 11 41 25 AM](https://github.com/glints-dev/glints-aries/assets/7514754/2aa335c2-1cc7-4928-b625-4bfdd0791aff) |![Screenshot 2023-06-06 at 11 42 07 AM](https://github.com/glints-dev/glints-aries/assets/7514754/921892c3-f43c-4f4b-ad57-11aa7ba984ba)
