### PR TITLE
Make this work with React v19

### DIFF
--- a/src/@next/Alert/AlertWithProvider.stories.tsx
+++ b/src/@next/Alert/AlertWithProvider.stories.tsx
@@ -57,11 +57,12 @@ Interactive.parameters = {
       import { AlertProvider } from 'glints-aries/lib/@next';
 
       // index.js
-      ReactDOM.render(
+      import { createRoot } from 'react-dom/client';
+      const root = createRoot(document.getElementById('root'));
+      root.render(
         <AlertProvider>
          <App />
-        </AlertProvider>,
-        document.getElementById('root')
+        </AlertProvider>
       );
 
       // Add "AlertWithProvider" component in the root so it's accessible from anywhere

--- a/src/@next/Modal/ModalWithProvider.stories.tsx
+++ b/src/@next/Modal/ModalWithProvider.stories.tsx
@@ -58,11 +58,12 @@ Interactive.parameters = {
       import { ModalProvider } from 'glints-aries/lib/@next';
 
       // index.js
-      ReactDOM.render(
+      import { createRoot } from 'react-dom/client';
+      const root = createRoot(document.getElementById('root'));
+      root.render(
         <ModalProvider>
          <App />
-        </ModalProvider>,
-        document.getElementById('root')
+        </ModalProvider>
       );
 
       // Add "ModalWithProvider" component in the root so it's accessible from anywhere

--- a/src/Display/Modal/Modal.tsx
+++ b/src/Display/Modal/Modal.tsx
@@ -32,17 +32,17 @@ import {
 export const Modal: FC<Props> = ({
   isVisible,
   title,
-  onClose,
+  onClose = () => undefined as () => void,
   children,
   className,
-  hideContentArea,
-  centering,
-  fullscreen,
-  removeAnimation,
+  hideContentArea = false,
+  centering = false,
+  fullscreen = false,
+  removeAnimation = false,
   footer,
-  size,
-  hideHeader,
-  keepChildrenMountedOnClose,
+  size = 'm',
+  hideHeader = false,
+  keepChildrenMountedOnClose = false,
   ...restProps
 }) => {
   const modalContentAreaRef = useRef(null);
@@ -231,16 +231,5 @@ export interface Props extends Omit<HTMLAttributes<HTMLDivElement>, 'title'> {
   /** Whether to keep the child in the DOM when the modal is close */
   keepChildrenMountedOnClose?: boolean;
 }
-
-Modal.defaultProps = {
-  onClose: () => undefined as () => void,
-  size: 'm',
-  hideContentArea: false,
-  hideHeader: false,
-  removeAnimation: false,
-  centering: false,
-  fullscreen: false,
-  keepChildrenMountedOnClose: false,
-};
 
 export default Modal;

--- a/src/Display/Slider/Slider.tsx
+++ b/src/Display/Slider/Slider.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import { isNil } from 'lodash-es';
 
 import classNames from 'classnames';
@@ -29,7 +28,7 @@ export const Slider = ({
   containerRef,
 }: Props) => {
   const interval = React.useRef<ReturnType<typeof setTimeout>>();
-  const privateContainerRef = React.useRef<HTMLDivElement>();
+  const privateContainerRef = React.useRef<HTMLDivElement>(null);
   const sliderContainerRef = containerRef || privateContainerRef;
 
   const [translateValue, setTranslateValue] = React.useState(0);
@@ -63,7 +62,7 @@ export const Slider = ({
   };
 
   const getSliderContainerDOMNode = React.useCallback(() => {
-    return ReactDOM.findDOMNode(sliderContainerRef.current) as Element;
+    return sliderContainerRef.current as HTMLDivElement;
   }, [sliderContainerRef]);
 
   const handleDotClick = (idx: number) => {

--- a/src/General/Tag/BasicTag.tsx
+++ b/src/General/Tag/BasicTag.tsx
@@ -2,9 +2,14 @@ import * as React from 'react';
 import classNames from 'classnames';
 import { TagContainer, TagContent } from './TagStyle';
 
-const Tag: React.FunctionComponent<Props> = props => {
-  const { className, children, block, outline, onClick, ...restProps } = props;
-
+const Tag: React.FunctionComponent<Props> = ({
+  className,
+  children,
+  block = false,
+  outline = false,
+  onClick,
+  ...restProps
+}) => {
   return (
     <TagContainer
       className={classNames('aries-tag', className)}
@@ -21,11 +26,6 @@ const Tag: React.FunctionComponent<Props> = props => {
       </TagContent>
     </TagContainer>
   );
-};
-
-Tag.defaultProps = {
-  block: false,
-  outline: false,
 };
 
 export type Props = React.ComponentPropsWithoutRef<typeof TagContainer> & {

--- a/src/Input/Select/Select.tsx
+++ b/src/Input/Select/Select.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import { get, toLower } from 'lodash-es';
 import classNames from 'classnames';
 
@@ -168,7 +167,7 @@ const Select: React.FC<Props> & {
       const element = event.target as HTMLElement;
       if (
         selectContainerRef.current &&
-        !ReactDOM.findDOMNode(selectContainerRef.current).contains(element)
+        !selectContainerRef.current.contains(element)
       ) {
         setIsFocus(false);
       }

--- a/src/Layout/Grid/Col.tsx
+++ b/src/Layout/Grid/Col.tsx
@@ -3,9 +3,9 @@ import * as React from 'react';
 import { ColumnContainer } from './GridStyle';
 
 export const Col: React.FunctionComponent<Props> = ({
-  xs,
-  sm,
-  md,
+  xs = 12,
+  sm = 12,
+  md = 12,
   xsOrder,
   smOrder,
   mdOrder,
@@ -30,12 +30,6 @@ export const Col: React.FunctionComponent<Props> = ({
     {children}
   </ColumnContainer>
 );
-
-Col.defaultProps = {
-  xs: 12,
-  sm: 12,
-  md: 12,
-};
 
 export interface Props {
   xs?: number;


### PR DESCRIPTION
- Update Modal, BasicTag, and Col components to use default parameters
- Remove defaultProps declarations in favor of inline defaults
- This is required for React 19, which has removed defaultProps.

This doesn't mean we support React 19 officially yet, but it makes the necessary changes to make things at least work. The official supported React versions will always be in peerDependencies.