### PR TITLE
@next Select: Close select options on blur

### DIFF
--- a/src/@next/Select/Select.tsx
+++ b/src/@next/Select/Select.tsx
@@ -114,6 +114,14 @@ export const Select = ({
     setMenuOptions(newState);
   };
 
+  const handleOnBlur = () => {
+    setTimeout(() => {
+      if (searchableSelectState.showSelected) setPopoverActive(false);
+    }, 101);
+
+    onBlur?.();
+  };
+
   const handleClose = () => {
     setPopoverActive(false);
     onClose?.();
@@ -185,7 +193,7 @@ export const Select = ({
           placeholder={placeholder ?? 'Search'}
           width={width}
           selectedValues={selectedValues}
-          onBlur={onBlur}
+          onBlur={handleOnBlur}
           onSelect={onSelect}
           onFocus={handleFocus}
           inputValue={inputValue}


### PR DESCRIPTION
This is related to the issue found by @music1353, where opening multiple selectors does not close the previous one.

There is still a lag time because of the 101ms. We can technically reduce it by reducing 

https://github.com/glints-dev/glints-aries/blob/0655a3bc8579d129461ad4fafd0f03788ef6e94e/src/@next/Select/components/SearchableSelectInput/SearchableSelectInput.tsx#L134

the initial timeout of 100 to 80. However I decided not to do so as we are unclear about the repercussions. I noticed that if we reduce it to 50, we are unable to select a value using the selector.

This is a hacky solution. As the 4pm team have discussed, a proper way requires a rewrite to somehow remove that 100ms blocker.