### PR TITLE
Popover: Set z-index higher

### DIFF
--- a/src/@next/Popover/PopoverStyle.ts
+++ b/src/@next/Popover/PopoverStyle.ts
@@ -145,7 +145,7 @@ export const StyledPopover: any = createGlobalStyle`
 
 .Polaris-PositionedOverlay {
   position: absolute;
-  z-index: 400;
+  z-index: 999;
 }
 
 .Polaris-PositionedOverlay--fixed {


### PR DESCRIPTION
Set the Popover's z index higher, so it can be used inside the modal