### PR TITLE
docs: fix local Storybook link

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ yarn build
 yarn storybook
 ```
 
-4. Open your browser on (port 6006)[http://localhost:6006].
+4. Open [http://localhost:6006](http://localhost:6006) in your browser.
 
 Note: For Windows user, please use [WSL2 Linux](https://learn.microsoft.com/en-us/windows/wsl/install) to execute all the commands above. Make sure that the repository is cloned on the linux folder, not on your C drive.
 


### PR DESCRIPTION
## Summary

- fix the malformed localhost link in the Storybook development instructions

## Checks

- `git diff --check`
- `npx prettier --check README.md`