### PR TITLE
DataTable: allow reactnode as datatable heading

### DIFF
--- a/src/@next/DataTable/DataTable.tsx
+++ b/src/@next/DataTable/DataTable.tsx
@@ -19,8 +19,11 @@ import { TableRow } from './TableRow';
 
 export type SortDirection = 'ASCENDING' | 'DESCENDING';
 
-export type TableHeading = React.ThHTMLAttributes<HTMLTableColElement> & {
-  title?: string;
+export type TableHeading = Omit<
+  React.ThHTMLAttributes<HTMLTableColElement>,
+  'title'
+> & {
+  title?: React.ReactNode;
   id?: string;
   defaultSortDirection?: SortDirection;
 };
@@ -69,7 +72,7 @@ const DataTableComponent = React.forwardRef<HTMLTableElement, DataTableProps>(
           sortDirection={defaultSortDirection}
           align={align}
           onSort={sortDirection =>
-            handleSortChanged(id || title, sortDirection)
+            handleSortChanged(id || title.toString(), sortDirection)
           }
         />
       );

--- a/src/@next/DataTable/DataTable.tsx
+++ b/src/@next/DataTable/DataTable.tsx
@@ -32,6 +32,7 @@ export type Total = TableHeading | null;
 
 export interface DataTableProps
   extends React.TableHTMLAttributes<HTMLTableElement> {
+  /** If the title in TableHeading is of type ReactNode and you require sorting functionality, please make sure to provide 'id' for the TableHeading */
   headings: TableHeading[];
   children: React.ReactNode;
   emptyState: React.ReactElement<EmptyStateProps>;
@@ -65,6 +66,12 @@ const DataTableComponent = React.forwardRef<HTMLTableElement, DataTableProps>(
     const rowHeaderMarkup = headings.map((heading, index) => {
       const { id, title, defaultSortDirection, align } = heading;
       const key = `table-header-heading-${title}-${index}`;
+
+      if (handleSortChanged && typeof title !== 'string' && !id)
+        console.warn(
+          "Warning: If the title in TableHeading is of type ReactNode and you require sorting functionality, please make sure to provide 'id' for the TableHeading."
+        );
+
       return (
         <TableHeader
           key={key}

--- a/src/@next/DataTable/TableHeader.tsx
+++ b/src/@next/DataTable/TableHeader.tsx
@@ -7,8 +7,8 @@ import { SortDirection } from './DataTable';
 import { StyledTabledHeader } from './DataTableStyle';
 
 export interface TableHeaderProps
-  extends React.ThHTMLAttributes<HTMLTableColElement> {
-  title: string;
+  extends Omit<React.ThHTMLAttributes<HTMLTableColElement>, 'title'> {
+  title: React.ReactNode;
   sortDirection?: SortDirection;
   onSort?: (sortDirection: SortDirection) => void;
 }


### PR DESCRIPTION
Reason: need to be able to pass reactnode for header for this (the tooltip, or if it is accompanied with other icons)
![image](https://github.com/glints-dev/glints-aries/assets/67429929/224868d2-9f04-4740-b991-95f55805f1f9)
