### PR TITLE
feature: Add change handler with synthetic event

### DIFF
--- a/src/@next/TextInput/TextInput.test.tsx
+++ b/src/@next/TextInput/TextInput.test.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { TextInput } from './TextInput';
+
+describe('<TextInput />', () => {
+  it('calls onChange handler correctly', () => {
+    const onChange = jest.fn();
+    const screen = render(<TextInput onChange={onChange} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Test Value' } });
+    expect(onChange).toHaveBeenCalledWith('Test Value');
+  });
+
+  it('calls onChangeHandler correctly', () => {
+    const onChangeHandler = jest.fn();
+    const screen = render(<TextInput onChangeHandler={onChangeHandler} />);
+    const input = screen.getByRole('textbox');
+
+    fireEvent.input(input, {
+      target: { value: 'Test Value' },
+    });
+
+    expect(onChangeHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({
+          value: 'Test Value',
+        }),
+      })
+    );
+  });
+});

--- a/src/@next/TextInput/TextInput.tsx
+++ b/src/@next/TextInput/TextInput.tsx
@@ -1,15 +1,28 @@
 import React, { useEffect, useState } from 'react';
 import { Icon } from '../Icon';
 import { Input, InputProps } from '../Input/Input';
+import { ChangeHandler } from '../../types/changeHandler';
 
 export type TextInputProps = Omit<InputProps, 'type' | 'onChange'> & {
   canClear?: boolean;
   onChange?: (value: string) => void;
+  /**
+   * Passes the SyntheticEvent to the onChange handler `(e: SyntheticEvent) => void`
+   */
+  onChangeHandler?: ChangeHandler;
 };
 
 export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
   function TextInput(
-    { canClear, suffix, value, onChange, error, ...props }: TextInputProps,
+    {
+      canClear,
+      suffix,
+      value,
+      onChange,
+      onChangeHandler,
+      error,
+      ...props
+    }: TextInputProps,
     ref
   ) {
     const ClearIcon = () => (
@@ -30,6 +43,7 @@ export const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
       const val = e.currentTarget.value;
       const currSuffix = canClear && !!val ? <ClearIcon /> : suffixValue;
       setSuffixValue(currSuffix);
+      onChangeHandler?.(e);
       onChange?.(val);
     };
 

--- a/src/types/changeHandler.ts
+++ b/src/types/changeHandler.ts
@@ -1,0 +1,3 @@
+import { SyntheticEvent } from 'react';
+
+export type ChangeHandler = (e: SyntheticEvent) => void;


### PR DESCRIPTION
The current onChange handler for the TextInput component only accepts a function with type `(value: string) => void`. This prevents us from passing an onChange handler of type `(e: SyntheticEvent) => void` which we require when using react-hook-form.