### PR TITLE
ButtonGroup: fix missing ampersand

### DIFF
--- a/src/@next/ButtonGroup/ButtonGroupStyle.ts
+++ b/src/@next/ButtonGroup/ButtonGroupStyle.ts
@@ -22,11 +22,11 @@ export const StyledButtonGroup = styled.div`
     border-radius: 0;
     border-right: 0;
 
-    :nth-child(1) {
+    &:nth-child(1) {
       border-radius: ${borderRadius4} 0px 0px ${borderRadius4};
     }
 
-    :nth-last-child(1) {
+    &:nth-last-child(1) {
       border-radius: 0px ${borderRadius4} ${borderRadius4} 0px;
       border-right: 1px solid ${Neutral.B68};
     }
@@ -46,11 +46,11 @@ export const StyledButtonGroup = styled.div`
       border-radius: 0;
       border-right: 0;
     }
-    :nth-child(1) button {
+    &:nth-child(1) button {
       border-radius: ${borderRadius4} 0px 0px ${borderRadius4};
     }
 
-    :nth-last-child(1) button {
+    &:nth-last-child(1) button {
       border-radius: 0px ${borderRadius4} ${borderRadius4} 0px;
       border-right: 1px solid ${Neutral.B68};
     }


### PR DESCRIPTION
## Problem
- missing apersand causes issues with the processed styles
![Screenshot 2024-02-22 at 4 06 56 PM](https://github.com/glints-dev/glints-aries/assets/7514754/096dbec4-65d2-4e28-9ca9-0433811952a2)

## Fix
- add the missing ampersands
![Screenshot 2024-02-22 at 4 34 18 PM](https://github.com/glints-dev/glints-aries/assets/7514754/ba5f1a8b-9bf6-4ce4-9e77-885a2b895189)
