### PR TITLE
Select: add customActivatorIcon prop to customize icon

### DIFF
--- a/src/@next/Select/Select.tsx
+++ b/src/@next/Select/Select.tsx
@@ -7,6 +7,7 @@ import { ActivatorTextInput, OptionList } from './components';
 import { ActivatorSelect } from './components/Activator/ActivatorSelect';
 import { Label } from './components/Label/Label';
 import { SearchableSelectState } from './components/SearchableSelectInput/SearchableSelectInput';
+import { IconNames } from '../Icon/icons/icons';
 import { ActivatorWrapper, HelpTextContainer } from './SelectStyle';
 
 interface SearchableProps {
@@ -17,6 +18,7 @@ interface SearchableProps {
 }
 export interface SelectProps {
   allowMultiple?: boolean;
+  customActivatorIcon?: IconNames;
   disabled?: boolean;
   hasError?: boolean;
   helpText?: React.ReactNode;
@@ -49,6 +51,7 @@ export interface SelectProps {
 
 export const Select = ({
   allowMultiple = false,
+  customActivatorIcon,
   disabled = false,
   hasError = false,
   helpText,
@@ -174,6 +177,7 @@ export const Select = ({
     return (
       <ActivatorSelect
         allowMultiple={allowMultiple}
+        customActivatorIcon={customActivatorIcon}
         disabled={disabled}
         hasError={hasError}
         placeholder={placeholder ?? 'Placeholder'}

--- a/src/@next/Select/components/Activator/ActivatorSelect.tsx
+++ b/src/@next/Select/components/Activator/ActivatorSelect.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Option } from '../../../Menu';
 
+import { IconNames } from '../../../Icon/icons/icons';
 import { Typography } from '../../../Typography';
 import { Blue, Neutral } from '../../../utilities/colors';
 import {
@@ -16,6 +17,7 @@ import {
 export interface ActivatorSelectProps
   extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'prefix'> {
   allowMultiple?: boolean;
+  customActivatorIcon?: IconNames;
   hasError?: boolean;
   selectedValues?: string[];
   placeholder?: string;
@@ -26,6 +28,7 @@ export interface ActivatorSelectProps
   width?: string;
 }
 export const ActivatorSelect = ({
+  customActivatorIcon,
   placeholder,
   selectedValues,
   onClick,
@@ -125,7 +128,7 @@ export const ActivatorSelect = ({
       </WithPrefixContainer>
       <StyledIcon
         height={24}
-        name="ri-arrow-m-down-line"
+        name={customActivatorIcon || 'ri-arrow-m-down-line'}
         fill={disabled ? Neutral.B85 : Neutral.B40}
       />
     </StyledSelect>


### PR DESCRIPTION
Not sure if this is the best way or not...

Simply allow the select icon to be customized (not just the default `ri-arrow-m-down-line`)
![image](https://github.com/glints-dev/glints-aries/assets/67429929/22491966-7d16-462f-b14b-212c04ff9b19)
in this case I need `ri-arrow-m-down-fill`