### PR TITLE
DataTable: remove hover of empty state

### DIFF
--- a/src/@next/DataTable/DataTable.tsx
+++ b/src/@next/DataTable/DataTable.tsx
@@ -113,7 +113,7 @@ const DataTableComponent = React.forwardRef<HTMLTableElement, DataTableProps>(
     }
 
     const emptyRow = emptyState ? (
-      <StyledTableRow>
+      <StyledTableRow className="empty-state">
         <StyledTableCell colSpan={headings.length}>
           {emptyState}
         </StyledTableCell>

--- a/src/@next/DataTable/DataTableStyle.ts
+++ b/src/@next/DataTable/DataTableStyle.ts
@@ -74,6 +74,10 @@ export const StyledTableRow = styled.tr`
       background: ${Neutral.B99};
     }
   }
+
+  &.empty-state&:hover {
+    background: none;
+  }
 `;
 
 export const StyledTabledHeader = styled.th`


### PR DESCRIPTION
## DataTable: remove hover of empty state
### Before

![Kapture 2024-02-28 at 14 09 57](https://github.com/glints-dev/glints-aries/assets/7514754/5e9e9073-c0a3-4dfa-b008-4b6154935b0e)

### After
![Kapture 2024-02-28 at 14 17 57](https://github.com/glints-dev/glints-aries/assets/7514754/b573df4f-3e1b-4ef0-8723-9fecba1629de)
