### PR TITLE
IndexTable: specify to apply only on mozilla

### DIFF
--- a/src/@next/IndexTable/IndexTableStyle.ts
+++ b/src/@next/IndexTable/IndexTableStyle.ts
@@ -1461,9 +1461,11 @@ export const StyledIndexTable: any = createGlobalStyle<{ height?: string }>`
 
   /* ===== Scrollbar CSS ===== */
   /* Firefox */
-  * {
-    scrollbar-width: auto;
-    scrollbar-color: ${Neutral.B68} ${Neutral.B100};
+  @supports (-moz-appearance:none) {
+    * {
+      scrollbar-width: auto;
+      scrollbar-color: ${Neutral.B68} ${Neutral.B100};
+    }
   }
 
   /* Chrome, Edge, and Safari */


### PR DESCRIPTION
### Issue
- `scrollbar-color` is introducing a scrollbar issue with Windows OS on Chrome

### Solution
- apply Firefox specific styles only to itself