### PR TITLE
Fixes Select showing "No matching results" for a fraction of a sec when there are many items in the list

### DIFF
--- a/src/@next/Select/components/OptionList/OptionList.tsx
+++ b/src/@next/Select/components/OptionList/OptionList.tsx
@@ -51,7 +51,7 @@ export const OptionList = ({
   width,
   menuOptions,
 }: OptionListProps) => {
-  const [hasMenuOptions, setHasMenuOptions] = useState(false);
+  const [hasMenuOptions, setHasMenuOptions] = useState(menuOptions?.length > 0);
 
   useEffect(() => {
     setHasMenuOptions(menuOptions?.length > 0);


### PR DESCRIPTION
There is a flashing with the text "No matching results" setting the initial
state to wether we have or not menu options fix the flashing.