### PR TITLE
@next IndexTable: fix display nothing issue if all rows disabled

### DIFF
--- a/src/@next/IndexTable/IndexTable.stories.tsx
+++ b/src/@next/IndexTable/IndexTable.stories.tsx
@@ -250,8 +250,13 @@ const Template: Story<IndexTableProps> = args => {
   const selectableCandidates = candidatesSlice.filter(
     candidate => !candidate.disabled
   );
+  const selectableCandidatesCount = selectableCandidates.length;
+
+  const tableCandidatesData = selectableCandidatesCount
+    ? selectableCandidates
+    : candidatesSlice;
   const { selectedResources, allResourcesSelected, handleSelectionChange } =
-    useIndexResourceState(selectableCandidates);
+    useIndexResourceState(tableCandidatesData);
 
   const rowMarkup = candidatesSlice.map(
     (
@@ -308,11 +313,12 @@ const Template: Story<IndexTableProps> = args => {
   return (
     <IndexTable
       {...args}
-      itemCount={selectableCandidates.length}
+      itemCount={tableCandidatesData.length}
       resourceName={resourceName}
       selectedItemsCount={
         allResourcesSelected ? 'All' : selectedResources.length
       }
+      selectableItemsCount={selectableCandidates.length}
       onSelectionChange={handleSelectionChange}
       promotedBulkActions={promotedBulkActions}
       headings={[

--- a/src/@next/IndexTable/IndexTable.tsx
+++ b/src/@next/IndexTable/IndexTable.tsx
@@ -13,6 +13,7 @@ import { CheckboxCellContentContainer } from './components/Checkbox/CheckboxStyl
 
 type IndexTableProps = Omit<PolarisIndexTableProps, 'emptySearchTitle'> & {
   height?: string;
+  selectableItemsCount?: number;
 };
 
 const IndexTable = ({
@@ -23,6 +24,7 @@ const IndexTable = ({
   selectedItemsCount,
   loading,
   emptyState,
+  selectableItemsCount,
   ...props
 }: IndexTableProps) => {
   const renderCheckboxHeader = ({
@@ -36,6 +38,7 @@ const IndexTable = ({
           onChange={onChange}
           checked={checked}
           isPadded={false}
+          disabled={props.disabled || selectableItemsCount === 0}
           {...props}
         />
       </CheckboxCellContentContainer>


### PR DESCRIPTION
Index Table will display empty if all data is unselectable, a design mistake from the official Polaris library.
Can refer to https://codesandbox.io/p/sandbox/sweet-resonance-jtw9yw
This MR is the solution for if all rows are disabled state.
