### PR TITLE
feat: fix empty value in CurrencyInput to be null

### DIFF
--- a/src/@next/CurrencyInput/CurrencyInput.test.tsx
+++ b/src/@next/CurrencyInput/CurrencyInput.test.tsx
@@ -17,7 +17,7 @@ describe('<Currency />', () => {
   });
 
   describe('allowEmptyValue', () => {
-    it('should call onChange with undefined when allowEmptyValue = true for empty input', async () => {
+    it('should call onChange with null when allowEmptyValue = true for empty input', async () => {
       const onChange = jest.fn();
 
       const screen = render(
@@ -34,7 +34,7 @@ describe('<Currency />', () => {
       expect(onChange).toHaveBeenCalledWith(1000);
 
       fireEvent.change(input, { target: { value: '' } });
-      expect(onChange).toHaveBeenCalledWith(undefined);
+      expect(onChange).toHaveBeenCalledWith(null);
 
       fireEvent.change(input, { target: { value: 2000 } });
       expect(onChange).toHaveBeenCalledWith(2000);

--- a/src/@next/CurrencyInput/CurrencyInput.tsx
+++ b/src/@next/CurrencyInput/CurrencyInput.tsx
@@ -6,7 +6,7 @@ export type CurrencyInputProps = Omit<
   'type' | 'prefix' | 'onChange' | 'value'
 > & {
   locale?: string;
-  value?: number;
+  value?: number | null;
   allowEmptyValue?: boolean;
   onChange?: (value: number | undefined) => void;
   currencyCode: string;
@@ -88,13 +88,13 @@ export const CurrencyInput = React.forwardRef<
   };
 
   const formattedValue =
-    allowEmptyValue && value === undefined
-      ? ''
+    allowEmptyValue && value === null
+      ? null
       : formatter.format(getRawNumber((value ?? 0).toString())) ?? '';
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (allowEmptyValue && e.currentTarget.value === '') {
-      onChange(undefined);
+      onChange(null);
       return;
     }
 


### PR DESCRIPTION
Make the empty value in CurrencyInput to be null instead of undefined for easier usage with react hook forms