### PR TITLE
Layout: Add GlintsContainer and GlintsContainerFluid to match Design

### DIFF
--- a/src/@next/Layouts/GlintsContainer/GlintsContainer.stories.mdx
+++ b/src/@next/Layouts/GlintsContainer/GlintsContainer.stories.mdx
@@ -1,0 +1,36 @@
+import { Meta } from '@storybook/addon-docs';
+import {
+  GlintsContainer,
+  BaseContainer,
+  PageContainer,
+} from './GlintsContainer';
+
+<Meta title="@next/Layouts/GlintsContainer" />
+
+# GlintsContainer
+
+`GlintsContainer` is a combination of `BaseContainer` and `PageContainer`.
+
+<GlintsContainer style={{ border: '1px solid black' }}>
+  <div style={{ background: 'lightBlue', width: '100%' }}>Content</div>
+</GlintsContainer>
+
+```
+<GlintsContainer>
+  <Loading />
+</GlintsContainer>
+```
+
+## GlintsContainerFluid
+
+`GlintsContainerFluid` defines common styles that are required by some Aries components. It also sets the font-family to Noto Sans. It is a fluid container that is not responsive
+
+<GlintsContainerFluid style={{ border: '1px solid black' }}>
+  <div style={{ background: 'lightBlue', width: '100%' }}>Content</div>
+</GlintsContainerFluid>
+
+```
+<GlintsContainerFluid>
+  <Loading />
+</GlintsContainerFluid>
+```

--- a/src/@next/Layouts/GlintsContainer/GlintsContainer.ts
+++ b/src/@next/Layouts/GlintsContainer/GlintsContainer.ts
@@ -1,0 +1,58 @@
+import styled, { css } from 'styled-components';
+import { NotoSans } from '../../utilities/fonts/Fonts';
+import { space16, space24, space32 } from '../../utilities/spacing/Spacing';
+import {
+  screenBreakPointExtraLarge,
+  screenBreakPointLarge,
+  screenBreakPointMedium,
+  screenBreakPointMediumLarge,
+  screenBreakPointSmall,
+} from '../../utilities/breakpoints/Breakpoints';
+
+const BaseStyles = css`
+  font-family: ${NotoSans}, sans-serif;
+  position: relative;
+
+  *,
+  *:before,
+  *:after {
+    box-sizing: border-box;
+  }
+`;
+
+const PageStyles = css`
+  margin: 0 auto;
+  max-width: 100%;
+  padding: 0 ${space16};
+
+  @media (min-width: ${screenBreakPointSmall}) {
+    padding: 0 ${space24};
+  }
+
+  @media (min-width: ${screenBreakPointMedium}) {
+    padding: 0 ${space32};
+  }
+
+  @media (min-width: ${screenBreakPointMediumLarge}) {
+    padding: 0 ${space32};
+  }
+
+  @media (min-width: ${screenBreakPointLarge}) {
+    max-width: 1140px;
+    padding: 0;
+  }
+
+  @media (min-width: ${screenBreakPointExtraLarge}) {
+    max-width: 1360px;
+    padding: 0;
+  }
+`;
+
+export const GlintsContainerFluid = styled.div`
+  ${BaseStyles}
+`;
+
+export const GlintsContainer = styled.div`
+  ${BaseStyles}
+  ${PageStyles}
+`;

--- a/src/@next/Layouts/GlintsContainer/index.ts
+++ b/src/@next/Layouts/GlintsContainer/index.ts
@@ -1,0 +1,1 @@
+export * from './GlintsContainer';

--- a/src/@next/index.ts
+++ b/src/@next/index.ts
@@ -57,6 +57,10 @@ export type {
 export { DataTable } from './DataTable';
 export { Divider } from './Divider';
 export { EmptyState } from './EmptyState';
+export {
+  GlintsContainerFluid,
+  GlintsContainer,
+} from './Layouts/GlintsContainer';
 export type { IconProps } from './Icon';
 export { Icon } from './Icon';
 export type { IndexTableProps } from './IndexTable';

--- a/src/@next/utilities/breakpoints/Breakpoints.ts
+++ b/src/@next/utilities/breakpoints/Breakpoints.ts
@@ -1,1 +1,15 @@
 export const large = '768px';
+
+export const screenBreakPointSmall = '360px';
+export const screenBreakPointMedium = '768px';
+export const screenBreakPointMediumLarge = '1024px';
+export const screenBreakPointLarge = '1260px';
+export const screenBreakPointExtraLarge = '1440px';
+
+export const screenBreakPoints = {
+  screenBreakPointSmall,
+  screenBreakPointMedium,
+  screenBreakPointMediumLarge,
+  screenBreakPointLarge,
+  screenBreakPointExtraLarge,
+};

--- a/src/@next/utilities/breakpoints/ScreenBreakpoints.stories.mdx
+++ b/src/@next/utilities/breakpoints/ScreenBreakpoints.stories.mdx
@@ -1,0 +1,20 @@
+import { Meta } from '@storybook/addon-docs';
+import { screenBreakPoints } from './Breakpoints';
+import * as Neutral from '../colors/neutral';
+
+<Meta title="@next/Utilities/ScreenBreakpoints" />
+
+# Screen Breakpoints
+
+<table>
+  <tr>
+    <th>Token name</th>
+    <th>Value</th>
+  </tr>
+  {Object.entries(screenBreakPoints).map(([tokenName, value]) => (
+    <tr>
+      <td>{tokenName}</td>
+      <td>{value}</td>
+    </tr>
+  ))}
+</table>

--- a/src/@next/utilities/breakpoints/index.ts
+++ b/src/@next/utilities/breakpoints/index.ts
@@ -1,1 +1,8 @@
-export * from './Breakpoints';
+export {
+  large,
+  screenBreakPointSmall,
+  screenBreakPointMedium,
+  screenBreakPointMediumLarge,
+  screenBreakPointLarge,
+  screenBreakPointExtraLarge,
+} from './Breakpoints';


### PR DESCRIPTION
In the [breakpoint](https://www.figma.com/file/87fhOdF8vk1Uiy20bCqS85/Aries---UI-Kit-3.0-%5BQ4-2022%5D?type=design&node-id=1-584&mode=design&t=H7JieeUHhgLNsPuL-0) document. It specifies how the GlintsContainer should look like.

The current legacy glints container is broken and unusable. We need to update it in order to use it.

Do note that in order for the container to work.
Margins = padding as we need margin: auto to centralized the content

https://glints.slack.com/archives/C04F7TDK99B/p1692184499689209?thread_ts=1692173330.580529&cid=C04F7TDK99B