### PR TITLE
Bump to v4.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glints-aries",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Glints ui-kit for frontend",
   "main": "./lib/index.js",
   "module": "./es/index.js",


### PR DESCRIPTION
Due to failing publish of v4.1.1, we need to update the version in order to retry it successfully

https://applink.larksuite.com/client/message/link/open\?token\=AmZsPh7F2QAgZqytcVTAQB8%3D